### PR TITLE
Enforcing in PulseCore that ghost computations cannot use witness/recall

### DIFF
--- a/lib/pulse/core/PulseCore.Action.fst
+++ b/lib/pulse/core/PulseCore.Action.fst
@@ -4,6 +4,7 @@ module Mem = PulseCore.Memory
 module I = PulseCore.InstantiatedSemantics
 module M = PulseCore.MonotonicStateMonad
 module F = FStar.FunctionalExtensionality
+module PST = PulseCore.PreorderStateMonad
 friend PulseCore.InstantiatedSemantics
 open FStar.PCM
 open FStar.Ghost
@@ -14,7 +15,7 @@ open PulseCore.InstantiatedSemantics
 // An abstraction on top of memory actions
 //////////////////////////////////////////////////////
 
-(* The type of atomic actions *)
+(* The type of semantic actions, does not distinguish reifiability *)
 let action
     (a:Type u#a)
     (except:inames)
@@ -29,31 +30,27 @@ let action
     (pre `star` frame)
     (fun x -> post x `star` frame)
 
-let return_action
-    (#a:Type u#a)
-    (#except:inames)
-    (#post:a -> slprop)
-    (x:a)
-: action a except (post x) post
-= fun frame -> M.weaken (M.return x)
 
-let bind_action
-     (#a:Type u#a)
-     (#b:Type u#b)
-     (#except:inames)
-     (#pre1 #post1 #post2:_)
-     (f:action a except pre1 post1)
-     (g:(x:a -> action b except (post1 x) post2))
-: action b except pre1 post2
-= fun frame -> M.weaken (M.bind (f frame) (fun x -> g x frame))
-
-let frame_action
-     (#a:Type u#a)
-     (#except:inames)
-     (#pre #post #frame:_)
-     (f:action a except pre post)
-: action a except (pre `star` frame) (fun x -> post x `star` frame)
-= fun frame' -> f (frame `star` frame')
+let action_as_mem_action
+        (a:Type u#a)
+        (except:inames)
+        (pre:slprop)
+        (post: a -> slprop) 
+        (act:action a except pre post)
+: Mem.action_except a except pre post
+= fun frame ->
+    let m
+      : M.mst state.evolves
+                a 
+                (fun s0 -> 
+                    inames_ok except s0 /\
+                    interp ((pre `star` locks_invariant except s0) `star` frame) s0)
+                (fun s0 x s1 ->
+                    inames_ok except s1 /\
+                    interp ((post x `star` locks_invariant except s1) `star` frame) s1)
+      = M.weaken (act frame)
+    in
+    M.to_msttotal _ _ _ _ m
 
 let stt_of_action (#a:Type u#100) #pre #post (m:action a Set.empty pre post)
 : stt a pre post
@@ -91,12 +88,26 @@ let stt_of_action2 (#a:Type u#2) #pre #post (m:action a Set.empty pre post)
   in
   let action : Sem.action state a = {pre=pre; post=F.on_dom _ post; step} in
   fun _ -> Sem.act_as_m2 u#2 u#100 action
-   
+
+let iname = iname
+
+let pre_act
+    (a:Type u#a)
+    (r:reifiability)
+    (opens:inames)
+    (pre:slprop)
+    (post:a -> slprop)
+= match r with
+  | Reifiable ->
+    Mem.pst_action_except a opens pre post
+  | _ ->
+    Mem.action_except a opens pre post
+
 let mem_action_as_action
-        (a:Type u#a)
-        (except:inames)
-        (req:slprop)
-        (ens: a -> slprop)
+        (#a:Type u#a)
+        (#except:inames)
+        (#req:slprop)
+        (#ens: a -> slprop)
         (act:Mem.action_except a except req ens)
 : action a except req ens
 = fun frame ->
@@ -106,109 +117,255 @@ let mem_action_as_action
     in
     M.of_msttotal _ _ _ _ thunk
 
-let action_as_mem_action
-        (a:Type u#a)
-        (except:inames)
-        (pre:slprop)
-        (post: a -> slprop) 
-        (act:action a except pre post)
-: Mem.action_except a except pre post
-= fun frame ->
-    let m
-      : M.mst state.evolves
-                a 
-                (fun s0 -> 
-                    inames_ok except s0 /\
-                    interp ((pre `star` locks_invariant except s0) `star` frame) s0)
-                (fun s0 x s1 ->
-                    inames_ok except s1 /\
-                    interp ((post x `star` locks_invariant except s1) `star` frame) s1)
-      = M.weaken (act frame)
-    in
-    M.to_msttotal _ _ _ _ m
+let mem_pst_action_as_action
+        (#a:Type u#a)
+        (#except:inames)
+        (#req:slprop)
+        (#ens: a -> slprop)
+        (act:Mem.pst_action_except a except req ens)
+: action a except req ens
+= fun frame -> M.weaken <| M.lift_pst (act frame)
 
-//////////////////////////////////////////////////////
-// Next, reversing the polarity of the inames index
-//////////////////////////////////////////////////////
-
-let iname = iname
+let action_of_pre_act
+    (#a:Type u#a)
+    (#r:reifiability)
+    (#opens:inames)
+    (#pre:slprop)
+    (#post:a -> slprop)
+    (f:pre_act a r opens pre post)
+: action a opens pre post
+= match r with
+  | Reifiable -> mem_pst_action_as_action f
+  | _ -> mem_action_as_action f
 
 let act 
     (a:Type u#a)
+    (r:reifiability)
     (opens:inames)
     (pre:slprop)
     (post:a -> slprop)
 : Type u#(max a 2)
 = #ictx:inames_disj opens ->
-   action a ictx pre post
+   pre_act a r ictx pre post
+
+let return_pre_act
+    (#a:Type u#a)
+    (#except:inames)
+    (#post:a -> slprop)
+    (x:a)
+: pre_act a Reifiable except (post x) post
+= fun frame m0 -> x, m0
+
+let bind_pre_act_reifiable
+     (#a:Type u#a)
+     (#b:Type u#b)
+     (#except:inames)
+     (#pre1 #post1 #post2:_)
+     (f:pre_act a Reifiable except pre1 post1)
+     (g:(x:a -> pre_act b Reifiable except (post1 x) post2))
+: pre_act b Reifiable except pre1 post2
+= fun frame ->
+    PST.weaken (PST.bind (f frame) (fun x -> g x frame))
+
+let bind_pre_act_non_reifiable
+     (#a:Type u#a)
+     (#b:Type u#b)
+     (#except:inames)
+     (#pre1 #post1 #post2:_)
+     ($f:pre_act a UsesInvariants except pre1 post1)
+     ($g:(x:a -> pre_act b UsesInvariants except (post1 x) post2))
+: pre_act b UsesInvariants except pre1 post2
+= fun frame ->
+    let x = f frame in
+    g x frame
+
+let bind_pre_act
+     (#a:Type u#a)
+     (#b:Type u#b)
+     (#r:reifiability)
+     (#except:inames)
+     (#pre1 #post1 #post2:_)
+     (f:pre_act a r except pre1 post1)
+     (g:(x:a -> pre_act b r except (post1 x) post2))
+: pre_act b r except pre1 post2
+= match r with
+  | Reifiable ->
+    bind_pre_act_reifiable #a #b #except #pre1 #post1 #post2 f g
+  | UsesInvariants ->
+    bind_pre_act_non_reifiable #a #b #except #pre1 #post1 #post2 f g
+
+let frame_pre_act_reifiable
+     (#a:Type u#a)
+     (#except:inames)
+     (#pre #post #frame:_)
+     (f:pre_act a Reifiable except pre post)
+: pre_act a Reifiable except (pre `star` frame) (fun x -> post x `star` frame)
+= fun frame' -> f (frame `star` frame')
+
+let frame_pre_act_non_reifiable
+     (#a:Type u#a)
+     (#except:inames)
+     (#pre #post #frame:_)
+     (f:pre_act a UsesInvariants except pre post)
+: pre_act a UsesInvariants except (pre `star` frame) (fun x -> post x `star` frame)
+= fun frame' -> f (frame `star` frame')
+
+let frame_pre_act
+     (#a:Type u#a)
+     (#r:reifiability)
+     (#except:inames)
+     (#pre #post #frame:_)
+     (f:pre_act a r except pre post)
+: pre_act a r except (pre `star` frame) (fun x -> post x `star` frame)
+= match r with
+  | Reifiable -> frame_pre_act_reifiable #a #except #pre #post #frame f
+  | _ -> frame_pre_act_non_reifiable #a #except #pre #post #frame f
+
+let lift_pre_act_reifiablity
+     (#a:Type u#a)
+     (#r:_)
+     (#except:inames)
+     (#pre #post:_)
+     (f:pre_act a r except pre post)
+: pre_act a UsesInvariants except pre post
+= if r = UsesInvariants then f
+  else let f : pre_act a Reifiable except pre post = f in
+       fun frame -> M.to_msttotal _ _ _ _ (M.lift_pst (f frame))
+
+//////////////////////////////////////////////////////
+// Next, reversing the polarity of the inames index
+//////////////////////////////////////////////////////
 
 let return 
     (#a:Type u#a)
+    (#r:reifiability)
     (#post:a -> slprop)
     (x:a)
-: act a emp_inames (post x) post
-= fun #ictx -> return_action #a #ictx #post x
+: act a r emp_inames (post x) post
+= fun #ictx ->
+    let m = return_pre_act #a #ictx #post x in
+    match r with
+    | Reifiable -> m
+    | _ -> lift_pre_act_reifiablity m
 
 let bind
      (#a:Type u#a)
      (#b:Type u#b)
+     (#r:reifiability)
      (#opens:inames)
      (#pre1 #post1 #post2:_)
-     (f:act a opens pre1 post1)
-     (g:(x:a -> act b opens (post1 x) post2))
-: act b opens pre1 post2
-= fun #ictx -> bind_action #a #b #ictx #pre1 #post1 #post2 (f #ictx) (fun x -> g x #ictx)
+     (f:act a r opens pre1 post1)
+     (g:(x:a -> act b r opens (post1 x) post2))
+: act b r opens pre1 post2
+= fun #ictx -> bind_pre_act #a #b #r #ictx #pre1 #post1 #post2 (f #ictx) (fun x -> g x #ictx)
 
 let frame
      (#a:Type u#a)
+     (#r:reifiability)
      (#opens:inames)
      (#pre #post #frame:_)
-     (f:act a opens pre post)
-: act a opens (pre `star` frame) (fun x -> post x `star` frame)
-= fun #ictx -> frame_action (f #ictx)
+     (f:act a r opens pre post)
+: act a r opens (pre `star` frame) (fun x -> post x `star` frame)
+= fun #ictx -> frame_pre_act (f #ictx)
+
+let lift_reifiability 
+    (#a:Type)
+    (#r:_)
+    (#pre:slprop)
+    (#post:a -> slprop)
+    (#opens:inames)
+    (f:act a r opens pre post)
+: act a UsesInvariants opens pre post
+= fun #ictx -> lift_pre_act_reifiablity (f #ictx)
 
 let weaken 
     (#a:Type)
     (#pre:slprop)
     (#post:a -> slprop)
+    (#r0 #r1:reifiability)
     (#opens opens':inames)
-    (f:act a opens pre post)
-: act a (Set.union opens opens') pre post
-= f
+    (f:act a r0 opens pre post)
+: act a (r0 ^^ r1) (Set.union opens opens') pre post
+= match r0 with
+  | UsesInvariants -> f
+  | _ ->
+    match r1 with
+    | Reifiable -> f
+    | _ -> lift_reifiability f
 
-let sub 
+let sub_pre_act_reifiable 
     (#a:Type)
     (#pre:slprop)
     (#post:a -> slprop)
     (#opens:inames)
     (pre':slprop { slprop_equiv pre pre' })
     (post':a -> slprop { forall x. slprop_equiv (post x) (post' x) })
-    (f:act a opens pre post)
-: act a opens pre' post'
+    (f:pre_act a Reifiable opens pre post)
+: pre_act a Reifiable opens pre' post'
 = I.slprop_equiv_elim pre pre';
   introduce forall x. post x == post' x
   with I.slprop_equiv_elim (post x) (post' x);
   f
 
-let lift (#a:Type u#100) #opens #pre #post
-         (m:act a opens pre post)
-: stt a pre post
-= stt_of_action (m #emp_inames)
+let sub_pre_act_non_reifiable 
+    (#a:Type)
+    (#pre:slprop)
+    (#post:a -> slprop)
+    (#opens:inames)
+    (pre':slprop { slprop_equiv pre pre' })
+    (post':a -> slprop { forall x. slprop_equiv (post x) (post' x) })
+    (f:pre_act a UsesInvariants opens pre post)
+: pre_act a UsesInvariants opens pre' post'
+= I.slprop_equiv_elim pre pre';
+  introduce forall x. post x == post' x
+  with I.slprop_equiv_elim (post x) (post' x);
+  f
 
-let lift0 (#a:Type u#0) #opens #pre #post
-          (m:act a opens pre post)
-: stt a pre post
-= stt_of_action0 (m #emp_inames)
+let sub 
+    (#a:Type)
+    (#pre:slprop)
+    (#post:a -> slprop)
+    (#r:_)
+    (#opens:inames)
+    (pre':slprop { slprop_equiv pre pre' })
+    (post':a -> slprop { forall x. slprop_equiv (post x) (post' x) })
+    (f:act a r opens pre post)
+: act a r opens pre' post'
+= match r with
+  | Reifiable ->
+    fun #ictx -> sub_pre_act_reifiable #a #pre #post #ictx pre' post' (f #ictx)
+  | _ ->
+    fun #ictx -> sub_pre_act_non_reifiable #a #pre #post #ictx pre' post' (f #ictx)
 
-let lift1 (#a:Type u#1) #opens #pre #post
-          (m:act a opens pre post)
-: stt a pre post
-= stt_of_action1 (m #emp_inames)
+let action_of_act 
+    (#a:Type)
+    (#r:reifiability)
+    (#opens:inames)
+    (#pre:slprop)
+    (#post:a -> slprop)
+    (f:act a r opens pre post)
+: action a emp_inames pre post
+= action_of_pre_act (f #emp_inames)
 
-let lift2 (#a:Type u#2) #opens #pre #post
-          (m:act a opens pre post)
+let lift (#a:Type u#100) #r #opens #pre #post
+         (m:act a r opens pre post)
 : stt a pre post
-= stt_of_action2 (m #emp_inames)
+= stt_of_action (action_of_act m)
+
+let lift0 (#a:Type u#0) #r #opens #pre #post
+          (m:act a r opens pre post)
+: stt a pre post
+= stt_of_action0 (action_of_act m)
+
+let lift1 (#a:Type u#1) #r #opens #pre #post
+          (m:act a r opens pre post)
+: stt a pre post
+= stt_of_action1 (action_of_act m)
+
+let lift2 (#a:Type u#2) #r #opens #pre #post
+          (m:act a r opens pre post)
+: stt a pre post
+= stt_of_action2 (action_of_act m)
 ///////////////////////////////////////////////////////
 // invariants
 ///////////////////////////////////////////////////////
@@ -219,38 +376,42 @@ let allocated_name_of_inv = pre_inv_of_inv
 let name_of_allocated_name = name_of_pre_inv
 
 let new_invariant (p:slprop)
-: act (inv p) emp_inames p (fun _ -> emp)
-= fun #ictx -> 
-    mem_action_as_action _ _ _ _ (new_invariant ictx p)
+: act (inv p) UsesInvariants emp_inames p (fun _ -> emp)
+= fun #ictx -> new_invariant ictx p
 
 let fresh_invariant ctx p
-: act (i:inv p { fresh_wrt (name_of_inv i) ctx  }) emp_inames p (fun _ -> emp)
-= fun #ictx -> mem_action_as_action _ _ _ _ (fresh_invariant ictx p ctx)
+: act (i:inv p { fresh_wrt (name_of_inv i) ctx  })
+      UsesInvariants emp_inames p (fun _ -> emp)
+= fun #ictx -> fresh_invariant ictx p ctx
 
 let with_invariant
     (#a:Type)
+    (#r:_)
     (#fp:slprop)
     (#fp':a -> slprop)
     (#f_opens:inames)
     (#p:slprop)
     (i:inv p{not (mem_inv f_opens i)})
-    (f:unit -> act a f_opens (p `star` fp) (fun x -> p `star` fp' x))
-: act a (add_inv f_opens i) fp fp'
+    (f:unit -> act a r f_opens (p `star` fp) (fun x -> p `star` fp' x))
+: act a UsesInvariants (add_inv f_opens i) fp fp'
 = fun #ictx ->
+    let f : act a UsesInvariants f_opens (p `star` fp) (fun x -> p `star` fp' x)
+      = match r with
+        | UsesInvariants -> f ()
+        | _ -> lift_reifiability (f ())
+    in
     let ictx' = Mem.add_inv ictx i in
-    let f = action_as_mem_action _ _ _ _ (f () #ictx') in
-    let m = with_invariant i f in
-    mem_action_as_action _ _ _ _ m
+    with_invariant #a #fp #fp' #ictx i (f #ictx')
 
 let distinct_invariants_have_distinct_names
     #p #q i j pf
-= fun #ictx -> mem_action_as_action _ _ _ _ (distinct_invariants_have_distinct_names ictx p q i j)
+= fun #ictx -> distinct_invariants_have_distinct_names ictx p q i j
 
 let invariant_name_identifies_invariant
       (p q:slprop)
       (i:inv p)
       (j:inv q { name_of_inv i == name_of_inv j } )
-= fun #ictx -> mem_action_as_action _ _ _ _ (invariant_name_identifies_invariant ictx p q i j)
+= fun #ictx -> invariant_name_identifies_invariant ictx p q i j
 
 ///////////////////////////////////////////////////////////////////
 // Core operations on references
@@ -260,17 +421,14 @@ let ref (a:Type u#a) (p:pcm a) = ref a p
 let ref_null (#a:Type u#a) (p:pcm a) = core_ref_null
 let is_ref_null (#a:Type u#a) (#p:pcm a) (r:ref a p) = core_ref_is_null r
 let pts_to = pts_to
-let pts_to_not_null #a #p r v =
-    fun #ictx -> mem_action_as_action _ _ _ _ (pts_to_not_null_action ictx r v)
+let pts_to_not_null #a #p r v #ictx = pts_to_not_null_action ictx r v
 
 let alloc
     (#a:Type u#1)
     (#pcm:pcm a)
     (x:a{compatible pcm x x /\ pcm.refine x})
-: act (ref a pcm) emp_inames emp (fun r -> pts_to r x)
-= fun #ictx ->
-    mem_action_as_action _ _ _ _
-        (alloc_action ictx x)
+: act (ref a pcm) Reifiable emp_inames emp (fun r -> pts_to r x)
+= fun #ictx -> alloc_action ictx x
 
 let read
     (#a:Type)
@@ -280,11 +438,12 @@ let read
     (f:(v:a{compatible p x v}
         -> GTot (y:a{compatible p y v /\
                      FStar.PCM.frame_compatible p x v y})))
-: act (v:a{compatible p x v /\ p.refine v}) emp_inames
+: act (v:a{compatible p x v /\ p.refine v})
+      Reifiable
+      emp_inames
       (pts_to r x)
       (fun v -> pts_to r (f v))
-= fun #ictx ->
-    mem_action_as_action _ _ _ _ (select_refine ictx r x f)
+= fun #ictx -> select_refine ictx r x f
 
 let write
     (#a:Type)
@@ -292,10 +451,12 @@ let write
     (r:ref a p)
     (x y:Ghost.erased a)
     (f:FStar.PCM.frame_preserving_upd p x y)
-: act unit emp_inames
-                  (pts_to r x)
-                  (fun _ -> pts_to r y)
-= fun #ictx -> mem_action_as_action _ _ _ _ (upd_gen ictx r x y f)
+: act unit
+      Reifiable 
+      emp_inames
+      (pts_to r x)
+      (fun _ -> pts_to r y)
+= fun #ictx -> upd_gen ictx r x y f
 
 let share
     (#a:Type)
@@ -303,10 +464,12 @@ let share
     (r:ref a pcm)
     (v0:FStar.Ghost.erased a)
     (v1:FStar.Ghost.erased a{composable pcm v0 v1})
-: act unit emp_inames
+: act unit
+      Reifiable
+      emp_inames
       (pts_to r (v0 `op pcm` v1))
       (fun _ -> pts_to r v0 `star` pts_to r v1)
-= fun #ictx -> mem_action_as_action _ _ _ _ (split_action ictx r v0 v1)
+= fun #ictx -> split_action ictx r v0 v1
 
 let gather
     (#a:Type)
@@ -315,10 +478,11 @@ let gather
     (v0:FStar.Ghost.erased a)
     (v1:FStar.Ghost.erased a)
 : act (squash (composable pcm v0 v1))
-    emp_inames
-    (pts_to r v0 `star` pts_to r v1)
-    (fun _ -> pts_to r (op pcm v0 v1))
-= fun #ictx -> mem_action_as_action _ _ _ _ (gather_action ictx r v0 v1)
+      Reifiable
+      emp_inames
+      (pts_to r v0 `star` pts_to r v1)
+      (fun _ -> pts_to r (op pcm v0 v1))
+= fun #ictx -> gather_action ictx r v0 v1
 
 let witnessed = witnessed
 let witness
@@ -328,8 +492,12 @@ let witness
     (fact:stable_property pcm)
     (v:Ghost.erased a)
     (pf:squash (forall z. compatible pcm v z ==> fact z))
-: act (witnessed r fact) emp_inames (pts_to r v) (fun _ -> pts_to r v)
-= fun #ictx -> mem_action_as_action _ _ _ _ (witness ictx r fact v pf)
+: act (witnessed r fact)
+      UsesInvariants
+      emp_inames
+      (pts_to r v)
+      (fun _ -> pts_to r v)
+= fun #ictx -> witness ictx r fact v pf
 
 let recall
     (#a:Type u#1)
@@ -339,10 +507,11 @@ let recall
     (v:Ghost.erased a)
     (w:witnessed r fact)
 : act (v1:Ghost.erased a{compatible pcm v v1})
-    emp_inames
-    (pts_to r v)
-    (fun v1 -> pts_to r v `star` pure (fact v1))
-= fun #ictx -> mem_action_as_action _ _ _ _ (recall ictx r v w)
+      UsesInvariants
+      emp_inames
+      (pts_to r v)
+      (fun v1 -> pts_to r v `star` pure (fact v1))
+= fun #ictx -> recall ictx r v w
 
 ///////////////////////////////////////////////////////////////////
 // pure
@@ -353,12 +522,12 @@ let pure_true ()
   coerce_eq () <| slprop_equiv_refl (pure True)
 
 let intro_pure (p:prop) (pf:squash p)
-: act unit emp_inames emp (fun _ -> pure p)
-= fun #ictx -> mem_action_as_action _ _ _ _ (intro_pure #ictx p pf)
+: act unit Reifiable emp_inames emp (fun _ -> pure p)
+= fun #ictx -> intro_pure #ictx p pf
 
 let elim_pure (p:prop)
-: act (squash p) emp_inames (pure p) (fun _ -> emp)
-= fun #ictx -> mem_action_as_action _ _ _ _ (elim_pure #ictx p)
+: act (squash p) Reifiable emp_inames (pure p) (fun _ -> emp)
+= fun #ictx -> elim_pure #ictx p
 
 ///////////////////////////////////////////////////////////////////
 // exists*
@@ -373,24 +542,23 @@ let exists_equiv (#a:_) (#p:a -> slprop)
 let thunk (p:slprop) = fun (_:unit) -> p
 
 let intro_exists' (#a:Type u#a) (p:a -> slprop) (x:erased a)
-: act unit emp_inames (p x) (thunk (op_exists_Star p))
-= fun #ictx -> mem_action_as_action _ _ _ _ (intro_exists #ictx (F.on_dom a p) x)
+: act unit Reifiable emp_inames (p x) (thunk (op_exists_Star p))
+= fun #ictx -> intro_exists #ictx (F.on_dom a p) x
 
 let intro_exists'' (#a:Type u#a) (p:a -> slprop) (x:erased a)
-: act unit emp_inames (p x) (thunk (exists* x. p x))
+: act unit Reifiable emp_inames (p x) (thunk (exists* x. p x))
 = coerce_eq (exists_equiv #a #p) (intro_exists' #a p x)
 
 let intro_exists (#a:Type u#a) (p:a -> slprop) (x:erased a)
-: act unit emp_inames (p x) (fun _ -> exists* x. p x)
+: act unit Reifiable emp_inames (p x) (fun _ -> exists* x. p x)
 = intro_exists'' p x
 
 let elim_exists' (#a:Type u#a) (p:a -> slprop)
-: act (erased a) emp_inames (op_exists_Star p) (fun x -> p x)
-= fun #ictx -> mem_action_as_action _ _ _ _ (witness_h_exists #ictx (F.on_dom a p))
+: act (erased a) Reifiable emp_inames (op_exists_Star p) (fun x -> p x)
+= fun #ictx -> witness_h_exists #ictx (F.on_dom a p)
 
 let elim_exists (#a:Type u#a) (p:a -> slprop)
-: act (erased a) emp_inames (exists* x. p x) (fun x -> p x)
+: act (erased a) Reifiable emp_inames (exists* x. p x) (fun x -> p x)
 = coerce_eq (exists_equiv #a #p) (elim_exists' #a p)
 
-let drop p
-= fun #ictx -> mem_action_as_action _ _ _ _ (drop #ictx p)
+let drop p = fun #ictx -> drop #ictx p

--- a/lib/pulse/core/PulseCore.Atomic.fsti
+++ b/lib/pulse/core/PulseCore.Atomic.fsti
@@ -326,8 +326,9 @@ val witness
     (fact:stable_property pcm)
     (v:Ghost.erased a)
     (pf:squash (forall z. compatible pcm v z ==> fact z))
-: stt_ghost
+: stt_atomic
     (witnessed r fact)
+    #Unobservable emp_inames
     (pts_to r v)
     (fun _ -> pts_to r v)
 
@@ -338,7 +339,8 @@ val recall
     (r:erased (ref a pcm))
     (v:Ghost.erased a)
     (w:witnessed r fact)
-: stt_ghost (v1:Ghost.erased a{compatible pcm v v1})
+: stt_atomic (v1:Ghost.erased a{compatible pcm v v1})
+    #Unobservable emp_inames
     (pts_to r v)
     (fun v1 -> pts_to r v ** pure (fact v1))
 
@@ -413,8 +415,9 @@ val ghost_witness
     (fact:stable_property pcm)
     (v:Ghost.erased a)
     (pf:squash (forall z. compatible pcm v z ==> fact z))
-: stt_ghost
+: stt_atomic
     (ghost_witnessed r fact)
+    #Unobservable emp_inames
     (ghost_pts_to r v)
     (fun _ -> ghost_pts_to r v)
 
@@ -425,7 +428,8 @@ val ghost_recall
     (r:ghost_ref pcm)
     (v:Ghost.erased a)
     (w:ghost_witnessed r fact)
-: stt_ghost (v1:Ghost.erased a{compatible pcm v v1})
+: stt_atomic (v1:Ghost.erased a{compatible pcm v v1})
+    #Unobservable emp_inames
     (ghost_pts_to r v)
     (fun v1 -> ghost_pts_to r v ** pure (fact v1))
 

--- a/lib/pulse/core/PulseCore.MonotonicStateMonad.fsti
+++ b/lib/pulse/core/PulseCore.MonotonicStateMonad.fsti
@@ -1,6 +1,7 @@
 module PulseCore.MonotonicStateMonad
 open FStar.Preorder
 module M = FStar.MSTTotal
+module PST = PulseCore.PreorderStateMonad
 
 val mst (#s:Type u#s)
         (rel:FStar.Preorder.preorder s)
@@ -8,6 +9,15 @@ val mst (#s:Type u#s)
         (pre:s -> prop)
         (post:s -> a -> s -> prop)
 : Type u#(max a s)
+
+val lift_pst
+    (#s:Type u#s)
+    (#rel:FStar.Preorder.preorder s)
+    (#a:Type u#a)
+    (#pre:s -> prop)
+    (#post:s -> a -> s -> prop)
+    (pst:PST.pst a rel pre post)
+: mst rel a pre post
 
 val of_msttotal (#s:Type u#2) (rel:FStar.Preorder.preorder s)
                 (a:Type u#a) (pre:s -> prop) (post:s -> a -> s -> prop)

--- a/lib/pulse/core/PulseCore.PreorderStateMonad.fst
+++ b/lib/pulse/core/PulseCore.PreorderStateMonad.fst
@@ -1,0 +1,49 @@
+module PulseCore.PreorderStateMonad
+open FStar.Preorder
+
+let return (#s:Type u#s)
+           (#rel:preorder s)
+           (#a:Type u#a)
+           (x:a)
+: pst a rel (fun _ -> True) (fun s0 v s1 -> x == v /\ s0 == s1)           
+= fun s -> x, s
+
+let bind
+      (#s:Type u#s)
+      (#a:Type u#a)
+      (#b:Type u#b)
+      (#rel:preorder s)
+      (#req_f:req_t s)
+      (#ens_f:ens_t s a)
+      (#req_g:a -> req_t s)
+      (#ens_g:a -> ens_t s b)
+      (f:pst a rel req_f ens_f)
+      (g:(x:a -> pst b rel (req_g x) (ens_g x)))
+: pst b rel
+  (fun s0 -> req_f s0 /\ (forall x s1. ens_f s0 x s1 ==> (req_g x) s1))
+  (fun s0 r s2 -> req_f s0 /\ (exists x s1. ens_f s0 x s1 /\ (req_g x) s1 /\ (ens_g x) s1 r s2))
+= fun s0 -> let x, s1 = f s0 in g x s1
+
+let weaken
+      (#s:Type u#s)
+      (#rel:preorder s)
+      (#a:Type u#a)
+      (#req_f:req_t s)
+      (#ens_f:ens_t s a)
+      (#req_g:req_t s)
+      (#ens_g:ens_t s a)
+      (f:pst a rel req_f ens_f)
+    : Pure (pst a rel req_g ens_g)
+      (requires
+        (forall s. req_g s ==> req_f s) /\
+        (forall s0 x s1. (req_g s0 /\ ens_f s0 x s1) ==> ens_g s0 x s1))
+      (ensures fun _ -> True)
+= fun s -> f s
+
+let get (#s:Type u#s) (#rel:preorder s) (_:unit)
+: pst s rel (fun _ -> True) (fun s0 x s1 -> s0 == s1 /\ x == s0)
+= fun s -> s, s
+
+let put (#s:Type u#s) (#rel:preorder s) (v:s)
+: pst unit rel  (fun s0 -> rel s0 v /\ True) (fun s0 x s1 -> v == s1)
+= fun _ -> (), v

--- a/lib/pulse/core/PulseCore.PreorderStateMonad.fsti
+++ b/lib/pulse/core/PulseCore.PreorderStateMonad.fsti
@@ -1,0 +1,62 @@
+module PulseCore.PreorderStateMonad
+open FStar.Preorder
+
+let req_t (s:Type) = s -> prop
+let ens_t (s:Type) (a:Type) = s -> a -> s -> prop
+
+let pst
+    (#s:Type u#s)
+    (a:Type u#a)
+    (rel:preorder s)
+    (pre:req_t s)
+    (post:ens_t s a)
+: Type u#(max a s)
+= s0:s { pre s0 }
+    -> (
+        res:(a & s) {
+            post s0 res._1 res._2 /\
+            rel s0 res._2
+        }
+    )
+
+val return (#s:Type u#s)
+           (#rel:preorder s)
+           (#a:Type u#a)
+           (x:a)
+: pst a rel (fun _ -> True) (fun s0 v s1 -> x == v /\ s0 == s1)           
+
+val bind
+      (#s:Type u#s)
+      (#a:Type u#a)
+      (#b:Type u#b)
+      (#rel:preorder s)
+      (#req_f:req_t s)
+      (#ens_f:ens_t s a)
+      (#req_g:a -> req_t s)
+      (#ens_g:a -> ens_t s b)
+      (f:pst a rel req_f ens_f)
+      (g:(x:a -> pst b rel (req_g x) (ens_g x)))
+: pst b rel
+  (fun s0 -> req_f s0 /\ (forall x s1. ens_f s0 x s1 ==> (req_g x) s1))
+  (fun s0 r s2 -> req_f s0 /\ (exists x s1. ens_f s0 x s1 /\ (req_g x) s1 /\ (ens_g x) s1 r s2))
+    
+val weaken
+      (#s:Type u#s)
+      (#rel:preorder s)
+      (#a:Type u#a)
+      (#req_f:req_t s)
+      (#ens_f:ens_t s a)
+      (#req_g:req_t s)
+      (#ens_g:ens_t s a)
+      (f:pst a rel req_f ens_f)
+    : Pure (pst a rel req_g ens_g)
+      (requires
+        (forall s. req_g s ==> req_f s) /\
+        (forall s0 x s1. (req_g s0 /\ ens_f s0 x s1) ==> ens_g s0 x s1))
+      (ensures fun _ -> True)
+
+val get (#s:Type u#s) (#rel:preorder s) (_:unit)
+  : pst s rel (fun _ -> True) (fun s0 x s1 -> s0 == s1 /\ x == s0)
+
+val put (#s:Type u#s) (#rel:preorder s) (v:s)
+  : pst unit rel  (fun s0 -> rel s0 v /\ True) (fun s0 x s1 -> v == s1)


### PR DESCRIPTION
I'm starting to strengthen the definition of ghost computations so that we rule out improper uses of witness/recall by typing at the lowest levels in PulseCore itself, rather than by relying on abstraction higher up the stack.

Towards this end, the semantics now begins with PulseCore.PreorderStateMonad, a simple, axiom-free state monad, augmented with a two-state invariant that the state evolves according to a given preorder. This monad is not abstract---it's exposed as a reified state-passing function. MonotonicStateMonad *is* abstract and augments PreorderStateMonad with witness/recall.

Actions in heap, memory etc. that do not use invariants or witness recall are defined in PreorderStateMonad.

PulseCore.Action distinguishes two kinds of actions by an index: Reifiable and UsesInvariants, the former being in PreorderStateMonad and the latter in MonotonicStateMonad.

Finally, PulseCore.Atomic defines `stt_ghost` as an erased reifiable actions and `stt_atomic _ #Neutral`  as a reifiable action.

This ensures that in the future we cannot mistakenly add invariant-using actions in ghost or neutral---they must be at least unobservable.