### PR TITLE
Bump rlimit.

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.HashTable.Spec.fst
+++ b/lib/pulse/lib/Pulse.Lib.HashTable.Spec.fst
@@ -731,7 +731,7 @@ let upd_pht (#kt:eqtype) (#vt:Type) (pht:pht_t kt vt) idx (k:kt) (v:vt)
              repr = repr';
              inv = () }
 
-#push-options "--z3rlimit_factor 2"
+#push-options "--z3rlimit_factor 3"
 let eliminate_strong_all_used_not_by #kt #vt (r:repr_t kt vt) (k:kt) (i:nat{i < r.sz})
   : Lemma 
     (requires strong_all_used_not_by r (canonical_index k r) r.sz k)


### PR DESCRIPTION
I'm not sure what's different about Z3 on my machine, but verifying `Pulse.Lib.HashTable.Spec.fst` failed on the command-line for me.  (Weirdly enough, it worked fine in vscode.)