### PR TITLE
library: rename Pulse.Lib.Par.Pledge.* into Pulse.Lib.Pledge.*

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.Task.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Task.fsti
@@ -17,7 +17,7 @@
 module Pulse.Lib.Task
 
 open Pulse.Lib.Pervasives
-open Pulse.Lib.Par.Pledge
+open Pulse.Lib.Pledge
 module T = FStar.Tactics
 
 val pool : Type0

--- a/lib/pulse/lib/pledge/Pulse.Lib.Pledge.Simple.fst
+++ b/lib/pulse/lib/pledge/Pulse.Lib.Pledge.Simple.fst
@@ -14,11 +14,11 @@
    limitations under the License.
 *)
 
-module Pulse.Lib.Par.Pledge.Simple
+module Pulse.Lib.Pledge.Simple
 
 open Pulse.Lib.Pervasives
 
-module P = Pulse.Lib.Par.Pledge
+module P = Pulse.Lib.Pledge
 
 let pledge (f:vprop) (v:vprop) : vprop =
   exists* is. P.pledge is f v

--- a/lib/pulse/lib/pledge/Pulse.Lib.Pledge.Simple.fsti
+++ b/lib/pulse/lib/pledge/Pulse.Lib.Pledge.Simple.fsti
@@ -14,7 +14,7 @@
    limitations under the License.
 *)
 
-module Pulse.Lib.Par.Pledge.Simple
+module Pulse.Lib.Pledge.Simple
 
 open Pulse.Lib.Pervasives
 
@@ -62,7 +62,7 @@ val join_pledge (#f v1 v2:vprop)
       (fun _ -> pledge f (v1 ** v2))
 
 //
-// See Pulse.Lib.Par.Pledge.fst
+// See Pulse.Lib.Pledge.fst
 // This requires pledges to be boxable,
 //
 // val split_pledge (#f:vprop) (v1:vprop) (v2:vprop)

--- a/lib/pulse/lib/pledge/Pulse.Lib.Pledge.fst
+++ b/lib/pulse/lib/pledge/Pulse.Lib.Pledge.fst
@@ -14,7 +14,7 @@
    limitations under the License.
 *)
 
-module Pulse.Lib.Par.Pledge
+module Pulse.Lib.Pledge
 
 open Pulse.Lib.Pervasives
 open Pulse.Lib.Trade

--- a/lib/pulse/lib/pledge/Pulse.Lib.Pledge.fsti
+++ b/lib/pulse/lib/pledge/Pulse.Lib.Pledge.fsti
@@ -14,7 +14,7 @@
    limitations under the License.
 *)
 
-module Pulse.Lib.Par.Pledge
+module Pulse.Lib.Pledge
 
 open Pulse.Lib.Pervasives
 open Pulse.Lib.InvList

--- a/share/pulse/examples/PledgeArith.fst
+++ b/share/pulse/examples/PledgeArith.fst
@@ -21,7 +21,7 @@ module PledgeArith
 open Pulse.Lib.Pervasives
 open Pulse.Lib.InvList
 module T = Pulse.Lib.Task
-open Pulse.Lib.Par.Pledge
+open Pulse.Lib.Pledge
 
 ```pulse
 ghost

--- a/share/pulse/examples/Quicksort.Task.fst
+++ b/share/pulse/examples/Quicksort.Task.fst
@@ -25,7 +25,7 @@ open Pulse.Lib.InvList
 
 module T = Pulse.Lib.Task
 open Quicksort.Base
-open Pulse.Lib.Par.Pledge
+open Pulse.Lib.Pledge
 
 let quicksort_post a lo hi s0 lb rb : vprop =
   exists* s. (A.pts_to_range a lo hi s ** pure (pure_post_quicksort a lo hi lb rb s0 s))

--- a/share/pulse/examples/parix/Async.fst
+++ b/share/pulse/examples/parix/Async.fst
@@ -17,7 +17,7 @@
 module Async
 
 open Pulse.Lib.Pervasives
-open Pulse.Lib.Par.Pledge
+open Pulse.Lib.Pledge
 open UnixFork
 
 (* Pulse will currently not recognize calls to anything other than

--- a/share/pulse/examples/parix/ParallelFor.fst
+++ b/share/pulse/examples/parix/ParallelFor.fst
@@ -20,10 +20,10 @@ open Pulse.Lib.Pervasives
 open Pulse.Lib.Fixpoints
 open Pulse.Lib.Task
 open FStar.Real
-open Pulse.Lib.Par.Pledge
+open Pulse.Lib.Pledge
 open Pulse.Lib.InvList
 
-module P = Pulse.Lib.Par.Pledge
+module P = Pulse.Lib.Pledge
 
 ```pulse
 ghost
@@ -42,7 +42,7 @@ fn squash_pledge (f v : vprop)
   requires pledge emp_inames f (pledge emp_inames f v)
   ensures pledge emp_inames f v
 {
-  Pulse.Lib.Par.Pledge.squash_pledge emp_inames f v
+  Pulse.Lib.Pledge.squash_pledge emp_inames f v
 }
 ```
 

--- a/share/pulse/examples/parix/Promises.Examples3.fst
+++ b/share/pulse/examples/parix/Promises.Examples3.fst
@@ -17,7 +17,7 @@
 module Promises.Examples3
 
 open Pulse.Lib.Pervasives
-open Pulse.Lib.Par.Pledge
+open Pulse.Lib.Pledge
 open Pulse.Lib.InvList
 module GR = Pulse.Lib.GhostReference
 

--- a/share/pulse/examples/parix/TaskPool.Examples.fst
+++ b/share/pulse/examples/parix/TaskPool.Examples.fst
@@ -17,7 +17,7 @@
 module TaskPool.Examples
 
 open Pulse.Lib.Pervasives
-open Pulse.Lib.Par.Pledge
+open Pulse.Lib.Pledge
 open Pulse.Lib.Task
 
 assume

--- a/share/pulse/examples/parix/UnixFork.fsti
+++ b/share/pulse/examples/parix/UnixFork.fsti
@@ -19,7 +19,7 @@ module UnixFork
 (* This module assumes an unstructured unix-style fork *)
 
 open Pulse.Lib.Pervasives
-open Pulse.Lib.Par.Pledge
+open Pulse.Lib.Pledge
 
 new
 val thread : Type0


### PR DESCRIPTION
No need for this Par namespace component