### PR TITLE
Core: remove explicit preconditions for `compatible x x`

### DIFF
--- a/lib/pulse/core/PulseCore.Action.fst
+++ b/lib/pulse/core/PulseCore.Action.fst
@@ -483,7 +483,7 @@ let pts_to_not_null #a #p r v #ictx = pts_to_not_null_action ictx r v
 let alloc
     (#a:Type u#1)
     (#pcm:pcm a)
-    (x:a{compatible pcm x x /\ pcm.refine x})
+    (x:a{pcm.refine x})
 : act (ref a pcm) Reifiable emp_inames emp (fun r -> pts_to r x)
 = fun #ictx -> alloc_action ictx x
 

--- a/lib/pulse/core/PulseCore.Action.fsti
+++ b/lib/pulse/core/PulseCore.Action.fsti
@@ -212,7 +212,7 @@ val pts_to_not_null (#a:Type) (#p:FStar.PCM.pcm a) (r:ref a p) (v:a)
 val alloc
     (#a:Type u#1)
     (#pcm:pcm a)
-    (x:a{compatible pcm x x /\ pcm.refine x})
+    (x:a{pcm.refine x})
 : act (ref a pcm)
       Reifiable
       emp_inames
@@ -342,7 +342,7 @@ val ghost_pts_to (#a:Type u#1) (#p:pcm a) (r:ghost_ref p) (v:a) : slprop
 val ghost_alloc
     (#a:Type u#1)
     (#pcm:pcm a)
-    (x:erased a{compatible pcm x x /\ pcm.refine x})
+    (x:erased a{pcm.refine x})
 : act (ghost_ref pcm) Ghost emp_inames
     emp 
     (fun r -> ghost_pts_to r x)

--- a/lib/pulse/core/PulseCore.Atomic.fsti
+++ b/lib/pulse/core/PulseCore.Atomic.fsti
@@ -266,7 +266,7 @@ val pts_to_not_null
 val alloc
     (#a:Type u#1)
     (#pcm:pcm a)
-    (x:a{compatible pcm x x /\ pcm.refine x})
+    (x:a{pcm.refine x})
 : stt_atomic (ref a pcm)
     #Observable
     emp_inames
@@ -354,7 +354,7 @@ val ghost_pts_to (#a:Type u#1) (#p:pcm a) (r:ghost_ref p) (v:a) : slprop
 val ghost_alloc
     (#a:Type u#1)
     (#pcm:pcm a)
-    (x:erased a{compatible pcm x x /\ pcm.refine x})
+    (x:erased a{pcm.refine x})
 : stt_ghost (ghost_ref pcm)
     emp
     (fun r -> ghost_pts_to r x)

--- a/lib/pulse/core/PulseCore.Heap.fst
+++ b/lib/pulse/core/PulseCore.Heap.fst
@@ -1102,7 +1102,7 @@ let pts_to_not_null_action #a #pcm r v
 let extend_alt
   (#a:Type u#a)
   (#pcm:pcm a)
-  (x:a{compatible pcm x x /\ pcm.refine x})
+  (x:a{pcm.refine x})
   (addr:nat)
 : refined_pre_action #mut_heap #allocs
     #(fun h -> h `free_above_addr` addr)
@@ -1125,6 +1125,7 @@ let extend_alt
     let h' = update_addr_full_heap h addr (Ref a pcm Frac.full_perm x) in
     assert (h' `free_above_addr` (addr + 1));
     assert (h' `contains_addr` addr);
+    PCM.compatible_refl pcm x;
     assert (interp (pts_to r x) h');
     let extend_aux (frame:slprop) (h0 hf:heap)
       : Lemma
@@ -1162,7 +1163,7 @@ let extend_alt
 #pop-options
 
 let extend #a #pcm
-        (x:a{compatible pcm x x /\ pcm.refine x})
+        (x:a{pcm.refine x})
         (addr:nat)
  = refined_pre_action_as_action (extend_alt x addr)
 

--- a/lib/pulse/core/PulseCore.Heap.fsti
+++ b/lib/pulse/core/PulseCore.Heap.fsti
@@ -632,7 +632,7 @@ val pts_to_not_null_action
 val extend
   (#a:Type u#a)
   (#pcm:pcm a)
-  (x:a{compatible pcm x x /\ pcm.refine x})
+  (x:a{pcm.refine x})
   (addr:nat)
   : action
       #mut_heap #allocs

--- a/lib/pulse/core/PulseCore.Heap2.fst
+++ b/lib/pulse/core/PulseCore.Heap2.fst
@@ -666,7 +666,7 @@ let lift_ghost_emp : squash (llift GHOST H.emp == emp) =
 let ghost_extend
     (#a:Type u#a)
     (#pcm:pcm a)
-    (x:erased a{compatible pcm x x /\ pcm.refine x})
+    (x:erased a{pcm.refine x})
     (addr:erased nat)
 = lift_erased #_ #(ni_erased H.core_ref)
     (Ghost.hide <|

--- a/lib/pulse/core/PulseCore.Heap2.fsti
+++ b/lib/pulse/core/PulseCore.Heap2.fsti
@@ -652,7 +652,7 @@ val pts_to_not_null_action
 val extend
   (#a:Type u#a)
   (#pcm:pcm a)
-  (x:a{compatible pcm x x /\ pcm.refine x})
+  (x:a{pcm.refine x})
   (addr:nat)
   : action
       #MUTABLE #(Some CONCRETE)
@@ -750,7 +750,7 @@ val ghost_pts_to (#a:Type u#a) (#p:pcm a) (r:ghost_ref p) (v:a) : slprop u#a
 val ghost_extend
     (#a:Type u#a)
     (#pcm:pcm a)
-    (x:erased a{compatible pcm x x /\ pcm.refine x})
+    (x:erased a{pcm.refine x})
     (addr:erased nat)
 : action #ONLY_GHOST #(Some GHOST)
       #(fun h -> h `free_above_addr GHOST` addr)

--- a/lib/pulse/core/PulseCore.Memory.fsti
+++ b/lib/pulse/core/PulseCore.Memory.fsti
@@ -257,7 +257,7 @@ val gather_action
   (v1:FStar.Ghost.erased a)
   : pst_ghost_action_except (_:unit{composable pcm v0 v1}) e (pts_to r v0 `star` pts_to r v1) (fun _ -> pts_to r (op pcm v0 v1))
 
-val alloc_action (#a:Type u#1) (#pcm:pcm a) (e:inames) (x:a{compatible pcm x x /\ pcm.refine x})
+val alloc_action (#a:Type u#1) (#pcm:pcm a) (e:inames) (x:a{pcm.refine x})
   : pst_action_except (ref a pcm) e emp (fun r -> pts_to r x)
 
 val select_refine (#a:Type u#1) (#p:pcm a)
@@ -432,7 +432,7 @@ val ghost_alloc
     (#o:_)
     (#a:Type u#1)
     (#pcm:pcm a)
-    (x:erased a{compatible pcm x x /\ pcm.refine x})
+    (x:erased a{pcm.refine x})
 : pst_ghost_action_except
     (ghost_ref pcm)
     o

--- a/lib/pulse/lib/Pulse.Lib.Core.fst
+++ b/lib/pulse/lib/Pulse.Lib.Core.fst
@@ -219,7 +219,7 @@ let pts_to_not_null #a #p r v = A.pts_to_not_null #a #p r v
 let alloc
     (#a:Type u#1)
     (#pcm:pcm a)
-    (x:a{compatible pcm x x /\ pcm.refine x})
+    (x:a{pcm.refine x})
 : stt (pcm_ref pcm)
     emp
     (fun r -> pcm_pts_to r x)

--- a/lib/pulse/lib/Pulse.Lib.Core.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Core.fsti
@@ -572,7 +572,7 @@ val pts_to_not_null
 val alloc
     (#a:Type u#1)
     (#pcm:pcm a)
-    (x:a{compatible pcm x x /\ pcm.refine x})
+    (x:a{pcm.refine x})
 : stt (pcm_ref pcm)
     emp
     (fun r -> pcm_pts_to r x)
@@ -640,7 +640,7 @@ val ghost_pcm_pts_to
 val ghost_alloc
     (#a:Type u#1)
     (#pcm:pcm a)
-    (x:erased a{compatible pcm x x /\ pcm.refine x})
+    (x:erased a{pcm.refine x})
 : stt_ghost (ghost_pcm_ref pcm)
     emp
     (fun r -> ghost_pcm_pts_to r x)


### PR DESCRIPTION
This is true by virtue of being in a PCM, where the unit is composable with any x. Remove the preconditions everywhere and call the lemma that proves this as needed.