### PR TITLE
Trying to remove fractional permission from the cells in PulseCore heap

### DIFF
--- a/lib/pulse/core/PulseCore.Heap.fsti
+++ b/lib/pulse/core/PulseCore.Heap.fsti
@@ -39,8 +39,7 @@ noeq
 type cell : Type u#(a + 1) =
   | Ref : a:Type u#a ->
           p:pcm a ->
-          frac:Frac.perm{ frac `Frac.lesser_equal_perm` Frac.full_perm } ->
-          v:a { frac == Frac.full_perm ==> p.refine v } ->
+          v:a ->
           cell
 
 (**
@@ -568,7 +567,7 @@ val interp_pts_to (i:core_ref)
     match select (core_ref_as_addr i) h0 with
     | None -> False
     | Some c ->
-      let Ref a' pcm' _ v' = c in
+      let Ref a' pcm' v' = c in
       a == a' /\
       pcm == pcm' /\
       compatible pcm v v')))
@@ -694,7 +693,7 @@ val extend_modifies_nothing
 : Lemma (
       let (| r, h1 |) = extend #a #pcm x addr h in
       (forall (a:nat). a <> addr ==> select a h == select a h1) /\
-      select addr h1 == Some (Ref a pcm Frac.full_perm x) /\
+      select addr h1 == Some (Ref a pcm x) /\
       not (core_ref_is_null r) /\
       addr == core_ref_as_addr r
   )

--- a/lib/pulse/core/PulseCore.Memory.fst
+++ b/lib/pulse/core/PulseCore.Memory.fst
@@ -686,12 +686,12 @@ let sl_pure_imp (p:prop) (q: squash p -> slprop) : slprop =
   as_slprop (fun (h:iheap) -> p ==> q () h)
 
 let cell_pred_pre (c:H0.cell) =
-  let H0.Ref a pcm _ _ = c in
+  let H0.Ref a pcm _ = c in
   a == PA.agreement H2.slprop /\
   pcm == PA.pcm_agreement #H2.slprop
 
 let cell_pred_post (c:H0.cell) (_:squash (cell_pred_pre c)) =
-  let H0.Ref _ _ _ v = c in
+  let H0.Ref _ _ v = c in
   let v : PA.agreement H2.slprop = v in
   match v with
   | None -> emp
@@ -767,7 +767,7 @@ let iname_for_p (i:iname) (p:slprop) (m:istore) =
   match H0.select i m with
   | None -> False
   | Some cell ->
-    let H0.Ref a pcm _ v = cell in
+    let H0.Ref a pcm v = cell in
     a == PA.agreement H2.slprop /\
     pcm == PA.pcm_agreement #H2.slprop /\ (
     let v : PA.agreement H2.slprop = cell.v in
@@ -1125,7 +1125,7 @@ let invariant_of_one_cell_is_big (from:nat) (e:inames) (i:istore)
        | Some c ->
          introduce cell_pred_pre c ==> is_big (cell_pred_post c ())
          with _ . (
-            let H0.Ref _ _ _ v = c in
+            let H0.Ref _ _ v = c in
             let v : PA.agreement H2.slprop = v in
             match v with
             | None -> ()


### PR DESCRIPTION
The PR tries to remove fractional permissions from the PulseCore heap cells. Instead it defines a cell being full as the cell value satisfying the pcm refine predicate.

This turned out to be a purely internal change, as in we can provide the same interface as before.