### PR TITLE
SpinLock: prove (a version of) the injectivity lemma

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.SpinLock.fst
+++ b/lib/pulse/lib/Pulse.Lib.SpinLock.fst
@@ -231,3 +231,27 @@ fn free_aux (#v:vprop) (l:lock)
 ```
 
 let free = free_aux
+
+```pulse
+ghost
+fn __lock_alive_inj
+  (l:lock) (#p1 #p2 :perm) (#v1 #v2 :vprop)
+  requires lock_alive l #p1 v1 ** lock_alive l #p2 v2
+  ensures  lock_alive l #p1 v1 ** lock_alive l #p2 v1
+{
+  unfold (lock_alive l #p1 v1);
+  unfold (lock_alive l #p2 v2);
+  invariant_name_identifies_invariant
+    (iref_of l.i) (iref_of l.i);
+  assert (
+    pure (
+      cinv_vp l.i (lock_inv l.r l.gr v1)
+      ==
+      cinv_vp l.i (lock_inv l.r l.gr v2)
+    )
+  );
+  fold (lock_alive l #p1 v1);
+  fold (lock_alive l #p2 v1);
+}
+```
+let lock_alive_inj = __lock_alive_inj

--- a/lib/pulse/lib/Pulse.Lib.SpinLock.fsti
+++ b/lib/pulse/lib/Pulse.Lib.SpinLock.fsti
@@ -51,3 +51,10 @@ val gather2 (#v:vprop) (#p : perm) (l:lock)
 
 val free (#v:vprop) (l:lock)
   : stt unit (lock_alive l #full_perm v ** lock_acquired l) (fun _ -> emp)
+
+(* A given lock is associated to a single vprop, roughly.
+I'm not sure if we can prove v1 == v2 here. *)
+val lock_alive_inj (l:lock) (#p1 #p2 : perm) (#v1 #v2 : vprop)
+  : stt_ghost unit emp_inames
+              (lock_alive l #p1 v1 ** lock_alive l #p2 v2)
+              (fun _ -> lock_alive l #p1 v1 ** lock_alive l #p2 v1)


### PR DESCRIPTION
This proves that, if we have

    lock_alive l #f1 v1 ** lock_alive l #f2 v2

then we can convert the second one to match the resource of the first, i.e.

    lock_alive l #f1 v1 ** lock_alive l #f2 v1

Ideally we would get `v1==v2`, but I am not sure if that's provable. At least, it would require to bubble up some equalities from the model, including (I think) that if `(exists* x. f1 x) == (exists* x. f2 x)`, then `forall x. f1 x == f2 x`.