### PR TITLE
Use HNF to normalize annotated computation types.

### DIFF
--- a/share/pulse/examples/bug-reports/Bug13.fst
+++ b/share/pulse/examples/bug-reports/Bug13.fst
@@ -1,0 +1,8 @@
+module Bug13
+open Pulse.Lib.Pervasives
+
+let effectful_deghost #t (x:erased t) = stt t emp (fun y -> pure (reveal x == y))
+let effectful_all_deghost (t: Type0) = x:erased t -> effectful_deghost #t x
+```pulse
+fn ead_unit () : effectful_all_deghost unit = x { () }
+```

--- a/src/checker/Pulse.Checker.Abs.fst
+++ b/src/checker/Pulse.Checker.Abs.fst
@@ -76,7 +76,7 @@ let rec arrow_of_abs (env:_) (prog:st_term { Tm_Abs? prog.term })
         let c = open_comp_with c (U.term_of_nvar px) in
         match c with
         | C_Tot tannot -> (
-          let tannot' = RU.whnf_lax (elab_env env) (elab_term tannot) in
+          let tannot' = RU.hnf_lax (elab_env env) (elab_term tannot) in
           match Pulse.Readback.readback_ty tannot' with
           | None -> 
             Env.fail 
@@ -290,7 +290,7 @@ let maybe_rewrite_body_typing
         let t, _ = Pulse.Checker.Pure.instantiate_term_implicits g t in
         let (| u, t_typing |) = Pulse.Checker.Pure.check_universe g t in
         match Pulse.Checker.Base.norm_st_typing_inverse
-                 #_ #_ #t' d t t_typing [weak;hnf;delta]
+                 #_ #_ #t' d t t_typing [hnf;delta]
         with
         | None -> 
           Env.fail g (Some e.range) "Inferred type is incompatible with annotation"

--- a/src/checker/Pulse.RuntimeUtils.fsti
+++ b/src/checker/Pulse.RuntimeUtils.fsti
@@ -62,6 +62,7 @@ val map_seal (s:FStar.Sealed.sealed 't) (f: 't -> 'u) : FStar.Sealed.sealed 'u
 val float_one : FStar.Float.float
 val lax_check_term_with_unknown_universes (g:env) (t:T.term) : option T.term
 val whnf_lax (g:env) (t:T.term) : T.term
+val hnf_lax (g:env) (t:T.term) : T.term
 module RT = FStar.Reflection.Typing
 module T = FStar.Tactics.V2
 val norm_well_typed_term

--- a/src/ocaml/plugin/Pulse_RuntimeUtils.ml
+++ b/src/ocaml/plugin/Pulse_RuntimeUtils.ml
@@ -167,6 +167,9 @@ let lax_check_term_with_unknown_universes (g:TcEnv.env) (e:S.term)
 let whnf_lax (g:TcEnv.env) (t:S.term) : S.term = 
   FStar_TypeChecker_Normalize.unfold_whnf' [TcEnv.Unascribe] g t
 
+let hnf_lax (g:TcEnv.env) (t:S.term) : S.term =
+  FStar_TypeChecker_Normalize.normalize [TcEnv.Unascribe; TcEnv.Primops; TcEnv.HNF; TcEnv.UnfoldUntil S.delta_constant; TcEnv.Beta] g t
+
 let norm_well_typed_term_aux
       (g:TcEnv.env)
       (t:S.term)

--- a/src/ocaml/plugin/generated/Pulse_Checker_Abs.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Abs.ml
@@ -359,7 +359,7 @@ let rec (arrow_of_abs :
                                                                     (Prims.of_int (79))
                                                                     (Prims.of_int (24))
                                                                     (Prims.of_int (79))
-                                                                    (Prims.of_int (69)))))
+                                                                    (Prims.of_int (68)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -371,7 +371,7 @@ let rec (arrow_of_abs :
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___2 ->
-                                                                    Pulse_RuntimeUtils.whnf_lax
+                                                                    Pulse_RuntimeUtils.hnf_lax
                                                                     (Pulse_Typing.elab_env
                                                                     env1)
                                                                     (Pulse_Elaborate_Pure.elab_term
@@ -2722,7 +2722,7 @@ let (maybe_rewrite_body_typing :
                                                                     (Prims.of_int (292))
                                                                     (Prims.of_int (14))
                                                                     (Prims.of_int (293))
-                                                                    (Prims.of_int (56)))))
+                                                                    (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -2735,8 +2735,7 @@ let (maybe_rewrite_body_typing :
                                                                     (Pulse_Checker_Base.norm_st_typing_inverse
                                                                     g e t' d
                                                                     u t1 ()
-                                                                    [FStar_Pervasives.weak;
-                                                                    FStar_Pervasives.hnf;
+                                                                    [FStar_Pervasives.hnf;
                                                                     FStar_Pervasives.delta]))
                                                                     (fun
                                                                     uu___3 ->


### PR DESCRIPTION
Fixes #13.