### PR TITLE
Some utilities on invariant names

### DIFF
--- a/lib/pulse/core/PulseCore.Action.fst
+++ b/lib/pulse/core/PulseCore.Action.fst
@@ -236,6 +236,15 @@ let with_invariant
     let m = with_invariant i f in
     mem_action_as_action _ _ _ _ m
 
+let distinct_invariants_have_distinct_names
+    #p #q i j pf
+= fun #ictx -> mem_action_as_action _ _ _ _ (distinct_invariants_have_distinct_names ictx p q i j)
+
+let invariant_name_identifies_invariant
+      (p q:slprop)
+      (i:inv p)
+      (j:inv q { name_of_inv i == name_of_inv j } )
+= fun #ictx -> mem_action_as_action _ _ _ _ (invariant_name_identifies_invariant ictx p q i j)
 
 ///////////////////////////////////////////////////////////////////
 // Core operations on references

--- a/lib/pulse/core/PulseCore.Action.fst
+++ b/lib/pulse/core/PulseCore.Action.fst
@@ -214,12 +214,18 @@ let lift2 (#a:Type u#2) #opens #pre #post
 ///////////////////////////////////////////////////////
 
 let inv = inv
-let name_of_inv = name_of_inv
+let allocated_name = pre_inv
+let allocated_name_of_inv = pre_inv_of_inv
+let name_of_allocated_name = name_of_pre_inv
 
 let new_invariant (p:slprop)
 : act (inv p) emp_inames p (fun _ -> emp)
 = fun #ictx -> 
     mem_action_as_action _ _ _ _ (new_invariant ictx p)
+
+let fresh_invariant ctx p
+: act (i:inv p { fresh_wrt (name_of_inv i) ctx  }) emp_inames p (fun _ -> emp)
+= fun #ictx -> mem_action_as_action _ _ _ _ (fresh_invariant ictx p ctx)
 
 let with_invariant
     (#a:Type)

--- a/lib/pulse/core/PulseCore.Action.fsti
+++ b/lib/pulse/core/PulseCore.Action.fsti
@@ -92,7 +92,17 @@ val lift2 (#a:Type u#2) #opens #pre #post
 
 val inv (p:slprop) : Type0
 
-val name_of_inv #p (i:inv p) : GTot iname
+val allocated_name : Type0
+
+val allocated_name_of_inv (#p:_) (i:inv p)
+: allocated_name
+
+val name_of_allocated_name (n:allocated_name)
+: GTot iname
+
+let name_of_inv #p (i:inv p)
+: GTot iname
+= name_of_allocated_name (allocated_name_of_inv i)
 
 let mem_inv (#p:_) (opens:inames) (i:inv p)
 : GTot bool
@@ -104,6 +114,14 @@ let add_inv (#p:_) (opens:inames) (i:inv p)
 
 val new_invariant (p:slprop)
 : act (inv p) emp_inames p (fun _ -> emp)
+
+let fresh_wrt (i:iname)
+              (ctx:list allocated_name)
+: prop
+= forall i'. List.Tot.memP i' ctx ==> name_of_allocated_name i' <> i
+
+val fresh_invariant (ctx:list allocated_name) (p:slprop)
+: act (i:inv p { name_of_inv i `fresh_wrt` ctx }) emp_inames p (fun _ -> emp)
 
 val with_invariant
     (#a:Type)

--- a/lib/pulse/core/PulseCore.Action.fsti
+++ b/lib/pulse/core/PulseCore.Action.fsti
@@ -115,6 +115,23 @@ val with_invariant
     (f:unit -> act a f_opens (p ** fp) (fun x -> p ** fp' x))
 : act a (add_inv f_opens i) fp fp'
 
+val distinct_invariants_have_distinct_names
+    (#p:slprop)
+    (#q:slprop)
+    (i:inv p)
+    (j:inv q)
+    (_:squash (p =!= q))
+: act (squash (name_of_inv i =!= name_of_inv j))
+    emp_inames 
+    emp
+    (fun _ -> emp)
+
+val invariant_name_identifies_invariant
+      (p q:slprop)
+      (i:inv p)
+      (j:inv q { name_of_inv i == name_of_inv j } )
+: act (squash (p == q /\ i == j)) emp_inames emp (fun _ -> emp)
+
 ////////////////////////////////////////////////////////////////////////
 // References
 ////////////////////////////////////////////////////////////////////////

--- a/lib/pulse/core/PulseCore.Atomic.fst
+++ b/lib/pulse/core/PulseCore.Atomic.fst
@@ -237,6 +237,9 @@ let with_invariant
 : stt_atomic a #obs (add_inv f_opens i) fp fp'
 = A.with_invariant i f
 
+let distinct_invariants_have_distinct_names = A.distinct_invariants_have_distinct_names
+let invariant_name_identifies_invariant = A.invariant_name_identifies_invariant
+
 let pts_to_not_null #a #p r v = Ghost.hide (A.pts_to_not_null #a #p r v)
 let alloc = A.alloc
 let read = A.read

--- a/lib/pulse/core/PulseCore.Atomic.fst
+++ b/lib/pulse/core/PulseCore.Atomic.fst
@@ -223,6 +223,8 @@ let new_invariant
 : stt_atomic (inv p) #Unobservable emp_inames p (fun _ -> emp)
 = A.new_invariant p
 
+let fresh_invariant = A.fresh_invariant
+
 let with_invariant
     (#a:Type)
     (#obs:_)

--- a/lib/pulse/core/PulseCore.Atomic.fsti
+++ b/lib/pulse/core/PulseCore.Atomic.fsti
@@ -210,6 +210,9 @@ val new_invariant
     (p:slprop)
 : stt_atomic (inv p) #Unobservable emp_inames p (fun _ -> emp)
 
+val fresh_invariant (ctx:list allocated_name) (p:slprop)
+: stt_atomic (i:inv p { name_of_inv i `fresh_wrt` ctx }) #Unobservable emp_inames p (fun _ -> emp)
+
 val with_invariant
     (#a:Type)
     (#obs:_)

--- a/lib/pulse/core/PulseCore.Atomic.fsti
+++ b/lib/pulse/core/PulseCore.Atomic.fsti
@@ -223,6 +223,28 @@ val with_invariant
                             (fun x -> p ** fp' x))
 : stt_atomic a #(join_obs obs Unobservable) (add_inv f_opens i) fp fp'
 
+val distinct_invariants_have_distinct_names
+    (#p:slprop)
+    (#q:slprop)
+    (i:inv p)
+    (j:inv q)
+    (_:squash (p =!= q))
+: stt_atomic (squash (name_of_inv i =!= name_of_inv j))
+    #Unobservable
+    emp_inames 
+    emp
+    (fun _ -> emp)
+
+val invariant_name_identifies_invariant
+      (p q:slprop)
+      (i:inv p)
+      (j:inv q { name_of_inv i == name_of_inv j } )
+: stt_atomic (squash (p == q /\ i == j))
+    #Unobservable
+    emp_inames
+    emp
+    (fun _ -> emp)
+
 ////////////////////////////////////////////////////////////////////////
 // References
 ////////////////////////////////////////////////////////////////////////

--- a/lib/pulse/core/PulseCore.Memory.fst
+++ b/lib/pulse/core/PulseCore.Memory.fst
@@ -1428,6 +1428,34 @@ let rec recall_all (ctx:list pre_inv)
       MSTTotal.recall _ mem_evolves (name_is_ok q) i;
       recall_all tl
 
+let distinct_invariants_have_distinct_names
+      (e:inames)
+      (p:slprop)
+      (q:slprop { p =!= q })
+      (i:inv p)
+      (j:inv q)
+      (frame:slprop u#1)
+: MstTot (squash (name_of_inv i =!= name_of_inv j)) e emp (fun _ -> emp) frame
+= let (| ni, wi, toki |) = i in
+  let (| nj, wj, tokj |) = j in
+  MSTTotal.recall _ _ _ toki;
+  MSTTotal.recall _ _ _ tokj
+
+let invariant_name_identifies_invariant
+      (e:inames)
+      (p:slprop)
+      (q:slprop)
+      (i:inv p)
+      (j:inv q { name_of_inv i == name_of_inv j })
+      (frame:slprop u#1)
+: MstTot (squash (p == q /\ i == j)) e emp (fun _ -> emp) frame
+= let (| ni, wi, toki |) = i in
+  let (| nj, wj, tokj |) = j in
+  MSTTotal.recall _ _ _ toki;
+  MSTTotal.recall _ _ _ tokj;
+  W.witnessed_proof_irrelevant _ _ _ wi wj;
+  W.witnessed_proof_irrelevant _ _ _ toki tokj
+
 let fresh_invariant (e:inames) (p:slprop) (ctx:list pre_inv) (frame:slprop)
   : MstTot (i:inv p { not (mem_inv e i) /\ fresh_wrt ctx (name_of_inv i)}) e p (fun _ -> emp) frame
   = let m0 = MSTTotal.get () in

--- a/lib/pulse/core/PulseCore.Memory.fsti
+++ b/lib/pulse/core/PulseCore.Memory.fsti
@@ -318,7 +318,7 @@ val invariant_name_identifies_invariant
   : action_except (squash (p == q /\ i == j)) e emp (fun _ -> emp)
 
 val fresh_invariant (e:inames) (p:slprop) (ctx:list pre_inv)
-  : action_except (i:inv p { not (mem_inv e i) /\ fresh_wrt ctx (name_of_inv i) }) e p (fun _ -> emp)
+  : action_except (i:inv p { fresh_wrt ctx (name_of_inv i) }) e p (fun _ -> emp)
 
 val new_invariant (e:inames) (p:slprop)
   : action_except (inv p) e p (fun _ -> emp)

--- a/lib/pulse/core/PulseCore.Memory.fsti
+++ b/lib/pulse/core/PulseCore.Memory.fsti
@@ -302,6 +302,21 @@ let fresh_wrt (ctx:list pre_inv)
               (i:iname)
   = forall i'. List.Tot.memP i' ctx ==> name_of_pre_inv i' <> i
 
+val distinct_invariants_have_distinct_names
+      (e:inames)
+      (p:slprop)
+      (q:slprop { p =!= q })
+      (i:inv p)
+      (j:inv q)
+  : action_except (squash (name_of_inv i =!= name_of_inv j)) e emp (fun _ -> emp)
+
+val invariant_name_identifies_invariant
+      (e:inames)
+      (p q:slprop)
+      (i:inv p)
+      (j:inv q { name_of_inv i == name_of_inv j } )
+  : action_except (squash (p == q /\ i == j)) e emp (fun _ -> emp)
+
 val fresh_invariant (e:inames) (p:slprop) (ctx:list pre_inv)
   : action_except (i:inv p { not (mem_inv e i) /\ fresh_wrt ctx (name_of_inv i) }) e p (fun _ -> emp)
 

--- a/lib/pulse/lib/Pulse.Lib.Core.fst
+++ b/lib/pulse/lib/Pulse.Lib.Core.fst
@@ -107,8 +107,11 @@ let join_emp is =
   Set.lemma_equal_intro (join_inames emp_inames is) (reveal is)
 
 let inv = Act.inv
+let allocated_name = Act.allocated_name
 let name_of_inv = Act.name_of_inv
-
+let allocated_name_of_inv = Act.allocated_name_of_inv
+let name_of_allocated_name = Act.name_of_allocated_name
+let allocated_name_of_inv_equiv #p i = ()
 let add_already_there i is = Set.lemma_equal_intro (add_inv is i) is
 
 ////////////////////////////////////////////////////////////////////
@@ -138,6 +141,9 @@ let lift_atomic0 = A.lift_atomic0
 let lift_atomic1 = A.lift_atomic1
 let lift_atomic2 = A.lift_atomic2
 let new_invariant = A.new_invariant
+let fresh_wrt = PulseCore.Action.fresh_wrt
+let fresh_wrt_def i c = ()
+let fresh_invariant = A.fresh_invariant
 let with_invariant = A.with_invariant
 let distinct_invariants_have_distinct_names #p #q i j = A.distinct_invariants_have_distinct_names #p #q i j ()
 let invariant_name_identifies_invariant #p #q i j = A.invariant_name_identifies_invariant p q i j

--- a/lib/pulse/lib/Pulse.Lib.Core.fst
+++ b/lib/pulse/lib/Pulse.Lib.Core.fst
@@ -139,7 +139,8 @@ let lift_atomic1 = A.lift_atomic1
 let lift_atomic2 = A.lift_atomic2
 let new_invariant = A.new_invariant
 let with_invariant = A.with_invariant
-
+let distinct_invariants_have_distinct_names #p #q i j = A.distinct_invariants_have_distinct_names #p #q i j ()
+let invariant_name_identifies_invariant #p #q i j = A.invariant_name_identifies_invariant p q i j
 ////////////////////////////////////////////////////////////////////
 // Ghost computations
 ////////////////////////////////////////////////////////////////////

--- a/lib/pulse/lib/Pulse.Lib.Core.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Core.fsti
@@ -121,8 +121,13 @@ let (/!) (is1 is2 : inames) : Type0 =
   Set.disjoint is1 is2
 
 val inv (p:vprop) : Type u#0
-
+val allocated_name : Type0
 val name_of_inv #p (i : inv p) : GTot iname
+val allocated_name_of_inv #p (i : inv p) : allocated_name
+val name_of_allocated_name (a:allocated_name) : GTot iname
+val allocated_name_of_inv_equiv (#p:vprop) (i:inv p)
+: Lemma (name_of_allocated_name (allocated_name_of_inv i) == name_of_inv i)
+        [SMTPat (name_of_allocated_name (allocated_name_of_inv i))]
 
 let mem_iname (e:inames) (i:iname) : erased bool = elift2 (fun e i -> Set.mem i e) e i
 let mem_inv (#p:vprop) (e:inames) (i:inv p) : erased bool = mem_iname e (name_of_inv i)
@@ -345,6 +350,20 @@ val lift_atomic2
 val new_invariant
     (p:vprop)
 : stt_atomic (inv p) #Unobservable emp_inames p (fun _ -> emp)
+
+val fresh_wrt (i:iname) (c:list allocated_name)
+: prop
+
+val fresh_wrt_def (i:iname) (c:list allocated_name)
+: Lemma
+    (fresh_wrt i c <==>
+    (forall (a:allocated_name). List.Tot.memP a c ==> name_of_allocated_name a =!= i))
+    [SMTPat (fresh_wrt i c)]
+
+val fresh_invariant
+    (ctx:list allocated_name)
+    (p:vprop)
+: stt_atomic (i:inv p { name_of_inv i `fresh_wrt` ctx }) #Unobservable emp_inames p (fun _ -> emp)
 
 val with_invariant
     (#a:Type)

--- a/lib/pulse/lib/Pulse.Lib.Core.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Core.fsti
@@ -359,6 +359,26 @@ val with_invariant
                             (fun x -> p ** fp' x))
 : stt_atomic a #(join_obs obs Unobservable) (add_inv f_opens i) fp fp'
 
+val distinct_invariants_have_distinct_names
+    (#p #q:vprop)
+    (i:inv p)
+    (j:inv q { (p =!= q) })
+: stt_atomic (_:squash (name_of_inv i =!= name_of_inv j))
+    #Unobservable
+    emp_inames
+    emp
+    (fun _ -> emp)
+
+val invariant_name_identifies_invariant
+      (#p #q:vprop)
+      (i:inv p)
+      (j:inv q { name_of_inv i == name_of_inv j } )
+: stt_atomic (squash (p == q /\ i == j))
+    #Unobservable
+    emp_inames
+    emp
+    (fun _ -> emp)
+
 //////////////////////////////////////////////////////////////////////////
 // Ghost computations
 //////////////////////////////////////////////////////////////////////////

--- a/lib/pulse/lib/Pulse.Lib.Core.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Core.fsti
@@ -127,7 +127,6 @@ val allocated_name_of_inv #p (i : inv p) : allocated_name
 val name_of_allocated_name (a:allocated_name) : GTot iname
 val allocated_name_of_inv_equiv (#p:vprop) (i:inv p)
 : Lemma (name_of_allocated_name (allocated_name_of_inv i) == name_of_inv i)
-        [SMTPat (name_of_allocated_name (allocated_name_of_inv i))]
 
 let mem_iname (e:inames) (i:iname) : erased bool = elift2 (fun e i -> Set.mem i e) e i
 let mem_inv (#p:vprop) (e:inames) (i:inv p) : erased bool = mem_iname e (name_of_inv i)
@@ -358,7 +357,6 @@ val fresh_wrt_def (i:iname) (c:list allocated_name)
 : Lemma
     (fresh_wrt i c <==>
     (forall (a:allocated_name). List.Tot.memP a c ==> name_of_allocated_name a =!= i))
-    [SMTPat (fresh_wrt i c)]
 
 val fresh_invariant
     (ctx:list allocated_name)

--- a/lib/pulse/lib/Pulse.Lib.Core.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Core.fsti
@@ -127,6 +127,7 @@ val allocated_name_of_inv #p (i : inv p) : allocated_name
 val name_of_allocated_name (a:allocated_name) : GTot iname
 val allocated_name_of_inv_equiv (#p:vprop) (i:inv p)
 : Lemma (name_of_allocated_name (allocated_name_of_inv i) == name_of_inv i)
+        [SMTPat (name_of_allocated_name (allocated_name_of_inv i))]
 
 let mem_iname (e:inames) (i:iname) : erased bool = elift2 (fun e i -> Set.mem i e) e i
 let mem_inv (#p:vprop) (e:inames) (i:inv p) : erased bool = mem_iname e (name_of_inv i)
@@ -357,6 +358,7 @@ val fresh_wrt_def (i:iname) (c:list allocated_name)
 : Lemma
     (fresh_wrt i c <==>
     (forall (a:allocated_name). List.Tot.memP a c ==> name_of_allocated_name a =!= i))
+    [SMTPat (fresh_wrt i c)]
 
 val fresh_invariant
     (ctx:list allocated_name)

--- a/share/pulse/examples/Quicksort.Base.fst
+++ b/share/pulse/examples/Quicksort.Base.fst
@@ -305,6 +305,7 @@ let transfer_larger_slice
   assert (forall (k: int). l - shift <= k /\ k < r - shift ==> (lb <= Seq.index s k));
   ()
 
+#push-options "--z3rlimit_factor 4 --split_queries no"
 let transfer_smaller_slice
   (s : Seq.seq int)
   (shift : nat)
@@ -320,6 +321,7 @@ let transfer_smaller_slice
   assert (forall (k: int). l <= (k+shift) /\ (k+shift) < r ==> (Seq.index s ((k+shift) - shift) <= rb));
   assert (forall (k: int). l - shift <= k /\ k < r - shift ==> (Seq.index s k <= rb));
   ()
+#pop-options
 #pop-options
 
 let transfer_equal_slice


### PR DESCRIPTION
This PR provides three utilities for working with invariant names.

1 & 2. A form on injectivity on invariant names. Both these lemmas involve eliminating an `inv p` and so are in stt_atomic Unobservable, i.e., they are computation steps since they involve using the recall operator of underlying monotonic state monad. That's why I also provided it in two forms, since it's not possible to take the contrapositive of these computation steps.

```fstar
val distinct_invariants_have_distinct_names
    (#p #q:vprop)
    (i:inv p)
    (j:inv q { (p =!= q) })
: stt_atomic (_:squash (name_of_inv i =!= name_of_inv j))
    #Unobservable
    emp_inames
    emp
    (fun _ -> emp)
```

```fstar
val invariant_name_identifies_invariant
      (#p #q:vprop)
      (i:inv p)
      (j:inv q { name_of_inv i == name_of_inv j } )
: stt_atomic (squash (p == q /\ i == j))
    #Unobservable
    emp_inames
    emp
    (fun _ -> emp)
```

3. Allocating invariants fresh w.r.t a given context:


```fstar
val fresh_invariant
    (ctx:list allocated_name)
    (p:vprop)
: stt_atomic (i:inv p { name_of_inv i `fresh_wrt` ctx }) #Unobservable emp_inames p (fun _ -> emp)
```

Note, here I use a notion of `allocated_name` instead of just a raw `iname`, though the two are related like so:

```fstar
val allocated_name : Type0
val allocated_name_of_inv #p (i : inv p) : allocated_name
val name_of_allocated_name (a:allocated_name) : GTot iname
val allocated_name_of_inv_equiv (#p:vprop) (i:inv p)
: Lemma (name_of_allocated_name (allocated_name_of_inv i) == name_of_inv i)
       [SMTPat (name_of_allocated_name (allocated_name_of_inv i))]
```