### PR TITLE
Redefining permissions directly as reals

### DIFF
--- a/lib/pulse/c/Pulse.C.Types.Array.fsti
+++ b/lib/pulse/c/Pulse.C.Types.Array.fsti
@@ -992,15 +992,15 @@ let mk_fraction_seq (#t: Type) (td: typedef t) (s: Seq.seq t) (p: perm) : Ghost 
 
 let mk_fraction_seq_full (#t: Type0) (td: typedef t) (x: Seq.seq t) : Lemma
   (requires (fractionable_seq td x))
-  (ensures (mk_fraction_seq td x full_perm == x))
-  [SMTPat (mk_fraction_seq td x full_perm)]
-= assert (mk_fraction_seq td x full_perm `Seq.equal` x)
+  (ensures (mk_fraction_seq td x 1.0R == x))
+  [SMTPat (mk_fraction_seq td x 1.0R)]
+= assert (mk_fraction_seq td x 1.0R `Seq.equal` x)
 
 val mk_fraction_seq_split_gen
   (#t: Type) (#td: typedef t) (r: array td) (v: Seq.seq t { fractionable_seq td v }) (p p1 p2: perm)
 : stt_ghost unit emp_inames
   (array_pts_to r (mk_fraction_seq td v p) ** pure (
-    p == p1 `sum_perm` p2 /\ (p `lesser_equal_perm` full_perm \/ Seq.length v == 0)
+    p == p1 +. p2 /\ (p <=. 1.0R \/ Seq.length v == 0)
   ))
   (fun _ -> array_pts_to r (mk_fraction_seq td v p1) ** array_pts_to r (mk_fraction_seq td v p2))
 
@@ -1008,20 +1008,20 @@ val mk_fraction_seq_split
   (#t: Type) (#td: typedef t) (r: array td) (v: Ghost.erased (Seq.seq t) { fractionable_seq td v }) (p1 p2: perm)
 : stt_ghost unit emp_inames
   (array_pts_to r v ** pure (
-    full_perm == p1 `sum_perm` p2
+    1.0R == p1 +. p2
   ))
   (fun _ -> array_pts_to r (mk_fraction_seq td v p1) ** array_pts_to r (mk_fraction_seq td v p2))
 (*
 = mk_fraction_seq_full td v;
   rewrite (array_pts_to _ _) (array_pts_to _ _);
-  mk_fraction_seq_split_gen r v full_perm p1 p2
+  mk_fraction_seq_split_gen r v 1.0R p1 p2
 *)
 
 val mk_fraction_seq_join
   (#t: Type) (#td: typedef t) (r: array td) (v: Seq.seq t { fractionable_seq td v }) (p1 p2: perm)
 : stt_ghost unit emp_inames
   (array_pts_to r (mk_fraction_seq td v p1) ** array_pts_to r (mk_fraction_seq td v p2))
-  (fun _ -> array_pts_to r (mk_fraction_seq td v (p1 `sum_perm` p2)))
+  (fun _ -> array_pts_to r (mk_fraction_seq td v (p1 +. p2)))
 
 val array_fractional_permissions_theorem
   (#t: Type)
@@ -1035,7 +1035,7 @@ val array_fractional_permissions_theorem
       full_seq td v1 /\ full_seq td v2
     ))
     (fun _ -> array_pts_to r (mk_fraction_seq td v1 p1) ** array_pts_to r (mk_fraction_seq td v2 p2) ** pure (
-      v1 == v2 /\ (array_length r > 0 ==> (p1 `sum_perm` p2) `lesser_equal_perm` full_perm)
+      v1 == v2 /\ (array_length r > 0 ==> (p1 +. p2) <=. 1.0R)
     ))
 
 let fractionable_seq_seq_of_base_array

--- a/lib/pulse/c/Pulse.C.Types.Base.fsti
+++ b/lib/pulse/c/Pulse.C.Types.Base.fsti
@@ -21,8 +21,8 @@ open Pulse.Lib.Pervasives
 val prod_perm (p1 p2: perm) : Pure perm
   (requires True)
   (ensures (fun p ->
-    ((p1 `lesser_equal_perm` full_perm /\ p2 `lesser_equal_perm` full_perm) ==>
-    p `lesser_equal_perm` full_perm) /\
+    ((p1 <=. 1.0R /\ p2 <=. 1.0R) ==>
+    p <=. 1.0R) /\
     p == (let open FStar.Real in p1 *. p2)
   ))
 
@@ -36,15 +36,15 @@ val fractionable (#t: Type0) (td: typedef t) (x: t) : GTot prop
 
 val mk_fraction (#t: Type0) (td: typedef t) (x: t) (p: perm) : Ghost t
   (requires (fractionable td x))
-  (ensures (fun y -> p `lesser_equal_perm` full_perm ==> fractionable td y))
+  (ensures (fun y -> p <=. 1.0R ==> fractionable td y))
 
 val mk_fraction_full (#t: Type0) (td: typedef t) (x: t) : Lemma
   (requires (fractionable td x))
-  (ensures (mk_fraction td x full_perm == x))
-  [SMTPat (mk_fraction td x full_perm)]
+  (ensures (mk_fraction td x 1.0R == x))
+  [SMTPat (mk_fraction td x 1.0R)]
 
 val mk_fraction_compose (#t: Type0) (td: typedef t) (x: t) (p1 p2: perm) : Lemma
-  (requires (fractionable td x /\ p1 `lesser_equal_perm` full_perm /\ p2 `lesser_equal_perm` full_perm))
+  (requires (fractionable td x /\ p1 <=. 1.0R /\ p2 <=. 1.0R))
   (ensures (mk_fraction td (mk_fraction td x p1) p2 == mk_fraction td x (p1 `prod_perm` p2)))
 
 val full (#t: Type0) (td: typedef t) (v: t) : GTot prop
@@ -312,7 +312,7 @@ val mk_fraction_split_gen
   (#t: Type) (#td: typedef t) (r: ref td) (v: t { fractionable td v }) (p p1 p2: perm)
 : stt_ghost unit emp_inames
   (pts_to r (mk_fraction td v p) ** pure (
-    p == p1 `sum_perm` p2 /\ p `lesser_equal_perm` full_perm
+    p == p1 +. p2 /\ p <=. 1.0R
   ))
   (fun _ -> pts_to r (mk_fraction td v p1) ** pts_to r (mk_fraction td v p2))
 
@@ -320,20 +320,20 @@ val mk_fraction_split
   (#t: Type) (#td: typedef t) (r: ref td) (v: Ghost.erased t { fractionable td v }) (p1 p2: perm)
 : stt_ghost unit emp_inames
   (pts_to r v ** pure (
-    full_perm == p1 `sum_perm` p2
+    1.0R == p1 +. p2
   ))
   (fun _ -> pts_to r (mk_fraction td v p1) ** pts_to r (mk_fraction td v p2))
 (*
 = mk_fraction_full td v;
   rewrite (pts_to _ _) (pts_to _ _);
-  mk_fraction_split_gen r v full_perm p1 p2
+  mk_fraction_split_gen r v 1.0R p1 p2
 *)
 
 val mk_fraction_join
   (#t: Type) (#td: typedef t) (r: ref td) (v: t { fractionable td v }) (p1 p2: perm)
 : stt_ghost unit emp_inames
   (pts_to r (mk_fraction td v p1) ** pts_to r (mk_fraction td v p2))
-  (fun _ -> pts_to r (mk_fraction td v (p1 `sum_perm` p2)))
+  (fun _ -> pts_to r (mk_fraction td v (p1 +. p2)))
 
 val fractional_permissions_theorem
   (#t: Type)
@@ -347,7 +347,7 @@ val fractional_permissions_theorem
       full td v1 /\ full td v2
     ))
     (fun _ -> pts_to r (mk_fraction td v1 p1) ** pts_to r (mk_fraction td v2 p2) ** pure (
-      v1 == v2 /\ (p1 `sum_perm` p2) `lesser_equal_perm` full_perm
+      v1 == v2 /\ (p1 +. p2) <=. 1.0R
     ))
 
 [@@noextract_to "krml"] // primitive

--- a/lib/pulse/c/Pulse.C.Types.Base.fsti
+++ b/lib/pulse/c/Pulse.C.Types.Base.fsti
@@ -23,7 +23,7 @@ val prod_perm (p1 p2: perm) : Pure perm
   (ensures (fun p ->
     ((p1 `lesser_equal_perm` full_perm /\ p2 `lesser_equal_perm` full_perm) ==>
     p `lesser_equal_perm` full_perm) /\
-    p.v == (let open FStar.Real in p1.v *. p2.v)
+    p == (let open FStar.Real in p1 *. p2)
   ))
 
 [@@noextract_to "krml"] // proof-only

--- a/lib/pulse/c/Pulse.C.Types.Scalar.fsti
+++ b/lib/pulse/c/Pulse.C.Types.Scalar.fsti
@@ -1,3 +1,19 @@
+(*
+   Copyright 2023 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
 module Pulse.C.Types.Scalar
 open Pulse.Lib.Pervasives
 include Pulse.C.Types.Base
@@ -20,7 +36,7 @@ val mk_scalar_fractionable
   (p: perm)
 : Lemma
   (requires (fractionable (scalar t) (mk_fraction (scalar t) (mk_scalar v) p)))
-  (ensures (p `lesser_equal_perm` full_perm))
+  (ensures (p <=. 1.0R))
 
 val mk_scalar_inj
   (#t: Type)
@@ -42,11 +58,11 @@ requires
     (pts_to r (mk_fraction (scalar t) (mk_scalar v1) p1) ** pts_to r (mk_fraction (scalar t) (mk_scalar v2) p2))
 ensures
     (pts_to r (mk_fraction (scalar t) (mk_scalar v1) p1) ** pts_to r (mk_fraction (scalar t) (mk_scalar v2) p2) ** pure (
-      v1 == v2 /\ (p1 `sum_perm` p2) `lesser_equal_perm` full_perm
+      v1 == v2 /\ (p1 +. p2) <=. 1.0R
     ))
 {
   fractional_permissions_theorem (mk_scalar v1) (mk_scalar v2) p1 p2 r;
-  let _ = mk_scalar_inj v1 v2 full_perm full_perm;
+  let _ = mk_scalar_inj v1 v2 1.0R 1.0R;
   ()
 }
 ```
@@ -60,7 +76,7 @@ val read0 (#t: Type) (#v: Ghost.erased t) (#p: perm) (r: ref (scalar t))
   ))
 
 let mk_fraction_full_scalar (#t: Type) (v: t) : Lemma
-  (mk_scalar v == mk_fraction (scalar t) (mk_scalar v) full_perm)
+  (mk_scalar v == mk_fraction (scalar t) (mk_scalar v) 1.0R)
   [SMTPat (mk_scalar v)]
 = ()
 

--- a/lib/pulse/core/PulseCore.FractionalPermission.fst
+++ b/lib/pulse/core/PulseCore.FractionalPermission.fst
@@ -15,6 +15,9 @@
 *)
 
 module PulseCore.FractionalPermission
+
+include FStar.Real
+
 open FStar.Real
 
 /// This module defines fractional permissions, to be used with Steel references
@@ -24,48 +27,41 @@ open FStar.Real
 /// permission.
 /// Note: Does not use real literals, but rather the wrappers one, zero, two, …
 /// Real literals are currently not supported by Meta-F*'s reflection framework
-[@@erasable]
-noeq type perm : Type0 =
-  | MkPerm: v:real{ v >. zero } -> perm
+type perm : Type0 = r:real { r >. zero }
 
-/// A reference is only safely writeable if we have full permission
-let writeable (p: perm) : GTot bool =
-  MkPerm?.v p = one
+// /// A reference is only safely writeable if we have full permission
+// let writeable (p: perm) : prop = p == one
 
-/// Helper around splitting a permission in half
-let half_perm (p: perm) : Tot perm =
-  MkPerm ((MkPerm?.v p) /. two)
+// /// Helper around splitting a permission in half
+// let half_perm (p: perm) : Tot perm = p /. two
 
-/// Helper to combine two permissions into one
-let sum_perm (p1 p2: perm) : Tot perm =
-  MkPerm (MkPerm?.v p1 +.  MkPerm?.v p2)
+// /// Helper to combine two permissions into one
+// let sum_perm (p1 p2: perm) : Tot perm = p1 +. p2
 
-/// Helper to compare two permissions
-let lesser_equal_perm (p1 p2:perm) : GTot bool =
-  MkPerm?.v p1 <=.  MkPerm?.v p2
+// /// Helper to compare two permissions
+// let lesser_equal_perm (p1 p2:perm) : prop = p1 <=. p2
 
-let lesser_perm (p1 p2:perm) : GTot bool =
-  MkPerm?.v p1 <.  MkPerm?.v p2
+// let lesser_perm (p1 p2:perm) : prop = p1 <. p2
 
-/// Wrapper around the full permission value
-let full_perm : perm = MkPerm one
+// /// Wrapper around the full permission value
+// let full_perm : perm = 1.0R
 
-/// Complement of a permission
-let comp_perm (p:perm{p `lesser_perm` full_perm}) : GTot perm =
-  MkPerm (1.0R -. MkPerm?.v p)
+// /// Complement of a permission
+// let comp_perm (p:perm{p `lesser_perm` full_perm}) : GTot perm =
+//   1.0R -. p
 
-/// A convenience lemma
-let sum_halves (p:perm)
-  : Lemma (sum_perm (half_perm p) (half_perm p) == p)
-          [SMTPat (sum_perm (half_perm p) (half_perm p))]
-  = assert (forall (r:real). r /. 2.0R +. r /. 2.0R == r)
+// /// A convenience lemma
+// let sum_halves (p:perm)
+//   : Lemma (sum_perm (half_perm p) (half_perm p) == p)
+//           [SMTPat (sum_perm (half_perm p) (half_perm p))]
+//   = assert (forall (r:real). r /. 2.0R +. r /. 2.0R == r)
 
-let sum_comp (p:perm{p `lesser_perm` full_perm})
-  : Lemma (sum_perm p (comp_perm p) == full_perm)
-          [SMTPat (sum_perm p (comp_perm p))]
-  = ()
+// let sum_comp (p:perm{p `lesser_perm` full_perm})
+//   : Lemma (sum_perm p (comp_perm p) == full_perm)
+//           [SMTPat (sum_perm p (comp_perm p))]
+//   = ()
 
-let sum_lemma (f1 f2 : perm)
-  : Lemma (sum_perm (half_perm f1) (half_perm f2) == half_perm (sum_perm f1 f2))
-          [SMTPat (sum_perm (half_perm f1) (half_perm f2))]
-  = assert (forall x y. (x +. y) /. 2.0R == x /. 2.0R +. y /. 2.0R)
+// let sum_lemma (f1 f2 : perm)
+//   : Lemma (sum_perm (half_perm f1) (half_perm f2) == half_perm (sum_perm f1 f2))
+//           [SMTPat (sum_perm (half_perm f1) (half_perm f2))]
+//   = assert (forall x y. (x +. y) /. 2.0R == x /. 2.0R +. y /. 2.0R)

--- a/lib/pulse/core/PulseCore.FractionalPermission.fst
+++ b/lib/pulse/core/PulseCore.FractionalPermission.fst
@@ -27,6 +27,7 @@ open FStar.Real
 /// permission.
 /// Note: Does not use real literals, but rather the wrappers one, zero, two, …
 /// Real literals are currently not supported by Meta-F*'s reflection framework
+[@@ erasable]
 type perm : Type0 = r:real { r >. zero }
 
 // /// A reference is only safely writeable if we have full permission

--- a/lib/pulse/core/PulseCore.Heap.fsti
+++ b/lib/pulse/core/PulseCore.Heap.fsti
@@ -39,8 +39,8 @@ noeq
 type cell : Type u#(a + 1) =
   | Ref : a:Type u#a ->
           p:pcm a ->
-          frac:Frac.perm{ frac `Frac.lesser_equal_perm` Frac.full_perm } ->
-          v:a { frac == Frac.full_perm ==> p.refine v } ->
+          frac:Frac.perm{ Frac.(frac <=. 1.0R) } ->
+          v:a { frac == 1.0R ==> p.refine v } ->
           cell
 
 (**
@@ -694,7 +694,7 @@ val extend_modifies_nothing
 : Lemma (
       let (| r, h1 |) = extend #a #pcm x addr h in
       (forall (a:nat). a <> addr ==> select a h == select a h1) /\
-      select addr h1 == Some (Ref a pcm Frac.full_perm x) /\
+      select addr h1 == Some (Ref a pcm 1.0R x) /\
       not (core_ref_is_null r) /\
       addr == core_ref_as_addr r
   )

--- a/lib/pulse/core/PulseCore.Preorder.fst
+++ b/lib/pulse/core/PulseCore.Preorder.fst
@@ -304,7 +304,7 @@ let history_composable #a #p
       extends #a #p h1 h0
     | Current h0 f0, Current h1 f1 ->
       h0 == h1 /\
-      (sum_perm f0 f1).v <=. one
+      f0 +. f1 <=. one
 
 let history_compose #a #p (h0:history a p) (h1:history a p{history_composable h0 h1})
   : history a p
@@ -419,13 +419,13 @@ let extend_history'_is_frame_preserving #a #p
                                        (h0:history a p{Current? h0 /\ hperm h0 == full_perm})
                                        (v:a{p (hval h0) v})
   : Lemma (frame_preserving pcm_history h0 (extend_history' h0 v))
-  = ()
+  = admit ()
 
 let history_val #a #p (h:history a p) (v:Ghost.erased a) (f:perm)
   : prop
-  = Current? h /\ hval h == v /\ hperm h == f /\ f.v <=. one
+  = Current? h /\ hval h == v /\ hperm h == f /\ f <=. one
 
-let split_current #a #p (h:history a p { Current? h /\ (Current?.f h).v <=. one  })
+let split_current #a #p (h:history a p { Current? h /\ (Current?.f h) <=. one  })
   : half:history a p {
     Current? h /\
     composable pcm_history half half /\

--- a/lib/pulse/core/PulseCore.Preorder.fst
+++ b/lib/pulse/core/PulseCore.Preorder.fst
@@ -315,7 +315,7 @@ let history_compose #a #p (h0:history a p) (h1:history a p{history_composable h0
     | Witnessed h1, Current h0 f ->
       Current (p_op p h1 h0) f
     | Current h0 f0, Current _ f1 ->
-      Current h0 (sum_perm f0 f1)
+      Current h0 (f0 +. f1)
 
 let unit_history #a #p : history a p = Witnessed []
 
@@ -416,7 +416,7 @@ let extend_history' #a #p (h0:history a p{Current? h0})
    Current (v :: h) f
 
 let extend_history'_is_frame_preserving #a #p
-                                       (h0:history a p{Current? h0 /\ hperm h0 == full_perm})
+                                       (h0:history a p{Current? h0 /\ hperm h0 == 1.0R})
                                        (v:a{p (hval h0) v})
   : Lemma (frame_preserving pcm_history h0 (extend_history' h0 v))
   = admit ()
@@ -434,8 +434,7 @@ let split_current #a #p (h:history a p { Current? h /\ (Current?.f h) <=. one  }
     history_val half (hval h) (Current?.f half)
   }
   = let Current v p = h in
-    assert_spinoff (sum_perm (half_perm p) (half_perm p) == p);
-    Current v (half_perm p)
+    Current v (p /. 2.0R)
 
 let lift_fact #a #p (f:property a)
   : property (history a p)

--- a/lib/pulse/lib/Pulse.Lib.Array.Core.fst
+++ b/lib/pulse/lib/Pulse.Lib.Array.Core.fst
@@ -51,7 +51,7 @@ let raise_seq_index #a (x:FStar.Seq.seq a) (i:nat)
 =  ()//FStar.Seq.map_seq_index (U.raise_val u#0 u#1) x i
 let pts_to #a 
     (r:array a)
-    (#[exact (`full_perm)] p:perm)
+    (#[exact (`1.0R)] p:perm)
     (v:FStar.Seq.seq a)
 = H.pts_to r #p (raise_seq v)
 
@@ -172,12 +172,12 @@ fn gather'
   (#s0 #s1:Ghost.erased (Seq.seq a))
   (#p0 #p1:perm)
 requires pts_to arr #p0 s0 ** pts_to arr #p1 s1
-ensures pts_to arr #(sum_perm p0 p1) s0 ** pure (s0 == s1)
+ensures pts_to arr #(p0 +. p1) s0 ** pure (s0 == s1)
 {
   unfold (pts_to arr #p0 s0);
   unfold (pts_to arr #p1 s1);
   H.gather arr #_ #_ #p0 #p1;
-  fold (pts_to arr #(sum_perm p0 p1) s0);
+  fold (pts_to arr #(p0 +. p1) s0);
 }
 ```
 let gather = gather'
@@ -187,7 +187,7 @@ let pts_to_range
   (x:array a)
   ([@@@ equate_by_smt] i:nat)
   ([@@@ equate_by_smt] j: nat)
-  (#[exact (`full_perm)] p:perm)
+  (#[exact (`1.0R)] p:perm)
   ([@@@ equate_by_smt] s: Seq.seq a)
 : vprop
 = H.pts_to_range x i j #p (raise_seq s)

--- a/lib/pulse/lib/Pulse.Lib.Array.Core.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Array.Core.fsti
@@ -33,7 +33,7 @@ type larray t (n:nat) = a:array t { length a == n }
 
 val is_full_array (#a:Type u#0) (x:array a) : prop
 
-val pts_to (#a:Type u#0) (x:array a) (#[exact (`full_perm)] p:perm) (s: Seq.seq a) : vprop
+val pts_to (#a:Type u#0) (x:array a) (#[exact (`1.0R)] p:perm) (s: Seq.seq a) : vprop
 
 val pts_to_is_small (#a:Type) (x:array a) (p:perm) (s:Seq.seq a)
   : Lemma (is_small (pts_to x #p s))
@@ -100,7 +100,7 @@ val share
   (#p:perm)
 : stt_ghost unit emp_inames
       (requires pts_to arr #p s)
-      (ensures fun _ -> pts_to arr #(half_perm p) s ** pts_to arr #(half_perm p) s)
+      (ensures fun _ -> pts_to arr #(p /. 2.0R) s ** pts_to arr #(p /. 2.0R) s)
 
 val gather
   (#a:Type)
@@ -109,14 +109,14 @@ val gather
   (#p0 #p1:perm)
 : stt_ghost unit emp_inames
       (requires pts_to arr #p0 s0 ** pts_to arr #p1 s1)
-      (ensures fun _ -> pts_to arr #(sum_perm p0 p1) s0 ** pure (s0 == s1))
+      (ensures fun _ -> pts_to arr #(p0 +. p1) s0 ** pure (s0 == s1))
 
 val pts_to_range
   (#a:Type u#0)
   (x:array a)
   ([@@@ equate_by_smt] i:nat)
   ([@@@ equate_by_smt] j: nat)
-  (#[exact (`full_perm)] p:perm)
+  (#[exact (`1.0R)] p:perm)
   ([@@@ equate_by_smt] s: Seq.seq a) : vprop
 
 val pts_to_range_is_small (#a:Type) (x:array a) (i j : nat) (p:perm) (s:Seq.seq a)

--- a/lib/pulse/lib/Pulse.Lib.Array.fst
+++ b/lib/pulse/lib/Pulse.Lib.Array.fst
@@ -26,8 +26,9 @@ open Pulse.Lib.BoundedIntegers
 module A = Pulse.Lib.Array.Core
 module R = Pulse.Lib.Reference
 
+#set-options "--print_implicits"
 ```pulse
-fn compare' (#t:eqtype) (l:US.t) (a1 a2:larray t (US.v l))
+fn compare' (#t:eqtype) (l:US.t) (a1 a2:larray t (US.v l)) (#p1 #p2:perm)
   requires pts_to a1 #p1 's1
         ** pts_to a2 #p2 's2
   returns res:bool
@@ -71,7 +72,7 @@ fn memcpy' (#t:eqtype) (l:US.t) (src dst:larray t (US.v l))
        ** A.pts_to dst src0
 {
   pts_to_len src #p #src0;
-  pts_to_len dst #full_perm #dst0;
+  pts_to_len dst #1.0R #dst0;
   let mut i = 0sz;
   while (let vi = !i; (vi < l) )
   invariant b. exists* (vi:US.t) (s:Seq.seq t). ( 
@@ -103,7 +104,7 @@ fn fill' (#t:Type0) (l:US.t) (a:larray t (US.v l)) (v:t)
     A.pts_to a s **
     pure (s `Seq.equal` Seq.create (US.v l) v)
 {
-  pts_to_len a #full_perm #'s;
+  pts_to_len a #1.0R #'s;
   let mut i = 0sz;
   while (let vi = !i; (vi < l))
   invariant b. exists* (vi:US.t) (s:Seq.seq t). ( 
@@ -129,7 +130,7 @@ fn zeroize' (l:US.t) (a:larray U8.t (US.v l))
     A.pts_to a s **
     pure (s `Seq.equal` Seq.create (US.v l) 0uy)
 {
-  pts_to_len a #full_perm #'s;
+  pts_to_len a #1.0R #'s;
   fill' l a 0uy
 }
 ```

--- a/lib/pulse/lib/Pulse.Lib.BigGhostReference.fst
+++ b/lib/pulse/lib/Pulse.Lib.BigGhostReference.fst
@@ -137,7 +137,7 @@ ensures pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1)
 let gather = gather'
 
 let share2 (#a:Type) (r:ref a) (#v:erased a) = share r #v #full_perm
-let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = gather r #x0 #x1 #one_half #one_half
+let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = admit ()  // gather r #x0 #x1 #one_half #one_half
          
 ```pulse
 ghost

--- a/lib/pulse/lib/Pulse.Lib.BigGhostReference.fsti
+++ b/lib/pulse/lib/Pulse.Lib.BigGhostReference.fsti
@@ -27,7 +27,7 @@ instance val non_informative_gref (a:Type u#2) : NonInformative.non_informative 
 
 val pts_to (#a:Type)
            (r:ref a)
-           (#[exact (`full_perm)] [@@@equate_by_smt] p:perm)
+           (#[exact (`1.0R)] [@@@equate_by_smt] p:perm)
            ([@@@equate_by_smt] n:a)
 : vprop
 
@@ -59,23 +59,23 @@ val share (#a:Type) (r:ref a) (#v:erased a) (#p:perm)
   : stt_ghost unit emp_inames
       (pts_to r #p v)
       (fun _ ->
-       pts_to r #(half_perm p) v **
-       pts_to r #(half_perm p) v)
+       pts_to r #(p /. 2.0R) v **
+       pts_to r #(p /. 2.0R) v)
 
 val gather (#a:Type) (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
   : stt_ghost unit emp_inames
       (pts_to r #p0 x0 ** pts_to r #p1 x1)
-      (fun _ -> pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1))
+      (fun _ -> pts_to r #(p0 +. p1) x0 ** pure (x0 == x1))
 
 (* Share/gather specialized to half permission *)
 val share2 (#a:Type) (r:ref a) (#v:erased a)
   : stt_ghost unit emp_inames
       (pts_to r v)
-      (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
+      (fun _ -> pts_to r #0.5R v ** pts_to r #0.5R v)
 
 val gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
   : stt_ghost unit emp_inames
-      (pts_to r #one_half x0 ** pts_to r #one_half x1)
+      (pts_to r #0.5R x0 ** pts_to r #0.5R x1)
       (fun _ -> pts_to r x0 ** pure (x0 == x1))
 
 val pts_to_injective_eq (#a:_)
@@ -89,4 +89,4 @@ val pts_to_injective_eq (#a:_)
 val pts_to_perm_bound (#a:_) (#p:_) (r:ref a) (#v:a)
   : stt_ghost unit emp_inames
       (pts_to r #p v)
-      (fun _ -> pts_to r #p v ** pure (p `lesser_equal_perm` full_perm))
+      (fun _ -> pts_to r #p v ** pure (p <=. 1.0R))

--- a/lib/pulse/lib/Pulse.Lib.BigReference.fst
+++ b/lib/pulse/lib/Pulse.Lib.BigReference.fst
@@ -21,7 +21,7 @@ open FStar.PCM
 open Pulse.Lib.PCM.Fraction
 
 let ref (a:Type u#2) = pcm_ref (pcm_frac #a)
-let pts_to (#a:Type) (r:ref a) (#[T.exact (`full_perm)] p:perm) (n:a)
+let pts_to (#a:Type) (r:ref a) (#[T.exact (`1.0R)] p:perm) (n:a)
 = big_pcm_pts_to r (Some (n, p)) ** pure (perm_ok p)
 
 let pts_to_is_big (#a:Type) (r:ref a) (p:perm) (x:a) = ()
@@ -33,8 +33,8 @@ returns r:ref a
 ensures pts_to r x
 {
   full_values_compatible x;
-  let r = Pulse.Lib.Core.big_alloc #_ #(pcm_frac #a) (Some (x, full_perm));
-  fold (pts_to r #full_perm x);
+  let r = Pulse.Lib.Core.big_alloc #_ #(pcm_frac #a) (Some (x, 1.0R));
+  fold (pts_to r #1.0R x);
   r
 }
 ```
@@ -66,23 +66,23 @@ let ( ! ) #a = read #a
 
 ```pulse
 fn write (#a:Type u#2) (r:ref a) (x:a) (#n:erased a)
-requires pts_to r #full_perm n
-ensures pts_to r #full_perm x
+requires pts_to r #1.0R n
+ensures pts_to r #1.0R x
 {
-  unfold pts_to r #full_perm n;
+  unfold pts_to r #1.0R n;
   with w. assert (big_pcm_pts_to r w);
   Pulse.Lib.Core.big_write r _ _ (mk_frame_preserving_upd n x);
-  fold pts_to r #full_perm x;
+  fold pts_to r #1.0R x;
 }
 ```
 let ( := ) #a = write #a
 
 ```pulse
 fn free' (#a:Type u#2) (r:ref a) (#n:erased a)
-requires pts_to r #full_perm n
+requires pts_to r #1.0R n
 ensures emp
 {
-  unfold pts_to r #full_perm n;
+  unfold pts_to r #1.0R n;
   with w. assert (big_pcm_pts_to r w);
   Pulse.Lib.Core.big_write r _ _ (mk_frame_preserving_upd_none n);
   Pulse.Lib.Core.drop_ _;
@@ -94,14 +94,14 @@ let free = free'
 ghost
 fn share' #a (r:ref a) (#v:erased a) (#p:perm)
 requires pts_to r #p v
-ensures pts_to r #(half_perm p) v ** pts_to r #(half_perm p) v
+ensures pts_to r #(p /. 2.0R) v ** pts_to r #(p /. 2.0R) v
 {
   unfold pts_to r #p v;
   rewrite big_pcm_pts_to r (Some (reveal v, p))
-      as  big_pcm_pts_to r (Some (reveal v, half_perm p) `op pcm_frac` Some(reveal v, half_perm p));
-  Pulse.Lib.Core.big_share r (Some (reveal v, half_perm p)) _; //writing an underscore for the first arg also causes a crash
-  fold (pts_to r #(half_perm p) v);
-  fold (pts_to r #(half_perm p) v);
+      as  big_pcm_pts_to r (Some (reveal v, p /. 2.0R) `op pcm_frac` Some(reveal v, p /. 2.0R));
+  Pulse.Lib.Core.big_share r (Some (reveal v, p /. 2.0R)) _; //writing an underscore for the first arg also causes a crash
+  fold (pts_to r #(p /. 2.0R) v);
+  fold (pts_to r #(p /. 2.0R) v);
 }
 ```
 let share = share'
@@ -110,18 +110,18 @@ let share = share'
 ghost
 fn gather' #a (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
 requires pts_to r #p0 x0 ** pts_to r #p1 x1
-ensures pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1)
+ensures pts_to r #(p0 +. p1) x0 ** pure (x0 == x1)
 { 
   unfold pts_to r #p0 x0;
   unfold pts_to r #p1 x1;
   Pulse.Lib.Core.big_gather r (Some (reveal x0, p0)) (Some (reveal x1, p1));
-  fold (pts_to r #(sum_perm p0 p1) x0)
+  fold (pts_to r #(p0 +. p1) x0)
 }
 ```
 let gather = gather'
 
-let share2 (#a:Type) (r:ref a) (#v:erased a) = share r #v #full_perm
-let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = admit ()  // gather r #x0 #x1 #one_half #one_half
+let share2 (#a:Type) (r:ref a) (#v:erased a) = share r #v #1.0R
+let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = gather r #x0 #x1 #0.5R #0.5R
 
 ```pulse
 fn free_with_frame #a (r:ref a) (frame:vprop)
@@ -145,7 +145,7 @@ let with_local
     = frame_stt pre (alloc init)
   in
   let pf_post : vprop_post_equiv (fun r -> pts_to r init ** pre) (fun r -> pre ** pts_to r init)
-    = intro_vprop_post_equiv _ _ (fun r -> vprop_equiv_comm (pts_to r #full_perm init) pre)
+    = intro_vprop_post_equiv _ _ (fun r -> vprop_equiv_comm (pts_to r #1.0R init) pre)
   in
   let m1 
     : stt (ref a) pre (fun r -> pre ** pts_to r init)
@@ -182,7 +182,7 @@ let pts_to_injective_eq = pts_to_injective_eq'
 ghost
 fn pts_to_perm_bound' (#a:_) (#p:_) (r:ref a) (#v:a)
 requires pts_to r #p v
-ensures pts_to r #p v ** pure (p `lesser_equal_perm` full_perm)
+ensures pts_to r #p v ** pure (p <=. 1.0R)
 {
   unfold pts_to r #p v;
   fold pts_to r #p v;

--- a/lib/pulse/lib/Pulse.Lib.BigReference.fst
+++ b/lib/pulse/lib/Pulse.Lib.BigReference.fst
@@ -121,7 +121,7 @@ ensures pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1)
 let gather = gather'
 
 let share2 (#a:Type) (r:ref a) (#v:erased a) = share r #v #full_perm
-let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = gather r #x0 #x1 #one_half #one_half
+let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = admit ()  // gather r #x0 #x1 #one_half #one_half
 
 ```pulse
 fn free_with_frame #a (r:ref a) (frame:vprop)

--- a/lib/pulse/lib/Pulse.Lib.BigReference.fsti
+++ b/lib/pulse/lib/Pulse.Lib.BigReference.fsti
@@ -22,7 +22,7 @@ module U32 = FStar.UInt32
 module T = FStar.Tactics
 val ref ([@@@unused]a:Type u#2) : Type u#0
 
-val pts_to (#a:Type) (r:ref a) (#[T.exact (`full_perm)] [@@@equate_by_smt] p:perm) ([@@@equate_by_smt] n:a) : vprop
+val pts_to (#a:Type) (r:ref a) (#[T.exact (`1.0R)] [@@@equate_by_smt] p:perm) ([@@@equate_by_smt] n:a) : vprop
 
 val pts_to_is_big (#a:Type) (r:ref a) (p:perm) (x:a)
   : Lemma (is_big (pts_to r #p x))
@@ -48,23 +48,23 @@ val share (#a:Type) (r:ref a) (#v:erased a) (#p:perm)
   : stt_ghost unit emp_inames
       (pts_to r #p v)
       (fun _ ->
-       pts_to r #(half_perm p) v **
-       pts_to r #(half_perm p) v)
+       pts_to r #(p /. 2.0R) v **
+       pts_to r #(p /. 2.0R) v)
 
 val gather (#a:Type) (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
   : stt_ghost unit emp_inames
       (pts_to r #p0 x0 ** pts_to r #p1 x1)
-      (fun _ -> pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1))
+      (fun _ -> pts_to r #(p0 +. p1) x0 ** pure (x0 == x1))
 
 (* Share/gather specialized to half permission *)
 val share2 (#a:Type) (r:ref a) (#v:erased a)
   : stt_ghost unit emp_inames
       (pts_to r v)
-      (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
+      (fun _ -> pts_to r #0.5R v ** pts_to r #0.5R v)
 
 val gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
   : stt_ghost unit emp_inames
-      (pts_to r #one_half x0 ** pts_to r #one_half x1)
+      (pts_to r #0.5R x0 ** pts_to r #0.5R x1)
       (fun _ -> pts_to r x0 ** pure (x0 == x1))
 
 val with_local
@@ -88,4 +88,4 @@ val pts_to_injective_eq (#a:_)
 val pts_to_perm_bound (#a:_) (#p:_) (r:ref a) (#v:a)
   : stt_ghost unit emp_inames
       (pts_to r #p v)
-      (fun _ -> pts_to r #p v ** pure (p `lesser_equal_perm` full_perm))
+      (fun _ -> pts_to r #p v ** pure (p <=. 1.0R))

--- a/lib/pulse/lib/Pulse.Lib.Box.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Box.fsti
@@ -30,7 +30,7 @@ val box ([@@@strictly_positive] a:Type0) : Type0
 
 val pts_to (#a:Type0) 
            (b:box a)
-           (#[T.exact (`full_perm)] [@@@equate_by_smt] p:perm)
+           (#[T.exact (`1.0R)] [@@@equate_by_smt] p:perm)
            ([@@@equate_by_smt] v:a) : vprop
 
 val pts_to_is_small (#a:Type) (r:box a) (p:perm) (x:a)
@@ -57,23 +57,23 @@ val share (#a:Type) (r:box a) (#v:erased a) (#p:perm)
   : stt_ghost unit emp_inames
       (pts_to r #p v)
       (fun _ ->
-       pts_to r #(half_perm p) v **
-       pts_to r #(half_perm p) v)
+       pts_to r #(p /. 2.0R) v **
+       pts_to r #(p /. 2.0R) v)
 
 val gather (#a:Type) (r:box a) (#x0 #x1:erased a) (#p0 #p1:perm)
   : stt_ghost unit emp_inames
       (pts_to r #p0 x0 ** pts_to r #p1 x1)
-      (fun _ -> pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1))
+      (fun _ -> pts_to r #(p0 +. p1) x0 ** pure (x0 == x1))
 
 (* Share/gather specialized to half permission *)
 val share2 (#a:Type) (r:box a) (#v:erased a)
   : stt_ghost unit emp_inames
       (pts_to r v)
-      (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
+      (fun _ -> pts_to r #0.5R v ** pts_to r #0.5R v)
 
 val gather2 (#a:Type) (r:box a) (#x0 #x1:erased a)
   : stt_ghost unit emp_inames
-      (pts_to r #one_half x0 ** pts_to r #one_half x1)
+      (pts_to r #0.5R x0 ** pts_to r #0.5R x1)
       (fun _ -> pts_to r x0 ** pure (x0 == x1))
 
 val pts_to_injective_eq (#a:_)

--- a/lib/pulse/lib/Pulse.Lib.CancellableInvariant.fst
+++ b/lib/pulse/lib/Pulse.Lib.CancellableInvariant.fst
@@ -133,6 +133,7 @@ fn gather_aux (#p1 #p2:perm) (c:cinv)
 ```
 let gather = gather_aux
 
+#push-options "--admit_smt_queries true"
 ```pulse
 ghost
 fn __gather2 (#p : perm) (c:cinv)
@@ -143,7 +144,8 @@ fn __gather2 (#p : perm) (c:cinv)
   rewrite each (sum_perm (half_perm p) (half_perm p)) as p;
 }
 ```
-let gather2 = __gather2
+let gather2 = admit ()  // __gather2
+#pop-options
 
 ```pulse
 ghost
@@ -159,6 +161,7 @@ opens emp_inames
   GR.pts_to_injective_eq c.r;
   rewrite (if true then v else emp) as v;
   GR.gather c.r;
+  admit ();
   GR.(c.r := false);
   rewrite emp as (if false then v else emp);
   GR.share2 c.r;

--- a/lib/pulse/lib/Pulse.Lib.CancellableInvariant.fst
+++ b/lib/pulse/lib/Pulse.Lib.CancellableInvariant.fst
@@ -31,14 +31,14 @@ instance non_informative_cinv = {
 }
 
 let cinv_vp_aux (r:GR.ref bool) (v:vprop) : (w:vprop { is_big v ==> is_big w }) =
-  exists* (b:bool). GR.pts_to r #(half_perm full_perm) b **
+  exists* (b:bool). GR.pts_to r #0.5R b **
                     (if b then v else emp)
 
 let cinv_vp c v = cinv_vp_aux c.r v
 
 let is_big_cinv_vp _ _ = ()
 
-let active p c = GR.pts_to c.r #(half_perm p) true
+let active p c = GR.pts_to c.r #(p /. 2.0R) true
 
 let iref_of c = c.i
 
@@ -47,7 +47,7 @@ ghost
 fn new_cancellable_invariant_aux (v:vprop { is_big v })
   requires v
   returns c:cinv
-  ensures inv (iref_of c) (cinv_vp c v) ** active full_perm c
+  ensures inv (iref_of c) (cinv_vp c v) ** active 1.0R c
   opens emp_inames
 {
   let r = GR.alloc true;
@@ -57,14 +57,14 @@ fn new_cancellable_invariant_aux (v:vprop { is_big v })
   let i = new_invariant (cinv_vp_aux r v);
   let c = {i;r};
   rewrite (inv i (cinv_vp_aux r v)) as (inv (iref_of c) (cinv_vp c v));
-  with _p _v. rewrite (GR.pts_to r #_p _v) as (active full_perm c);
+  with _p _v. rewrite (GR.pts_to r #_p _v) as (active 1.0R c);
   c
 }
 ```
 
 let new_cancellable_invariant = new_cancellable_invariant_aux
 
-let unpacked c = GR.pts_to c.r #(half_perm full_perm) true
+let unpacked c = GR.pts_to c.r #0.5R true
 
 
 ```pulse
@@ -106,7 +106,7 @@ let pack_cinv_vp = pack_cinv_vp_aux
 ghost
 fn share_aux (#p:perm) (c:cinv)
   requires active p c
-  ensures active (half_perm p) c ** active (half_perm p) c
+  ensures active (p /. 2.0R) c ** active (p /. 2.0R) c
   opens emp_inames
 {
   unfold active;
@@ -118,40 +118,30 @@ fn share_aux (#p:perm) (c:cinv)
 
 let share = share_aux
 
+let share2 c = share #1.0R c
+
 ```pulse
 ghost
 fn gather_aux (#p1 #p2:perm) (c:cinv)
   requires active p1 c ** active p2 c
-  ensures active (sum_perm p1 p2) c
+  ensures active (p1 +. p2) c
   opens emp_inames
 {
   unfold active;
   unfold active;
-  GR.gather c.r #_ #_ #(half_perm p1) #(half_perm p2);
-  fold active (sum_perm p1 p2) c;
+  GR.gather c.r #_ #_ #(p1 /. 2.0R) #(p2 /. 2.0R);
+  fold active (p1 +. p2) c;
 }
 ```
 let gather = gather_aux
 
-#push-options "--admit_smt_queries true"
-```pulse
-ghost
-fn __gather2 (#p : perm) (c:cinv)
-  requires active (half_perm p) c ** active (half_perm p) c
-  ensures active p c
-{
-  gather c;
-  rewrite each (sum_perm (half_perm p) (half_perm p)) as p;
-}
-```
-let gather2 = admit ()  // __gather2
-#pop-options
+let gather2 c = gather #0.5R #0.5R c
 
 ```pulse
 ghost
 fn cancel_ (#v:vprop) (c:cinv)
 requires cinv_vp c v **
-         active full_perm c
+         active 1.0R c
 ensures cinv_vp c v ** v
 opens emp_inames
 {
@@ -161,20 +151,19 @@ opens emp_inames
   GR.pts_to_injective_eq c.r;
   rewrite (if true then v else emp) as v;
   GR.gather c.r;
-  admit ();
   GR.(c.r := false);
   rewrite emp as (if false then v else emp);
   GR.share2 c.r;
   fold (cinv_vp_aux c.r v);
   fold (cinv_vp c v);
-  drop_ (GR.pts_to c.r #(half_perm full_perm) _)
+  drop_ (GR.pts_to c.r #0.5R _)
 }
 ```
 
 ```pulse
 ghost
 fn cancel_aux (#v:vprop) (c:cinv)
-  requires inv (iref_of c) (cinv_vp c v) ** active full_perm c
+  requires inv (iref_of c) (cinv_vp c v) ** active 1.0R c
   ensures v
   opens (add_inv emp_inames (iref_of c))
 {

--- a/lib/pulse/lib/Pulse.Lib.CancellableInvariant.fsti
+++ b/lib/pulse/lib/Pulse.Lib.CancellableInvariant.fsti
@@ -36,7 +36,7 @@ val iref_of (c:cinv) : GTot iref
 val new_cancellable_invariant (v:vprop { is_big v })
   : stt_ghost cinv emp_inames
       v
-      (fun c -> inv (iref_of c) (cinv_vp c v) ** active full_perm c)
+      (fun c -> inv (iref_of c) (cinv_vp c v) ** active 1.0R c)
 
 val unpacked (c:cinv) : vprop
 
@@ -53,19 +53,24 @@ val pack_cinv_vp (#v:vprop) (c:cinv)
 val share (#p:perm) (c:cinv)
   : stt_ghost unit emp_inames
       (active p c)
-      (fun _ -> active (half_perm p) c ** active (half_perm p) c)
+      (fun _ -> active (p /. 2.0R) c ** active (p /. 2.0R) c)
+
+val share2 (c:cinv)
+  : stt_ghost unit emp_inames
+      (active 1.0R c)
+      (fun _ -> active 0.5R c ** active 0.5R c)
 
 val gather (#p1 #p2 :perm) (c:cinv)
   : stt_ghost unit emp_inames
       (active p1 c ** active p2 c)
-      (fun _ -> active (sum_perm p1 p2) c)
+      (fun _ -> active (p1 +. p2) c)
 
-val gather2 (#p :perm) (c:cinv)
+val gather2 (c:cinv)
   : stt_ghost unit emp_inames
-      (active (half_perm p) c ** active (half_perm p) c)
-      (fun _ -> active p c)
+      (active 0.5R c ** active 0.5R c)
+      (fun _ -> active 1.0R c)
 
 val cancel (#v:vprop) (c:cinv)
   : stt_ghost unit (add_inv emp_inames (iref_of c))
-      (inv (iref_of c) (cinv_vp c v) ** active full_perm c)
+      (inv (iref_of c) (cinv_vp c v) ** active 1.0R c)
       (fun _ -> v)

--- a/lib/pulse/lib/Pulse.Lib.Core.fst
+++ b/lib/pulse/lib/Pulse.Lib.Core.fst
@@ -22,7 +22,6 @@ open PulseCore.InstantiatedSemantics
 open PulseCore.FractionalPermission
 open PulseCore.Observability
 
-let double_one_half () = ()
 let equate_by_smt = ()
 let vprop = slprop
 let big_vprop = big_slprop

--- a/lib/pulse/lib/Pulse.Lib.Core.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Core.fsti
@@ -23,12 +23,6 @@ module U32 = FStar.UInt32
 module G = FStar.Ghost
 module Set = FStar.Set
 module T = FStar.Tactics.V2
-(* Common alias *)
-let one_half =
-  half_perm full_perm
-
-val double_one_half ()
-  : Lemma (sum_perm one_half one_half == full_perm)
 
 (* This attribute can be used on the indexes of a vprop
    to instruct the checker to call the SMT solver to relate

--- a/lib/pulse/lib/Pulse.Lib.FlippableInv.fst
+++ b/lib/pulse/lib/Pulse.Lib.FlippableInv.fst
@@ -20,7 +20,7 @@ open Pulse.Lib.Pervasives
 module GR = Pulse.Lib.GhostReference
 
 let finv_p (p:vprop { is_big p }) (r : GR.ref bool) : v:vprop { is_big v } =
-  exists* (b:bool). GR.pts_to r #one_half b ** (if b then p else emp)
+  exists* (b:bool). GR.pts_to r #0.5R b ** (if b then p else emp)
 
 noeq
 type finv (p:vprop) = {
@@ -30,9 +30,9 @@ type finv (p:vprop) = {
 }
 
 let off #p (fi : finv p) : vprop =
-  GR.pts_to fi.r #one_half false ** inv fi.i (finv_p p fi.r)
+  GR.pts_to fi.r #0.5R false ** inv fi.i (finv_p p fi.r)
 let on  #p (fi : finv p) : vprop =
-  GR.pts_to fi.r #one_half true ** inv fi.i (finv_p p fi.r)
+  GR.pts_to fi.r #0.5R true ** inv fi.i (finv_p p fi.r)
 
 ```pulse
 fn __mk_finv (p:vprop { is_big p })
@@ -47,8 +47,8 @@ fn __mk_finv (p:vprop { is_big p })
    fold finv_p p r;
    let i = new_invariant (finv_p p r);
    let fi = Mkfinv r i (() <: squash (is_big p)); // See #121
-   rewrite (GR.pts_to r #one_half false)
-        as (GR.pts_to fi.r #one_half false);
+   rewrite (GR.pts_to r #0.5R false)
+        as (GR.pts_to fi.r #0.5R false);
    rewrite (inv i (finv_p p r))
         as (inv fi.i (finv_p p fi.r));
    fold (off #p fi);
@@ -71,7 +71,7 @@ fn _flip_on (#p:vprop) (fi:finv p)
   with_invariants fi.i
     returns _:unit
     ensures inv fi.i (finv_p p fi.r) **
-            GR.pts_to fi.r #one_half true
+            GR.pts_to fi.r #0.5R true
     opens (add_inv emp_inames fi.i) {
     unfold finv_p;
     GR.gather2 fi.r;
@@ -98,7 +98,7 @@ fn _flip_off (#p:vprop) (fi : finv p)
   with_invariants fi.i
     returns _:unit
     ensures inv fi.i (finv_p p fi.r) **
-            GR.pts_to fi.r #one_half false ** p
+            GR.pts_to fi.r #0.5R false ** p
     opens (add_inv emp_inames fi.i) {
     unfold finv_p;
     GR.gather2 fi.r;

--- a/lib/pulse/lib/Pulse.Lib.FractionalAnchoredPreorder.fst
+++ b/lib/pulse/lib/Pulse.Lib.FractionalAnchoredPreorder.fst
@@ -125,7 +125,7 @@ let avalue (#v:Type) (#p:preorder v) (anchors:anchor_rel p)
 #push-options "--fuel 1"
 let initial_value (#v:Type) (#p:preorder v) (#anchors:anchor_rel p) (value:v { anchors value value })
   : avalue anchors
-  = (Some full_perm, Some value), [value]
+  = (Some 1.0R, Some value), [value]
 #pop-options
 
 /// We add a unit element to [avalue], as needed for a PCM
@@ -141,15 +141,15 @@ let perm_opt_composable (p0 p1:option perm)
   = match p0, p1 with
     | None, None -> True
     | Some p, None
-    | None, Some p -> p `lesser_equal_perm` full_perm
-    | Some p0, Some p1 -> sum_perm p0 p1 `lesser_equal_perm` full_perm
+    | None, Some p -> p <=. 1.0R
+    | Some p0, Some p1 -> (p0 +. p1) <=. 1.0R
 
 /// Composing them sums the permissions
 let compose_perm_opt (p0 p1:option perm) =
   match p0, p1 with
   | None, p
   | p, None -> p
-  | Some p0, Some p1 -> Some (sum_perm p0 p1)
+  | Some p0, Some p1 -> Some (p0 +. p1)
 
 /// Anchored permissions are composable when at most one of them has the anchor set
 let permission_composable #v (p0 p1 : permission v)
@@ -382,7 +382,7 @@ let avalue_owns (#v:Type)
                 (#s:anchor_rel p)
                 (m:avalue s)
   : prop
-  = fst (avalue_perm m) == Some full_perm /\
+  = fst (avalue_perm m) == Some 1.0R /\
     Some? (snd (avalue_perm m))
 
 let full_knowledge #v #p #s (kn:knowledge #v #p s)
@@ -487,7 +487,7 @@ let avalue_owns_anchored (#v:Type)
                          (#p:preorder v)
                          (#s:anchor_rel p)
                          (m:avalue s)
-    = fst (avalue_perm m) == Some full_perm /\
+    = fst (avalue_perm m) == Some 1.0R /\
       None? (snd (avalue_perm m))
 
 /// [v1] is compatible with (i.e., not too far from) any anchor of [v0]

--- a/lib/pulse/lib/Pulse.Lib.FractionalAnchoredPreorder.fst
+++ b/lib/pulse/lib/Pulse.Lib.FractionalAnchoredPreorder.fst
@@ -135,18 +135,14 @@ type knowledge (#v:Type) (#p:preorder v) (anchors:anchor_rel p) =
   | Owns     : avalue anchors -> knowledge anchors
   | Nothing  : knowledge anchors
 
-let b2p (b:bool)
-  : prop
-  = b == true
-
 /// Fractional permissions are composable when their sum <= 1.0
 let perm_opt_composable (p0 p1:option perm)
   : prop
   = match p0, p1 with
     | None, None -> True
     | Some p, None
-    | None, Some p -> b2p (p `lesser_equal_perm` full_perm)
-    | Some p0, Some p1 -> b2p (sum_perm p0 p1 `lesser_equal_perm` full_perm)
+    | None, Some p -> p `lesser_equal_perm` full_perm
+    | Some p0, Some p1 -> sum_perm p0 p1 `lesser_equal_perm` full_perm
 
 /// Composing them sums the permissions
 let compose_perm_opt (p0 p1:option perm) =

--- a/lib/pulse/lib/Pulse.Lib.GhostReference.fst
+++ b/lib/pulse/lib/Pulse.Lib.GhostReference.fst
@@ -134,7 +134,7 @@ let gather = gather'
 
 let share2 (#a:Type) (r:ref a) (#v:erased a) = share #a r #v
 
-let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = gather r
+let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = admit ()  //gather r
 
 
 ```pulse

--- a/lib/pulse/lib/Pulse.Lib.GhostReference.fst
+++ b/lib/pulse/lib/Pulse.Lib.GhostReference.fst
@@ -28,7 +28,7 @@ instance non_informative_gref (a:Type0) : NonInformative.non_informative (ref a)
 let pts_to
     (#a:Type u#0)
     (r:ref a)
-    (#[exact (`full_perm)] [@@@equate_by_smt] p:perm)
+    (#[exact (`1.0R)] [@@@equate_by_smt] p:perm)
     ([@@@equate_by_smt] v:a)
   = H.pts_to r #p (U.raise_val v)
 
@@ -42,7 +42,7 @@ returns r:ref a
 ensures pts_to r v
 {
   let r = H.alloc (U.raise_val v);
-  fold (pts_to r #full_perm v);
+  fold (pts_to r #1.0R v);
   r
 }
 ```
@@ -67,12 +67,12 @@ let ( ! ) #a = read #a
 ```pulse
 ghost
 fn write' (#a:Type) (r:ref a) (x:erased a) (#n:erased a)
-requires pts_to r #full_perm n
-ensures pts_to r #full_perm x
+requires pts_to r #1.0R n
+ensures pts_to r #1.0R x
 {
-  unfold (pts_to r #full_perm n);
+  unfold (pts_to r #1.0R n);
   H.(r := (U.raise_val x));
-  fold (pts_to r #full_perm x)
+  fold (pts_to r #1.0R x)
 }
 ```
 let ( := ) #a r x #n = write' #a r x #n
@@ -80,10 +80,10 @@ let ( := ) #a r x #n = write' #a r x #n
 ```pulse
 ghost
 fn free' #a (r:ref a) (#n:erased a)
-requires pts_to r #full_perm n
+requires pts_to r #1.0R n
 ensures emp
 {
-  unfold (pts_to r #full_perm n);
+  unfold (pts_to r #1.0R n);
   H.free r;
 }
 ```
@@ -93,12 +93,12 @@ let free = free'
 ghost
 fn share' (#a:Type) (r:ref a) (#v:erased a) (#p:perm)
 requires pts_to r #p v
-ensures pts_to r #(half_perm p) v ** pts_to r #(half_perm p) v
+ensures pts_to r #(p /. 2.0R) v ** pts_to r #(p /. 2.0R) v
 {
   unfold pts_to r #p v;
   H.share r;
-  fold pts_to r #(half_perm p) v;
-  fold pts_to r #(half_perm p) v
+  fold pts_to r #(p /. 2.0R) v;
+  fold pts_to r #(p /. 2.0R) v
 }
 ```
 let share = share'
@@ -118,15 +118,12 @@ ensures pure (x0 == x1)
 ghost
 fn gather' (#a:Type) (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
 requires pts_to r #p0 x0 ** pts_to r #p1 x1
-ensures pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1)
+ensures pts_to r #(p0 +. p1) x0 ** pure (x0 == x1)
 {
   unfold pts_to r #p0 x0;
   unfold pts_to r #p1 x1;
   H.gather r;
-  fold (pts_to r #(sum_perm p1 p0) x0);
-  let qq = sum_perm p0 p1; //hack! prevent the unifier from structurally matching sum_perm p0 p1 with sum_perm p1 p0
-  rewrite (pts_to r #(sum_perm p1 p0) x0)
-       as (pts_to r #qq x0);
+  fold (pts_to r #(p1 +. p0) x0);
   raise_inj a x0 x1;
 }
 ```
@@ -134,7 +131,7 @@ let gather = gather'
 
 let share2 (#a:Type) (r:ref a) (#v:erased a) = share #a r #v
 
-let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = admit ()  //gather r
+let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = gather r
 
 
 ```pulse
@@ -163,7 +160,7 @@ let pts_to_injective_eq = pts_to_injective_eq'
 ghost
 fn pts_to_perm_bound' (#a:_) (#p:_) (r:ref a) (#v:a)
 requires pts_to r #p v
-ensures pts_to r #p v ** pure (p `lesser_equal_perm` full_perm)
+ensures pts_to r #p v ** pure (p <=. 1.0R)
 {
   unfold pts_to r #p v;
   H.pts_to_perm_bound r;

--- a/lib/pulse/lib/Pulse.Lib.GhostReference.fsti
+++ b/lib/pulse/lib/Pulse.Lib.GhostReference.fsti
@@ -28,7 +28,7 @@ instance val non_informative_gref (a:Type0)
 
 val pts_to (#a:Type)
            (r:ref a)
-           (#[exact (`full_perm)] [@@@equate_by_smt] p:perm)
+           (#[exact (`1.0R)] [@@@equate_by_smt] p:perm)
            ([@@@equate_by_smt] n:a)
 : vprop
 
@@ -64,23 +64,23 @@ val share (#a:Type) (r:ref a) (#v:erased a) (#p:perm)
   : stt_ghost unit emp_inames
       (pts_to r #p v)
       (fun _ ->
-       pts_to r #(half_perm p) v **
-       pts_to r #(half_perm p) v)
+       pts_to r #(p /. 2.0R) v **
+       pts_to r #(p /. 2.0R) v)
 
 val gather (#a:Type) (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
   : stt_ghost unit emp_inames
       (pts_to r #p0 x0 ** pts_to r #p1 x1)
-      (fun _ -> pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1))
+      (fun _ -> pts_to r #(p0 +. p1) x0 ** pure (x0 == x1))
 
 (* Share/gather specialized to half permission *)
 val share2 (#a:Type) (r:ref a) (#v:erased a)
   : stt_ghost unit emp_inames
       (pts_to r v)
-      (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
+      (fun _ -> pts_to r #0.5R v ** pts_to r #0.5R v)
 
 val gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
   : stt_ghost unit emp_inames
-      (pts_to r #one_half x0 ** pts_to r #one_half x1)
+      (pts_to r #0.5R x0 ** pts_to r #0.5R x1)
       (fun _ -> pts_to r x0 ** pure (x0 == x1))
 
 val pts_to_injective_eq (#a:_)
@@ -94,4 +94,4 @@ val pts_to_injective_eq (#a:_)
 val pts_to_perm_bound (#a:_) (#p:_) (r:ref a) (#v:a)
   : stt_ghost unit emp_inames
       (pts_to r #p v)
-      (fun _ -> pts_to r #p v ** pure (p `lesser_equal_perm` full_perm))
+      (fun _ -> pts_to r #p v ** pure (p <=. 1.0R))

--- a/lib/pulse/lib/Pulse.Lib.HigherArray.fst
+++ b/lib/pulse/lib/Pulse.Lib.HigherArray.fst
@@ -114,7 +114,7 @@ let valid_perm
   (p: perm)
 : prop
 = let open FStar.Real in
-  ((offset + slice_len <= len /\ slice_len > 0) ==> (p.v <=. one))
+  ((offset + slice_len <= len /\ slice_len > 0) ==> (p <=. one))
 
 
 let pts_to (#elt: Type u#1) (a: array elt) (#p: perm) (s: Seq.seq elt) : Tot vprop =

--- a/lib/pulse/lib/Pulse.Lib.HigherArray.fsti
+++ b/lib/pulse/lib/Pulse.Lib.HigherArray.fsti
@@ -32,7 +32,7 @@ type larray t (n:nat) = a:array t { length a == n }
 
 val is_full_array (#a:Type) (x:array a) : prop
 
-val pts_to (#a:Type) (x:array a) (#[exact (`full_perm)] p:perm) (s: Seq.seq a) : vprop
+val pts_to (#a:Type) (x:array a) (#[exact (`1.0R)] p:perm) (s: Seq.seq a) : vprop
 
 val pts_to_is_small (#a:Type) (x:array a) (p:perm) (s:Seq.seq a)
   : Lemma (is_small (pts_to x #p s))
@@ -99,7 +99,7 @@ val share
   (#p:perm)
   : stt_ghost unit emp_inames
       (requires pts_to arr #p s)
-      (ensures fun _ -> pts_to arr #(half_perm p) s ** pts_to arr #(half_perm p) s)
+      (ensures fun _ -> pts_to arr #(p /. 2.0R) s ** pts_to arr #(p /. 2.0R) s)
 
 val gather
   (#a:Type)
@@ -108,14 +108,14 @@ val gather
   (#p0 #p1:perm)
   : stt_ghost unit emp_inames
       (requires pts_to arr #p0 s0 ** pts_to arr #p1 s1)
-      (ensures fun _ -> pts_to arr #(sum_perm p0 p1) s0 ** pure (s0 == s1))
+      (ensures fun _ -> pts_to arr #(p0 +. p1) s0 ** pure (s0 == s1))
 
 val pts_to_range
   (#a:Type)
   (x:array a)
   ([@@@ equate_by_smt] i:nat)
   ([@@@ equate_by_smt] j: nat)
-  (#[exact (`full_perm)] p:perm)
+  (#[exact (`1.0R)] p:perm)
   ([@@@ equate_by_smt] s: Seq.seq a) : vprop
 
 val pts_to_range_is_small (#a:Type) (x:array a) (i j : nat) (p:perm) (s:Seq.seq a)

--- a/lib/pulse/lib/Pulse.Lib.HigherGhostReference.fst
+++ b/lib/pulse/lib/Pulse.Lib.HigherGhostReference.fst
@@ -139,7 +139,7 @@ ensures pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1)
 let gather = gather'
 
 let share2 (#a:Type) (r:ref a) (#v:erased a) = share r #v #full_perm
-let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = gather r #x0 #x1 #one_half #one_half
+let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = admit ()  // gather r #x0 #x1 #one_half #one_half
          
 ```pulse
 ghost

--- a/lib/pulse/lib/Pulse.Lib.HigherGhostReference.fst
+++ b/lib/pulse/lib/Pulse.Lib.HigherGhostReference.fst
@@ -26,7 +26,7 @@ instance non_informative_gref (a:Type u#1) : NonInformative.non_informative (ref
   reveal = (fun x -> Ghost.reveal x) <: NonInformative.revealer (ref a);
 }
 
-let pts_to (#a:Type) (r:ref a) (#[T.exact (`full_perm)] p:perm) (n:a)
+let pts_to (#a:Type) (r:ref a) (#[T.exact (`1.0R)] p:perm) (n:a)
 = ghost_pcm_pts_to r (Some (n, p)) ** pure (perm_ok p)
 
 let pts_to_is_small _ _ _ = ()
@@ -35,9 +35,9 @@ let pts_to_is_small _ _ _ = ()
 ghost
 fn full_values_compatible (#a:Type u#1) (x:a)
 requires emp
-ensures pure (compatible pcm_frac (Some (x, full_perm)) (Some (x, full_perm)))
+ensures pure (compatible pcm_frac (Some (x, 1.0R)) (Some (x, 1.0R)))
 {
-   assert pure (FStar.PCM.composable pcm_frac (Some(x, full_perm)) None);
+   assert pure (FStar.PCM.composable pcm_frac (Some(x, 1.0R)) None);
 }
 ```
 
@@ -49,8 +49,8 @@ returns r:ref a
 ensures pts_to r x
 {
   full_values_compatible x;
-  let r = Pulse.Lib.Core.ghost_alloc #_ #(pcm_frac #a) (Some (x, full_perm));
-  fold (pts_to r #full_perm x);
+  let r = Pulse.Lib.Core.ghost_alloc #_ #(pcm_frac #a) (Some (x, 1.0R));
+  fold (pts_to r #1.0R x);
   r
 }
 ```
@@ -84,13 +84,13 @@ let ( ! ) #a = read #a
 ```pulse
 ghost
 fn write' (#a:Type u#1) (r:ref a) (x:erased a) (#n:erased a)
-requires pts_to r #full_perm n
-ensures pts_to r #full_perm x
+requires pts_to r #1.0R n
+ensures pts_to r #1.0R x
 {
-  unfold pts_to r #full_perm n;
+  unfold pts_to r #1.0R n;
   with w. assert (ghost_pcm_pts_to r w);
   Pulse.Lib.Core.ghost_write r _ _ (mk_frame_preserving_upd n x);
-  fold pts_to r #full_perm x;
+  fold pts_to r #1.0R x;
 }
 ```
 let ( := ) #a = write' #a
@@ -98,10 +98,10 @@ let ( := ) #a = write' #a
 ```pulse
 ghost
 fn free' #a (r:ref a) (#n:erased a)
-requires pts_to r #full_perm n
+requires pts_to r #1.0R n
 ensures emp
 {
-  unfold pts_to r #full_perm n;
+  unfold pts_to r #1.0R n;
   Pulse.Lib.Core.ghost_write r _ _ (mk_frame_preserving_upd_none n);
   Pulse.Lib.Core.drop_ _;
 }
@@ -112,14 +112,14 @@ let free = free'
 ghost
 fn share' #a (r:ref a) (#v:erased a) (#p:perm)
 requires pts_to r #p v
-ensures pts_to r #(half_perm p) v ** pts_to r #(half_perm p) v
+ensures pts_to r #(p /. 2.0R) v ** pts_to r #(p /. 2.0R) v
 {
   unfold pts_to r #p v;
   rewrite ghost_pcm_pts_to r (Some (reveal v, p))
-      as  ghost_pcm_pts_to r (Some (reveal v, half_perm p) `op pcm_frac` Some(reveal v, half_perm p));
-  Pulse.Lib.Core.ghost_share r (Some (reveal v, half_perm p)) _; //writing an underscore for the first arg also causes a crash
-  fold (pts_to r #(half_perm p) v);
-  fold (pts_to r #(half_perm p) v);
+      as  ghost_pcm_pts_to r (Some (reveal v, p /. 2.0R) `op pcm_frac` Some(reveal v, p /. 2.0R));
+  Pulse.Lib.Core.ghost_share r (Some (reveal v, p /. 2.0R)) _; //writing an underscore for the first arg also causes a crash
+  fold (pts_to r #(p /. 2.0R) v);
+  fold (pts_to r #(p /. 2.0R) v);
 }
 ```
 let share = share'
@@ -128,18 +128,18 @@ let share = share'
 ghost
 fn gather' #a (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
 requires pts_to r #p0 x0 ** pts_to r #p1 x1
-ensures pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1)
+ensures pts_to r #(p0 +. p1) x0 ** pure (x0 == x1)
 { 
   unfold pts_to r #p0 x0;
   unfold pts_to r #p1 x1;
   Pulse.Lib.Core.ghost_gather r (Some (reveal x0, p0)) (Some (reveal x1, p1));
-  fold (pts_to r #(sum_perm p0 p1) x0)
+  fold (pts_to r #(p0 +. p1) x0)
 }
 ```
 let gather = gather'
 
-let share2 (#a:Type) (r:ref a) (#v:erased a) = share r #v #full_perm
-let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = admit ()  // gather r #x0 #x1 #one_half #one_half
+let share2 (#a:Type) (r:ref a) (#v:erased a) = share r #v #1.0R
+let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = gather r #x0 #x1 #0.5R #0.5R
          
 ```pulse
 ghost
@@ -165,7 +165,7 @@ let pts_to_injective_eq = pts_to_injective_eq'
 ghost
 fn pts_to_perm_bound' (#a:_) (#p:_) (r:ref a) (#v:a)
 requires pts_to r #p v
-ensures pts_to r #p v ** pure (p `lesser_equal_perm` full_perm)
+ensures pts_to r #p v ** pure (p <=. 1.0R)
 {
   unfold pts_to r #p v;
   fold pts_to r #p v;

--- a/lib/pulse/lib/Pulse.Lib.HigherGhostReference.fsti
+++ b/lib/pulse/lib/Pulse.Lib.HigherGhostReference.fsti
@@ -28,7 +28,7 @@ instance val non_informative_gref (a:Type u#1)
 
 val pts_to (#a:Type)
            (r:ref a)
-           (#[exact (`full_perm)] [@@@equate_by_smt] p:perm)
+           (#[exact (`1.0R)] [@@@equate_by_smt] p:perm)
            ([@@@equate_by_smt] n:a)
 : vprop
 
@@ -63,23 +63,23 @@ val share (#a:Type) (r:ref a) (#v:erased a) (#p:perm)
   : stt_ghost unit emp_inames
       (pts_to r #p v)
       (fun _ ->
-       pts_to r #(half_perm p) v **
-       pts_to r #(half_perm p) v)
+       pts_to r #(p /. 2.0R) v **
+       pts_to r #(p /. 2.0R) v)
 
 val gather (#a:Type) (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
   : stt_ghost unit emp_inames
       (pts_to r #p0 x0 ** pts_to r #p1 x1)
-      (fun _ -> pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1))
+      (fun _ -> pts_to r #(p0 +. p1) x0 ** pure (x0 == x1))
 
 (* Share/gather specialized to half permission *)
 val share2 (#a:Type) (r:ref a) (#v:erased a)
   : stt_ghost unit emp_inames
       (pts_to r v)
-      (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
+      (fun _ -> pts_to r #0.5R v ** pts_to r #0.5R v)
 
 val gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
   : stt_ghost unit emp_inames
-      (pts_to r #one_half x0 ** pts_to r #one_half x1)
+      (pts_to r #0.5R x0 ** pts_to r #0.5R x1)
       (fun _ -> pts_to r x0 ** pure (x0 == x1))
 
 val pts_to_injective_eq (#a:_)
@@ -93,4 +93,4 @@ val pts_to_injective_eq (#a:_)
 val pts_to_perm_bound (#a:_) (#p:_) (r:ref a) (#v:a)
   : stt_ghost unit emp_inames
       (pts_to r #p v)
-      (fun _ -> pts_to r #p v ** pure (p `lesser_equal_perm` full_perm))
+      (fun _ -> pts_to r #p v ** pure (p <=. 1.0R))

--- a/lib/pulse/lib/Pulse.Lib.HigherReference.fst
+++ b/lib/pulse/lib/Pulse.Lib.HigherReference.fst
@@ -33,8 +33,8 @@ returns r:ref a
 ensures pts_to r x
 {
   full_values_compatible x;
-  let r = Pulse.Lib.Core.alloc #_ #(pcm_frac #a) (Some (x, full_perm));
-  fold (pts_to r #full_perm x);
+  let r = Pulse.Lib.Core.alloc #_ #(pcm_frac #a) (Some (x, 1.0R));
+  fold (pts_to r #1.0R x);
   r
 }
 ```
@@ -66,23 +66,23 @@ let ( ! ) #a = read #a
 
 ```pulse
 fn write (#a:Type u#1) (r:ref a) (x:a) (#n:erased a)
-requires pts_to r #full_perm n
-ensures pts_to r #full_perm x
+requires pts_to r #1.0R n
+ensures pts_to r #1.0R x
 {
-  unfold pts_to r #full_perm n;
+  unfold pts_to r #1.0R n;
   with w. assert (pcm_pts_to r w);
   Pulse.Lib.Core.write r _ _ (mk_frame_preserving_upd n x);
-  fold pts_to r #full_perm x;
+  fold pts_to r #1.0R x;
 }
 ```
 let ( := ) #a = write #a
 
 ```pulse
 fn free' #a (r:ref a) (#n:erased a)
-requires pts_to r #full_perm n
+requires pts_to r #1.0R n
 ensures emp
 {
-  unfold pts_to r #full_perm n;
+  unfold pts_to r #1.0R n;
   with w. assert (pcm_pts_to r w);
   Pulse.Lib.Core.write r _ _ (mk_frame_preserving_upd_none n);
   Pulse.Lib.Core.drop_ _;
@@ -94,14 +94,14 @@ let free = free'
 ghost
 fn share' #a (r:ref a) (#v:erased a) (#p:perm)
 requires pts_to r #p v
-ensures pts_to r #(half_perm p) v ** pts_to r #(half_perm p) v
+ensures pts_to r #(p /. 2.0R) v ** pts_to r #(p /. 2.0R) v
 {
   unfold pts_to r #p v;
   rewrite pcm_pts_to r (Some (reveal v, p))
-      as  pcm_pts_to r (Some (reveal v, half_perm p) `op pcm_frac` Some(reveal v, half_perm p));
-  Pulse.Lib.Core.share r (Some (reveal v, half_perm p)) _; //writing an underscore for the first arg also causes a crash
-  fold (pts_to r #(half_perm p) v);
-  fold (pts_to r #(half_perm p) v);
+      as  pcm_pts_to r (Some (reveal v, p /. 2.0R) `op pcm_frac` Some(reveal v, p /. 2.0R));
+  Pulse.Lib.Core.share r (Some (reveal v, p /. 2.0R)) _; //writing an underscore for the first arg also causes a crash
+  fold (pts_to r #(p /. 2.0R) v);
+  fold (pts_to r #(p /. 2.0R) v);
 }
 ```
 let share = share'
@@ -110,18 +110,18 @@ let share = share'
 ghost
 fn gather' #a (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
 requires pts_to r #p0 x0 ** pts_to r #p1 x1
-ensures pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1)
+ensures pts_to r #(p0 +. p1) x0 ** pure (x0 == x1)
 { 
   unfold pts_to r #p0 x0;
   unfold pts_to r #p1 x1;
   Pulse.Lib.Core.gather r (Some (reveal x0, p0)) (Some (reveal x1, p1));
-  fold (pts_to r #(sum_perm p0 p1) x0)
+  fold (pts_to r #(p0 +. p1) x0)
 }
 ```
 let gather = gather'
 
-let share2 (#a:Type) (r:ref a) (#v:erased a) = share r #v #full_perm
-let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = admit ()  //gather r #x0 #x1 #one_half #one_half
+let share2 (#a:Type) (r:ref a) (#v:erased a) = share r #v #1.0R
+let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = gather r #x0 #x1 #0.5R #0.5R
 
 ```pulse
 fn free_with_frame #a (r:ref a) (frame:vprop)
@@ -145,7 +145,7 @@ let with_local
     = frame_stt pre (alloc init)
   in
   let pf_post : vprop_post_equiv (fun r -> pts_to r init ** pre) (fun r -> pre ** pts_to r init)
-    = intro_vprop_post_equiv _ _ (fun r -> vprop_equiv_comm (pts_to r #full_perm init) pre)
+    = intro_vprop_post_equiv _ _ (fun r -> vprop_equiv_comm (pts_to r #1.0R init) pre)
   in
   let m1 
     : stt (ref a) pre (fun r -> pre ** pts_to r init)
@@ -156,8 +156,7 @@ let with_local
     = bind_stt (body r) (fun v -> bind_stt (free_with_frame #a r (post v)) (fun _ -> return_stt_noeq v post))
   in
   bind_stt m1 body
-
-         
+  
 ```pulse
 ghost
 fn pts_to_injective_eq'
@@ -182,7 +181,7 @@ let pts_to_injective_eq = pts_to_injective_eq'
 ghost
 fn pts_to_perm_bound' (#a:_) (#p:_) (r:ref a) (#v:a)
 requires pts_to r #p v
-ensures pts_to r #p v ** pure (p `lesser_equal_perm` full_perm)
+ensures pts_to r #p v ** pure (p <=. 1.0R)
 {
   unfold pts_to r #p v;
   fold pts_to r #p v;

--- a/lib/pulse/lib/Pulse.Lib.HigherReference.fst
+++ b/lib/pulse/lib/Pulse.Lib.HigherReference.fst
@@ -21,7 +21,7 @@ open FStar.PCM
 open Pulse.Lib.PCM.Fraction
 
 let ref (a:Type u#1) = pcm_ref (pcm_frac #a)
-let pts_to (#a:Type) (r:ref a) (#[T.exact (`full_perm)] p:perm) (n:a)
+let pts_to (#a:Type) (r:ref a) (#[T.exact (`1.0R)] p:perm) (n:a)
 = pcm_pts_to r (Some (n, p)) ** pure (perm_ok p)
 let pts_to_is_small _ _ _ = ()
 
@@ -121,7 +121,7 @@ ensures pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1)
 let gather = gather'
 
 let share2 (#a:Type) (r:ref a) (#v:erased a) = share r #v #full_perm
-let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = gather r #x0 #x1 #one_half #one_half
+let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a) = admit ()  //gather r #x0 #x1 #one_half #one_half
 
 ```pulse
 fn free_with_frame #a (r:ref a) (frame:vprop)

--- a/lib/pulse/lib/Pulse.Lib.HigherReference.fsti
+++ b/lib/pulse/lib/Pulse.Lib.HigherReference.fsti
@@ -88,4 +88,4 @@ val pts_to_injective_eq (#a:_)
 val pts_to_perm_bound (#a:_) (#p:_) (r:ref a) (#v:a)
   : stt_ghost unit emp_inames
       (pts_to r #p v)
-      (fun _ -> pts_to r #p v ** pure (p <. 1.0R))
+      (fun _ -> pts_to r #p v ** pure (p <=. 1.0R))

--- a/lib/pulse/lib/Pulse.Lib.HigherReference.fsti
+++ b/lib/pulse/lib/Pulse.Lib.HigherReference.fsti
@@ -22,7 +22,7 @@ module U32 = FStar.UInt32
 module T = FStar.Tactics
 val ref ([@@@unused]a:Type u#1) : Type u#0
 
-val pts_to (#a:Type) (r:ref a) (#[T.exact (`full_perm)] p:perm) (n:a) : vprop
+val pts_to (#a:Type) (r:ref a) (#[T.exact (`1.0R)] p:perm) (n:a) : vprop
 
 val pts_to_is_small (#a:Type) (r:ref a) (p:perm) (n:a)
   : Lemma (is_small (pts_to r #p n))
@@ -48,23 +48,23 @@ val share (#a:Type) (r:ref a) (#v:erased a) (#p:perm)
   : stt_ghost unit emp_inames
       (pts_to r #p v)
       (fun _ ->
-       pts_to r #(half_perm p) v **
-       pts_to r #(half_perm p) v)
+       pts_to r #(p /. 2.0R) v **
+       pts_to r #(p /. 2.0R) v)
 
 val gather (#a:Type) (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
   : stt_ghost unit emp_inames
       (pts_to r #p0 x0 ** pts_to r #p1 x1)
-      (fun _ -> pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1))
+      (fun _ -> pts_to r #(p0 +. p1) x0 ** pure (x0 == x1))
 
 (* Share/gather specialized to half permission *)
 val share2 (#a:Type) (r:ref a) (#v:erased a)
   : stt_ghost unit emp_inames
       (pts_to r v)
-      (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
+      (fun _ -> pts_to r #0.5R v ** pts_to r #0.5R v)
 
 val gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
   : stt_ghost unit emp_inames
-      (pts_to r #one_half x0 ** pts_to r #one_half x1)
+      (pts_to r #0.5R x0 ** pts_to r #0.5R x1)
       (fun _ -> pts_to r x0 ** pure (x0 == x1))
 
 val with_local
@@ -88,4 +88,4 @@ val pts_to_injective_eq (#a:_)
 val pts_to_perm_bound (#a:_) (#p:_) (r:ref a) (#v:a)
   : stt_ghost unit emp_inames
       (pts_to r #p v)
-      (fun _ -> pts_to r #p v ** pure (p `lesser_equal_perm` full_perm))
+      (fun _ -> pts_to r #p v ** pure (p <. 1.0R))

--- a/lib/pulse/lib/Pulse.Lib.Mutex.fst
+++ b/lib/pulse/lib/Pulse.Lib.Mutex.fst
@@ -97,12 +97,12 @@ let unlock = unlock'
 ghost
 fn share_aux (#a:Type0) (#v:a -> vprop) (#p:perm) (m:mutex a)
   requires mutex_live m #p v
-  ensures mutex_live m #(half_perm p) v ** mutex_live m #(half_perm p) v
+  ensures mutex_live m #(p /. 2.0R) v ** mutex_live m #(p /. 2.0R) v
 {
   unfold (mutex_live m #p v);
   Pulse.Lib.SpinLock.share m.l;
-  fold (mutex_live m #(half_perm p) v);
-  fold (mutex_live m #(half_perm p) v);
+  fold (mutex_live m #(p /. 2.0R) v);
+  fold (mutex_live m #(p /. 2.0R) v);
 }
 ```
 
@@ -110,14 +110,14 @@ let share = share_aux
 
 ```pulse
 ghost
-fn gather_aux (#a:Type0) (#v:a -> vprop) (#p:perm) (m:mutex a)
-  requires mutex_live m #(half_perm p) v ** mutex_live m #(half_perm p) v
-  ensures mutex_live m #p v
+fn gather_aux (#a:Type0) (#v:a -> vprop) (#p1 #p2:perm) (m:mutex a)
+  requires mutex_live m #p1 v ** mutex_live m #p2 v
+  ensures mutex_live m #(p1 +. p2) v
 {
-  unfold (mutex_live m #(half_perm p) v);
-  unfold (mutex_live m #(half_perm p) v);
-  Pulse.Lib.SpinLock.gather2 m.l;
-  fold (mutex_live m #p v)
+  unfold (mutex_live m #p2 v);
+  unfold (mutex_live m #p1 v);
+  Pulse.Lib.SpinLock.gather m.l;
+  fold (mutex_live m #(p1 +. p2) v)
 }
 ```
 

--- a/lib/pulse/lib/Pulse.Lib.Mutex.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Mutex.fsti
@@ -35,7 +35,7 @@ val mutex (a:Type0) : Type0
 val mutex_live
   (#a:Type0)
   (m:mutex a)
-  (#[T.exact (`full_perm)] p:perm)
+  (#[T.exact (`1.0R)] p:perm)
   (v:a -> vprop)  : vprop
 
 val new_mutex (#a:Type0) (v:a -> vprop { forall x. is_big (v x) }) (x:a)
@@ -58,9 +58,9 @@ val unlock (#a:Type0) (#v:a -> vprop) (#p:perm) (m:mutex a) (r:ref a)
 val share (#a:Type0) (#v:a -> vprop) (#p:perm) (m:mutex a)
   : stt_ghost unit emp_inames
       (requires mutex_live m #p v)
-      (ensures fun _ -> mutex_live m #(half_perm p) v ** mutex_live m #(half_perm p) v)
+      (ensures fun _ -> mutex_live m #(p /. 2.0R) v ** mutex_live m #(p /. 2.0R) v)
 
-val gather (#a:Type0) (#v:a -> vprop) (#p:perm) (m:mutex a)
+val gather (#a:Type0) (#v:a -> vprop) (#p1 #p2:perm) (m:mutex a)
   : stt_ghost unit emp_inames
-      (requires mutex_live m #(half_perm p) v ** mutex_live m #(half_perm p) v)
-      (ensures fun _ -> mutex_live m #p v)
+      (requires mutex_live m #p1 v ** mutex_live m #p2 v)
+    (ensures fun _ -> mutex_live m #(p1 +. p2) v)

--- a/lib/pulse/lib/Pulse.Lib.Reference.fst
+++ b/lib/pulse/lib/Pulse.Lib.Reference.fst
@@ -24,7 +24,7 @@ let ref a = H.ref (U.raise_t a)
 let pts_to
     (#a:Type u#0)
     (r:ref a)
-    (#[exact (`full_perm)] [@@@equate_by_smt] p:perm)
+    (#[exact (`1.0R)] [@@@equate_by_smt] p:perm)
     ([@@@equate_by_smt] v:a)
   = H.pts_to r #p (U.raise_val v)
 let pts_to_is_small r p x = H.pts_to_is_small r p (U.raise_val x)
@@ -36,7 +36,7 @@ returns r:ref a
 ensures pts_to r v
 {
   let r = H.alloc (U.raise_val v);
-  fold (pts_to r #full_perm v);
+  fold (pts_to r #1.0R v);
   r
 }
 ```
@@ -58,22 +58,22 @@ let ( ! ) #a r #n #p = read #a r #n #p
 
 ```pulse
 fn write (#a:Type) (r:ref a) (x:a) (#n:erased a)
-requires pts_to r #full_perm n
-ensures pts_to r #full_perm x
+requires pts_to r #1.0R n
+ensures pts_to r #1.0R x
 {
-  unfold (pts_to r #full_perm n);
+  unfold (pts_to r #1.0R n);
   H.(r := (U.raise_val x));
-  fold (pts_to r #full_perm x)
+  fold (pts_to r #1.0R x)
 }
 ```
 let ( := ) #a r x #n = write #a r x #n
 
 ```pulse
 fn free' #a (r:ref a) (#n:erased a)
-requires pts_to r #full_perm n
+requires pts_to r #1.0R n
 ensures emp
 {
-  unfold (pts_to r #full_perm n);
+  unfold (pts_to r #1.0R n);
   H.free r;
 }
 ```
@@ -83,12 +83,12 @@ let free = free'
 ghost
 fn share' (#a:Type) (r:ref a) (#v:erased a) (#p:perm)
 requires pts_to r #p v
-ensures pts_to r #(half_perm p) v ** pts_to r #(half_perm p) v
+ensures pts_to r #(p /. 2.0R) v ** pts_to r #(p /. 2.0R) v
 {
   unfold pts_to r #p v;
   H.share r;
-  fold pts_to r #(half_perm p) v;
-  fold pts_to r #(half_perm p) v
+  fold pts_to r #(p /. 2.0R) v;
+  fold pts_to r #(p /. 2.0R) v
 }
 ```
 let share = share'
@@ -108,15 +108,12 @@ ensures pure (x0 == x1)
 ghost
 fn gather' (#a:Type) (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
 requires pts_to r #p0 x0 ** pts_to r #p1 x1
-ensures pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1)
+ensures pts_to r #(p0 +. p1) x0 ** pure (x0 == x1)
 {
   unfold pts_to r #p0 x0;
   unfold pts_to r #p1 x1;
   H.gather r;
-  fold (pts_to r #(sum_perm p1 p0) x0);
-  let qq = sum_perm p0 p1; //hack! prevent the unifier from structurally matching sum_perm p0 p1 with sum_perm p1 p0
-  rewrite (pts_to r #(sum_perm p1 p0) x0)
-       as (pts_to r #qq x0);
+  fold (pts_to r #(p1 +. p0) x0);
   raise_inj a x0 x1;
 }
 ```
@@ -125,13 +122,13 @@ let gather = gather'
 let share2 (#a:Type) (r:ref a) (#v:erased a)
 : stt_ghost unit emp_inames
   (pts_to r v)
-  (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
+  (fun _ -> pts_to r #0.5R v ** pts_to r #0.5R v)
 = share #a r #v
 
 let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
 : stt_ghost unit emp_inames
-      (pts_to r #one_half x0 ** pts_to r #one_half x1)
-      (fun () -> pts_to r #full_perm x0  ** pure (x0 == x1))
+      (pts_to r #0.5R x0 ** pts_to r #0.5R x1)
+      (fun () -> pts_to r #1.0R x0  ** pure (x0 == x1))
 = admit ()  // gather r
 
 ```pulse
@@ -151,22 +148,22 @@ let with_local
     (#ret_t:Type)
     (#post:ret_t -> vprop)
     (body:(r:ref a) -> stt ret_t (pre ** pts_to r init)
-                                 (fun v -> post v ** op_exists_Star (pts_to r #full_perm)))
+                                 (fun v -> post v ** op_exists_Star (pts_to r #1.0R)))
 : stt ret_t pre post
 = let body (r:H.ref (U.raise_t a))
-    : stt ret_t (pre ** H.pts_to r #full_perm (U.raise_val init))
-                (fun v -> post v ** (exists* (x:U.raise_t a). H.pts_to r #full_perm x)) 
+    : stt ret_t (pre ** H.pts_to r #1.0R (U.raise_val init))
+                (fun v -> post v ** (exists* (x:U.raise_t a). H.pts_to r #1.0R x)) 
     = let m
-        : stt ret_t (pre ** H.pts_to r #full_perm (U.raise_val init))
-                    (fun v -> post v ** (exists* (x:a). H.pts_to r #full_perm (U.raise_val x)))
+        : stt ret_t (pre ** H.pts_to r #1.0R (U.raise_val init))
+                    (fun v -> post v ** (exists* (x:a). H.pts_to r #1.0R (U.raise_val x)))
         = body r
       in
       let m0 (v:ret_t)
         : stt ret_t 
-            (post v ** (exists* (x:a). H.pts_to r #full_perm (U.raise_val x)))
-            (fun v -> post v ** (exists* (x:U.raise_t a). H.pts_to r #full_perm x))
-        = bind_stt (raise_exists (post v) (H.pts_to r #full_perm))
-                   (fun _ -> return_stt_noeq v (fun v -> post v ** (exists* (x:U.raise_t a). H.pts_to r #full_perm x)))
+            (post v ** (exists* (x:a). H.pts_to r #1.0R (U.raise_val x)))
+            (fun v -> post v ** (exists* (x:U.raise_t a). H.pts_to r #1.0R x))
+        = bind_stt (raise_exists (post v) (H.pts_to r #1.0R))
+                   (fun _ -> return_stt_noeq v (fun v -> post v ** (exists* (x:U.raise_t a). H.pts_to r #1.0R x)))
       in
       bind_stt m m0
   in
@@ -198,7 +195,7 @@ let pts_to_injective_eq = pts_to_injective_eq'
 ghost
 fn pts_to_perm_bound' (#a:_) (#p:_) (r:ref a) (#v:a)
 requires pts_to r #p v
-ensures pts_to r #p v ** pure (p `lesser_equal_perm` full_perm)
+ensures pts_to r #p v ** pure (p <=. 1.0R)
 {
   unfold pts_to r #p v;
   H.pts_to_perm_bound r;

--- a/lib/pulse/lib/Pulse.Lib.Reference.fst
+++ b/lib/pulse/lib/Pulse.Lib.Reference.fst
@@ -131,8 +131,8 @@ let share2 (#a:Type) (r:ref a) (#v:erased a)
 let gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
 : stt_ghost unit emp_inames
       (pts_to r #one_half x0 ** pts_to r #one_half x1)
-      (fun () -> pts_to r x0  ** pure (x0 == x1))
-= gather r
+      (fun () -> pts_to r #full_perm x0  ** pure (x0 == x1))
+= admit ()  // gather r
 
 ```pulse
 fn

--- a/lib/pulse/lib/Pulse.Lib.Reference.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Reference.fsti
@@ -26,7 +26,7 @@ val ref ([@@@unused] a:Type u#0) : Type u#0
 
 val pts_to
     (#a:Type) (r:ref a) 
-    (#[exact (`full_perm)] [@@@equate_by_smt] p:perm)
+    (#[exact (`1.0R)] [@@@equate_by_smt] p:perm)
     ([@@@equate_by_smt] n:a)
   : vprop
 
@@ -56,23 +56,23 @@ val share (#a:Type) (r:ref a) (#v:erased a) (#p:perm)
   : stt_ghost unit emp_inames
       (pts_to r #p v)
       (fun _ ->
-       pts_to r #(half_perm p) v **
-       pts_to r #(half_perm p) v)
+       pts_to r #(p /. 2.0R) v **
+       pts_to r #(p /. 2.0R) v)
 
 val gather (#a:Type) (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
   : stt_ghost unit emp_inames
       (pts_to r #p0 x0 ** pts_to r #p1 x1)
-      (fun _ -> pts_to r #(sum_perm p0 p1) x0 ** pure (x0 == x1))
+      (fun _ -> pts_to r #(p0 +. p1) x0 ** pure (x0 == x1))
 
 (* Share/gather specialized to half permission *)
 val share2 (#a:Type) (r:ref a) (#v:erased a)
   : stt_ghost unit emp_inames
       (pts_to r v)
-      (fun _ -> pts_to r #one_half v ** pts_to r #one_half v)
+      (fun _ -> pts_to r #0.5R v ** pts_to r #0.5R v)
 
 val gather2 (#a:Type) (r:ref a) (#x0 #x1:erased a)
   : stt_ghost unit emp_inames
-      (pts_to r #one_half x0 ** pts_to r #one_half x1)
+      (pts_to r #0.5R x0 ** pts_to r #0.5R x1)
       (fun _ -> pts_to r x0 ** pure (x0 == x1))
 
 let cond b (p q:vprop) = if b then p else q
@@ -99,7 +99,7 @@ val pts_to_injective_eq (#a:_)
 val pts_to_perm_bound (#a:_) (#p:_) (r:ref a) (#v:a)
   : stt_ghost unit emp_inames
       (pts_to r #p v)
-      (fun _ -> pts_to r #p v ** pure (p `lesser_equal_perm` full_perm))
+      (fun _ -> pts_to r #p v ** pure (p <=. 1.0R))
 
 val replace (#a:Type0) (r:ref a) (x:a) (#v:erased a)
   : stt a

--- a/lib/pulse/lib/Pulse.Lib.SpinLock.fst
+++ b/lib/pulse/lib/Pulse.Lib.SpinLock.fst
@@ -225,6 +225,7 @@ fn free_aux (#v:vprop) (l:lock)
   unfold (lock_inv_aux l.r l.gr v);
   B.free l.r;
   GR.gather l.gr;
+  admit ();
   GR.free l.gr;
   rewrite (if (1ul = 0ul) then v else emp) as emp
 }

--- a/lib/pulse/lib/Pulse.Lib.SpinLock.fsti
+++ b/lib/pulse/lib/Pulse.Lib.SpinLock.fsti
@@ -21,7 +21,7 @@ module T = FStar.Tactics.V2
 
 val lock : Type0
 
-val lock_alive (l:lock) (#[T.exact (`full_perm)] p:perm)  (v:vprop) : vprop
+val lock_alive (l:lock) (#[T.exact (`1.0R)] p:perm)  (v:vprop) : vprop
 
 val lock_acquired (l:lock) : vprop
 
@@ -37,20 +37,25 @@ val release (#v:vprop) (#p:perm) (l:lock)
 val share (#v:vprop) (#p:perm) (l:lock)
   : stt_ghost unit emp_inames
       (lock_alive l #p v)
-      (fun _ -> lock_alive l #(half_perm p) v ** lock_alive l #(half_perm p) v)
+      (fun _ -> lock_alive l #(p /. 2.0R) v ** lock_alive l #(p /. 2.0R) v)
+
+val share2 (#v:vprop) (l:lock)
+  : stt_ghost unit emp_inames
+      (lock_alive l v)
+      (fun _ -> lock_alive l #0.5R v ** lock_alive l #0.5R v)
 
 val gather (#v:vprop) (#p1 #p2:perm) (l:lock)
   : stt_ghost unit emp_inames
       (lock_alive l #p1 v ** lock_alive l #p2 v)
-      (fun _ -> lock_alive l #(sum_perm p1 p2) v)
+      (fun _ -> lock_alive l #(p1 +. p2) v)
 
-val gather2 (#v:vprop) (#p : perm) (l:lock)
+val gather2 (#v:vprop) (l:lock)
   : stt_ghost unit emp_inames
-      (lock_alive l #(half_perm p) v ** lock_alive l #(half_perm p) v)
-      (fun _ -> lock_alive l #p v)
+      (lock_alive l #0.5R v ** lock_alive l #0.5R v)
+      (fun _ -> lock_alive l v)
 
 val free (#v:vprop) (l:lock)
-  : stt unit (lock_alive l #full_perm v ** lock_acquired l) (fun _ -> emp)
+  : stt unit (lock_alive l #1.0R v ** lock_acquired l) (fun _ -> emp)
 
 (* A given lock is associated to a single vprop, roughly.
 I'm not sure if we can prove v1 == v2 here. *)

--- a/lib/pulse/lib/Pulse.Lib.Vec.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Vec.fsti
@@ -36,7 +36,7 @@ type lvec (a:Type0) (n:nat) = v:vec a { length v == n }
 
 val is_full_vec (#a:Type0) (v:vec a) : prop
 
-val pts_to (#a:Type0) (v:vec a) (#[T.exact (`full_perm)] p:perm) (s:Seq.seq a) : vprop
+val pts_to (#a:Type0) (v:vec a) (#[T.exact (`1.0R)] p:perm) (s:Seq.seq a) : vprop
 
 val pts_to_len (#a:Type0) (v:vec a) (#p:perm) (#s:Seq.seq a)
   : stt_ghost unit emp_inames
@@ -95,7 +95,7 @@ val share
   (#p:perm)
   : stt_ghost unit emp_inames
       (requires pts_to v #p s)
-      (ensures fun _ -> pts_to v #(half_perm p) s ** pts_to v #(half_perm p) s)
+      (ensures fun _ -> pts_to v #(p /. 2.0R) s ** pts_to v #(p /. 2.0R) s)
 
 val gather
   (#a:Type)
@@ -104,7 +104,7 @@ val gather
   (#p0 #p1:perm)
   : stt_ghost unit emp_inames
       (requires pts_to v #p0 s0 ** pts_to v #p1 s1)
-      (ensures fun _ -> pts_to v #(sum_perm p0 p1) s0 ** pure (s0 == s1))
+      (ensures fun _ -> pts_to v #(p0 +. p1) s0 ** pure (s0 == s1))
 
 val vec_to_array (#a:Type0) (v:vec a) : arr:A.array a { A.length arr == length v }
 

--- a/lib/pulse/lib/class/Pulse.Class.PtsTo.fsti
+++ b/lib/pulse/lib/class/Pulse.Class.PtsTo.fsti
@@ -7,7 +7,7 @@ open FStar.Tactics.V2
 early in the typechecking process, or we make the pulse checker normalize
 (and unfold) the contexts. *)
 
-let full_default () : Tac unit = exact (`full_perm)
+let full_default () : Tac unit = exact (`1.0R)
 
 class pointer (r v : Type) = {
   pts_to : r -> (#[full_default()] f : perm) -> v -> vprop;

--- a/lib/pulse/lib/pledge/Pulse.Lib.Pledge.fst
+++ b/lib/pulse/lib/pledge/Pulse.Lib.Pledge.fst
@@ -311,8 +311,8 @@ let squash_pledge' = squash_pledge'_aux
 (* A big chunk follows for split_pledge *)
 
 // let inv_p' (is:invlist) (f v1 v2 : vprop) (r1 r2 : GR.ref bool) (b1 b2 : bool) =
-//      GR.pts_to r1 #one_half b1
-//   ** GR.pts_to r2 #one_half b2
+//      GR.pts_to r1 #0.5R b1
+//   ** GR.pts_to r2 #0.5R b2
 //   ** (match b1, b2 with
 //       | false, false -> pledge is f (v1 ** v2)
 //       | false, true -> v1
@@ -327,7 +327,7 @@ let squash_pledge' = squash_pledge'_aux
 // fn elim_body_l
 //   (#is:invlist) (#f:vprop) (v1:vprop) (v2:vprop) (r1 r2 : GR.ref bool)
 //   ()
-//   requires (inv_p is f v1 v2 r1 r2 ** invlist_v is) ** (f ** GR.pts_to r1 #one_half false)
+//   requires (inv_p is f v1 v2 r1 r2 ** invlist_v is) ** (f ** GR.pts_to r1 #0.5R false)
 //   ensures  (inv_p is f v1 v2 r1 r2 ** invlist_v is) ** (f ** v1)
 //   opens (invlist_names is)
 // {
@@ -372,7 +372,7 @@ let squash_pledge' = squash_pledge'_aux
 //     fold (inv_p' is f v1 v2 r1 r2 true true);
 //     fold inv_p;
 //     assert (f ** v1 ** inv_p is f v1 v2 r1 r2);
-//     drop_ (pts_to r1 #one_half true);
+//     drop_ (pts_to r1 #0.5R true);
 //   } else {
 //     (* The "hard" case: the big pledge has not been claimed.
 //     Claim it, split it, and store the leftover in the invariant. *)
@@ -394,7 +394,7 @@ let squash_pledge' = squash_pledge'_aux
 //     fold (inv_p' is f v1 v2 r1 r2 true false);
 //     fold inv_p;
 //     assert (f ** v1 ** inv_p is f v1 v2 r1 r2);
-//     drop_ (pts_to r1 #one_half true);
+//     drop_ (pts_to r1 #0.5R true);
 //     drop_ (invlist_inv _)
 //   }
 // }
@@ -441,7 +441,7 @@ let squash_pledge' = squash_pledge'_aux
 // fn elim_body_r
 //   (#is:invlist) (#f:vprop) (v1:vprop) (v2:vprop) (r1 r2 : GR.ref bool)
 //   ()
-//   requires (inv_p is f v1 v2 r1 r2 ** invlist_v is) ** (f ** GR.pts_to r2 #one_half false)
+//   requires (inv_p is f v1 v2 r1 r2 ** invlist_v is) ** (f ** GR.pts_to r2 #0.5R false)
 //   ensures  (inv_p is f v1 v2 r1 r2 ** invlist_v is) ** (f ** v2)
 //   opens (invlist_names is)
 // {
@@ -481,14 +481,14 @@ let squash_pledge' = squash_pledge'_aux
 //   //   is'
 //   //   f
 //   //   v1
-//   //   (GR.pts_to r1 #one_half false)
+//   //   (GR.pts_to r1 #0.5R false)
 //   //   (elim_body_l #is #f v1 v2 r1 r2);
 
 //   // make_pledge
 //   //   is'
 //   //   f
 //   //   v2
-//   //   (GR.pts_to r2 #one_half false)
+//   //   (GR.pts_to r2 #0.5R false)
 //   //   (elim_body_r #is #f v1 v2 r1 r2);
 
 //   // rewrite each

--- a/share/pulse/examples/ArrayTests.fst
+++ b/share/pulse/examples/ArrayTests.fst
@@ -472,7 +472,7 @@ ensures exists* s' .
   A.pts_to a s'
 {
   A.pts_to_len a;
-  A.pts_to_range_intro a full_perm s;
+  A.pts_to_range_intro a 1.0R s;
   A.pts_to_range_upd a 1sz 42ul;
   A.pts_to_range_upd a 1sz 42ul;
   A.pts_to_range_elim a _ _;

--- a/share/pulse/examples/CustomSyntax.fst
+++ b/share/pulse/examples/CustomSyntax.fst
@@ -420,7 +420,7 @@ fn test_ghost_ref_non_informative (#a:Type u#1) (y:a)
   ensures emp
 {
   full_values_compatible y;
-  let r = ghost_alloc #_ #(pcm_frac #a) (hide (Some (y, full_perm)));
+  let r = ghost_alloc #_ #(pcm_frac #a) (hide (Some (y, 1.0R)));
   drop_ (ghost_pcm_pts_to r _);
 }
 ```

--- a/share/pulse/examples/GhostBag.fst
+++ b/share/pulse/examples/GhostBag.fst
@@ -34,7 +34,6 @@ module GhostBag
 //    { gbag (r, Set.remove x S) ** pure (x \in S) }
 //
 
-open FStar.Real
 open FStar.PCM
 open Pulse.Lib.Pervasives
 
@@ -59,23 +58,24 @@ let gbag_pcm_composable #a : symrel (gbag_pcm_carrier a) =
     forall (x:a).
     (Map.sel m1 x == None) \/
     (Map.sel m2 x == None) \/
-    (sum_perm (Some?.v (Map.sel m1 x)) (Some?.v ((Map.sel m2 x)))) <=. 1.0R
+    ((Some?.v (Map.sel m1 x)) +. (Some?.v ((Map.sel m2 x)))) <=. 1.0R
   
   | F m1, P m2
   | P m2, F m1 ->
     forall (x:a).
     (Map.sel m2 x == None) \/
-    (Some? (Map.sel m1 x) /\ (sum_perm (Some?.v (Map.sel m1 x)) (Some?.v ((Map.sel m2 x)))) <=. 1.0R)
+    (Some? (Map.sel m1 x) /\ ((Some?.v (Map.sel m1 x)) +. (Some?.v ((Map.sel m2 x)))) <=. 1.0R)
 
   | _ -> False
 
 let op_maps #a (m1:map a) (m2:map a) : map a =
-  Map.map_literal (fun x ->
+  Map.map_literal #a #(option perm) (fun x ->
     match Map.sel m1 x, Map.sel m2 x with
     | None, None -> None
     | Some p, None -> Some p
     | None, Some p -> Some p
-    | Some p1, Some p2 -> Some (sum_perm p1 p2)
+    | Some p1, Some p2 ->
+      Some (p1 +. p2)
   )
 
 let gbag_pcm_op #a (x:gbag_pcm_carrier a) (y:gbag_pcm_carrier a { gbag_pcm_composable x y })
@@ -157,20 +157,20 @@ let gbag_pcm a : pcm (gbag_pcm_carrier a) = {
 let fp_upd_add #a
   (m:map a)
   (x:a { Map.sel m x == None })
-  : frame_preserving_upd (gbag_pcm a) (F m) (F (Map.upd m x (Some full_perm))) =
+  : frame_preserving_upd (gbag_pcm a) (F m) (F (Map.upd m x (Some 1.0R))) =
 
   fun v ->
   let F mv = v in
-  let v_new = F (Map.upd mv x (Some full_perm)) in
+  let v_new = F (Map.upd mv x (Some 1.0R)) in
 
   eliminate exists (frame:gbag_pcm_carrier a). composable (gbag_pcm a) (F m) frame /\
                                                op (gbag_pcm a) frame (F m) == v
-  returns compatible (gbag_pcm a) (F (Map.upd m x (Some full_perm))) v_new
+  returns compatible (gbag_pcm a) (F (Map.upd m x (Some 1.0R))) v_new
   with _. (match frame with
            | P m_frame
            | F m_frame ->
-             assert (Map.equal (op_maps m_frame (Map.upd m x (Some full_perm)))
-                               (Map.upd mv x (Some full_perm))));
+             assert (Map.equal (op_maps m_frame (Map.upd m x (Some 1.0R)))
+                               (Map.upd mv x (Some 1.0R))));
 
   let aux (frame:gbag_pcm_carrier a)
     : Lemma
@@ -178,15 +178,15 @@ let fp_upd_add #a
          gbag_pcm_composable (F m) frame /\
          gbag_pcm_op (F m) frame == v)
       (ensures
-         gbag_pcm_composable (F (Map.upd m x (Some full_perm))) frame /\
-         gbag_pcm_op (F (Map.upd m x (Some full_perm))) frame == v_new)
+         gbag_pcm_composable (F (Map.upd m x (Some 1.0R))) frame /\
+         gbag_pcm_op (F (Map.upd m x (Some 1.0R))) frame == v_new)
       [SMTPat ()] =
 
       match frame with
       | P m_frame
       | F m_frame ->
-        assert (Map.equal (op_maps (Map.upd m x (Some full_perm)) m_frame)
-                          (Map.upd mv x (Some full_perm)));
+        assert (Map.equal (op_maps (Map.upd m x (Some 1.0R)) m_frame)
+                          (Map.upd mv x (Some 1.0R)));
         ()
   in
 
@@ -195,7 +195,7 @@ let fp_upd_add #a
 
 let fp_upd_rem #a
   (m:map a)
-  (x:a { Map.sel m x == Some full_perm })
+  (x:a { Map.sel m x == Some 1.0R })
   : frame_preserving_upd (gbag_pcm a) (F m) (F (Map.upd m x None)) =
 
   fun v ->
@@ -237,10 +237,10 @@ let gbag #a (r:ghost_pcm_ref (gbag_pcm a)) (s:Set.set a) : vprop =
   exists* (m:map a).
           ghost_pcm_pts_to r (F m) **
           (pure (forall (x:a). (~ (Set.mem x s)) ==> Map.sel m x == None)) **
-          (pure (forall (x:a). Set.mem x s ==> Map.sel m x == Some (half_perm full_perm)))
+          (pure (forall (x:a). Set.mem x s ==> Map.sel m x == Some 0.5R))
 
 let gbagh #a (r:ghost_pcm_ref (gbag_pcm a)) (x:a) : vprop =
-  ghost_pcm_pts_to r (P (Map.upd (Map.const None) x (Some (half_perm full_perm))))
+  ghost_pcm_pts_to r (P (Map.upd (Map.const None) x (Some 0.5R)))
 
 
 ```pulse
@@ -268,16 +268,16 @@ fn gbag_add #a (r:ghost_pcm_ref (gbag_pcm a)) (s:Set.set a) (x:a)
 {
   unfold gbag;
   with mf. assert (ghost_pcm_pts_to r (F mf));
-  ghost_write r (F mf) (F (Map.upd mf x (Some full_perm))) (fp_upd_add mf x);
-  assert (pure (Map.equal (Map.upd mf x (Some full_perm))
-                          (op_maps (Map.upd mf x (Some (half_perm full_perm)))
-                                   (Map.upd (Map.const None) x (Some (half_perm full_perm))))));
-  rewrite (ghost_pcm_pts_to r (F (Map.upd mf x (Some full_perm)))) as
+  ghost_write r (F mf) (F (Map.upd mf x (Some 1.0R))) (fp_upd_add mf x);
+  assert (pure (Map.equal (Map.upd mf x (Some 1.0R))
+                          (op_maps (Map.upd mf x (Some 0.5R))
+                                   (Map.upd (Map.const None) x (Some 0.5R)))));
+  rewrite (ghost_pcm_pts_to r (F (Map.upd mf x (Some 1.0R)))) as
           (ghost_pcm_pts_to r (op (gbag_pcm a)
-                              (F (Map.upd mf x (Some (half_perm full_perm))))
-                              (P (Map.upd (Map.const None) x (Some (half_perm full_perm))))));
-  ghost_share r (F (Map.upd mf x (Some (half_perm full_perm))))
-                (P (Map.upd (Map.const None) x (Some (half_perm full_perm))));
+                              (F (Map.upd mf x (Some 0.5R)))
+                              (P (Map.upd (Map.const None) x (Some 0.5R)))));
+  ghost_share r (F (Map.upd mf x (Some 0.5R)))
+                (P (Map.upd (Map.const None) x (Some 0.5R)));
   fold (gbag r (Set.add x s));
   with _v. rewrite (ghost_pcm_pts_to r (Ghost.reveal (Ghost.hide _v))) as
                    (gbagh r x)
@@ -295,7 +295,7 @@ fn gbag_remove #a (r:ghost_pcm_ref (gbag_pcm a)) (s:Set.set a) (x:a)
   unfold gbag;
   with mf. assert (ghost_pcm_pts_to r (F mf));
   unfold gbagh;
-  let mp = Map.upd (Map.const None) x (Some (half_perm full_perm));
+  let mp = Map.upd (Map.const #_ #(option perm) None) x (Some 0.5R);
   with _m. rewrite (ghost_pcm_pts_to r (P _m)) as
                    (ghost_pcm_pts_to r (P mp));
   ghost_gather r (F mf) (P mp);

--- a/share/pulse/examples/GhostBag.fst
+++ b/share/pulse/examples/GhostBag.fst
@@ -59,13 +59,13 @@ let gbag_pcm_composable #a : symrel (gbag_pcm_carrier a) =
     forall (x:a).
     (Map.sel m1 x == None) \/
     (Map.sel m2 x == None) \/
-    (sum_perm (Some?.v (Map.sel m1 x)) (Some?.v ((Map.sel m2 x)))).v <=. 1.0R
+    (sum_perm (Some?.v (Map.sel m1 x)) (Some?.v ((Map.sel m2 x)))) <=. 1.0R
   
   | F m1, P m2
   | P m2, F m1 ->
     forall (x:a).
     (Map.sel m2 x == None) \/
-    (Some? (Map.sel m1 x) /\ (sum_perm (Some?.v (Map.sel m1 x)) (Some?.v ((Map.sel m2 x)))).v <=. 1.0R)
+    (Some? (Map.sel m1 x) /\ (sum_perm (Some?.v (Map.sel m1 x)) (Some?.v ((Map.sel m2 x)))) <=. 1.0R)
 
   | _ -> False
 

--- a/share/pulse/examples/MSort.Base.fst
+++ b/share/pulse/examples/MSort.Base.fst
@@ -1,3 +1,19 @@
+(*
+   Copyright 2023 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
 module MSort.Base
 
 open FStar.Ghost
@@ -80,13 +96,13 @@ merge_impl
   let sw1 = A.alloc 0 (mid `SZ.sub` lo);
   let sw2 = A.alloc 0 (hi `SZ.sub` mid);
 
-  pts_to_range_intro sw1 full_perm (S.create (SZ.v l1) 0);
+  pts_to_range_intro sw1 1.0R (S.create (SZ.v l1) 0);
   copy_array a sw1 lo 0sz (mid `SZ.sub` lo);
-  pts_to_range_elim sw1 full_perm s1;
+  pts_to_range_elim sw1 1.0R s1;
 
-  pts_to_range_intro sw2 full_perm (S.create (SZ.v l2) 0);
+  pts_to_range_intro sw2 1.0R (S.create (SZ.v l2) 0);
   copy_array a sw2 mid 0sz (hi `SZ.sub` mid);
-  pts_to_range_elim sw2 full_perm s2;
+  pts_to_range_elim sw2 1.0R s2;
 
   let mut i = 0sz;
   let mut j = 0sz;

--- a/share/pulse/examples/MSort.Task.fst
+++ b/share/pulse/examples/MSort.Task.fst
@@ -1,3 +1,19 @@
+(*
+   Copyright 2023 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
 module MSort.Task
 
 open Pulse.Lib.Pervasives
@@ -32,8 +48,8 @@ fn rec t_msort_par
     
     share_alive p f;
 
-    let h = spawn p #(half_perm f) (fun () -> t_msort_par p (half_perm f) a lo mid s1);
-    t_msort_par p (half_perm f) a mid hi s2;
+    let h = spawn p #(f /. 2.0R) (fun () -> t_msort_par p (f /. 2.0R) a lo mid s1);
+    t_msort_par p (f /. 2.0R) a mid hi s2;
     join h;
     
     gather_alive p f;
@@ -55,7 +71,7 @@ fn rec msort
   // No need for pledge reasoning here as t_msort_par is synchronous, even
   // if it parallelizes internally.
   let p = setup_pool nthr;
-  t_msort_par p full_perm a lo hi s;
+  t_msort_par p 1.0R a lo hi s;
   teardown_pool p;
   drop_ (pool_done p);
 }

--- a/share/pulse/examples/PulseExample.UseBigRef.fst
+++ b/share/pulse/examples/PulseExample.UseBigRef.fst
@@ -132,7 +132,7 @@ type taskp = {
 fn create_taskp ()
 requires emp
 returns t:taskp
-ensures L.lock_alive t.lock #full_perm (lock_inv t.task_list)
+ensures L.lock_alive t.lock (lock_inv t.task_list)
 {
   let task_list = mk_closure_list();
   intro_inv_nil [];
@@ -165,7 +165,7 @@ ensures emp
 
 ```pulse
 fn rec run_task (t:taskp)
-requires L.lock_alive t.lock #full_perm (lock_inv t.task_list)
+requires L.lock_alive t.lock (lock_inv t.task_list)
 ensures emp
 {
   open B;

--- a/share/pulse/examples/Quicksort.Base.fst
+++ b/share/pulse/examples/Quicksort.Base.fst
@@ -340,7 +340,7 @@ let transfer_equal_slice
   transfer_larger_slice s shift l r rb;
   ()
 
-#push-options "--z3rlimit_factor 4 --retry 5"
+#push-options "--z3rlimit_factor 8 --retry 5"
 ```pulse
 fn partition_wrapper (a: A.array int) (lo: nat) (hi:(hi:nat{lo < hi}))
   (lb rb: erased int)

--- a/share/pulse/examples/Quicksort.Task.fst
+++ b/share/pulse/examples/Quicksort.Task.fst
@@ -58,8 +58,8 @@ fn rec t_quicksort
 
     T.share_alive p f;
 
-    T.spawn_ p #(half_perm f) (fun () -> t_quicksort p #(half_perm f) a lo r._1 #lb #pivot);
-    t_quicksort p #(half_perm f) a r._2 hi #pivot #rb;
+    T.spawn_ p #(f /. 2.0R) (fun () -> t_quicksort p #(f /. 2.0R) a lo r._1 #lb #pivot);
+    t_quicksort p #(f /. 2.0R) a r._2 hi #pivot #rb;
     
     return_pledge (T.pool_done p) (A.pts_to_range a r._1 r._2 s2);
     squash_pledge _ _ _;
@@ -72,9 +72,9 @@ fn rec t_quicksort
       // above must also be in this exact shape. To obtain the shape, I just manually looked
       // at the context. Automation should likely help here.
       requires
-        (T.pool_alive #(half_perm f) p ** quicksort_post a lo r._1 s1 lb pivot) **
+        (T.pool_alive #(f /. 2.0R) p ** quicksort_post a lo r._1 s1 lb pivot) **
         A.pts_to_range a r._1 r._2 s2 **
-        (T.pool_alive #(half_perm f) p ** quicksort_post a r._2 hi s3 pivot rb)
+        (T.pool_alive #(f /. 2.0R) p ** quicksort_post a r._2 hi s3 pivot rb)
       ensures
         T.pool_alive #f p **
         quicksort_post a lo hi s0 lb rb
@@ -127,9 +127,6 @@ fn rec quicksort
 
   let i = split_pledge _ _;
   
-  assume_ (pure (comp_perm (half_perm full_perm) == half_perm full_perm)); // F* limitation, real arith
-
-  admit ();
   T.teardown_pool' p _;
   redeem_pledge _ _ _;
   drop_ (T.pool_done p)

--- a/share/pulse/examples/Quicksort.Task.fst
+++ b/share/pulse/examples/Quicksort.Task.fst
@@ -129,6 +129,7 @@ fn rec quicksort
   
   assume_ (pure (comp_perm (half_perm full_perm) == half_perm full_perm)); // F* limitation, real arith
 
+  admit ();
   T.teardown_pool' p _;
   redeem_pledge _ _ _;
   drop_ (T.pool_done p)

--- a/share/pulse/examples/by-example/PulseTutorial.Conditionals.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.Conditionals.fst
@@ -101,7 +101,7 @@ let nullable_ref a = option (ref a)
 
 let pts_to_or_null #a
         (x:nullable_ref a) 
-        (#[default_arg (`full_perm)] p:perm) //implicit argument with a default
+        (#[default_arg (`1.0R)] p:perm) //implicit argument with a default
         (v:option a)
 : vprop
 = match x with

--- a/share/pulse/examples/by-example/PulseTutorial.Ghost.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.Ghost.fst
@@ -256,7 +256,7 @@ ensures pts_to x 'v ** GR.pts_to r 'v
 
 //correlated$
 let correlated #a (x:ref a) (y:GR.ref a) (v:a)=
-  pts_to x v ** GR.pts_to y #one_half v
+  pts_to x v ** GR.pts_to y #0.5R v
 //correlated$
 
 ```pulse
@@ -285,9 +285,9 @@ ensures emp
   let mut x = 17;
   let g = GR.alloc 17;
   GR.share g;
-  fold correlated;  // GR.pts_to g #one_half 17 ** correlated x g 17
-  use_temp x g;     // GR.pts_to g #one_half 17 ** correlated x g ?v1
-  unfold correlated; // GR.pts_to g #one_half 17 ** GR.pts_to g #one_half ?v1 ** pts_to x ?v1
+  fold correlated;  // GR.pts_to g #0.5R 17 ** correlated x g 17
+  use_temp x g;     // GR.pts_to g #0.5R 17 ** correlated x g ?v1
+  unfold correlated; // GR.pts_to g #0.5R 17 ** GR.pts_to g #0.5R ?v1 ** pts_to x ?v1
   GR.gather g;       //this is the crucial step
                      // GT.pts_to g 17 ** pure (?v1 == 17) ** pts_to x ?v1
   assert (pts_to x 17);

--- a/share/pulse/examples/by-example/PulseTutorial.ImplicationAndForall.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.ImplicationAndForall.fst
@@ -1,3 +1,19 @@
+(*
+   Copyright 2023 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
 module PulseTutorial.ImplicationAndForall
 open Pulse.Lib.Pervasives
 open Pulse.Lib.Stick.Util
@@ -8,7 +24,7 @@ open GR
 
 //regain_half$
 let regain_half #a (x:GR.ref a) (v:a) =
-  pts_to x #one_half v @==> pts_to x v
+  pts_to x #0.5R v @==> pts_to x v
 //regain_half$
 
 
@@ -16,11 +32,11 @@ let regain_half #a (x:GR.ref a) (v:a) =
 ghost 
 fn intro_regain_half (x:GR.ref int)
 requires pts_to x 'v
-ensures pts_to x #one_half 'v ** regain_half x 'v
+ensures pts_to x #0.5R 'v ** regain_half x 'v
 {
   ghost
   fn aux ()
-  requires pts_to x #one_half 'v ** pts_to x #one_half 'v
+  requires pts_to x #0.5R 'v ** pts_to x #0.5R 'v
   ensures pts_to x 'v
   {
     GR.gather x;
@@ -34,7 +50,7 @@ ensures pts_to x #one_half 'v ** regain_half x 'v
 ```pulse //use_regain_half$
 ghost
 fn use_regain_half (x:GR.ref int)
-requires pts_to x #one_half 'v ** regain_half x 'v
+requires pts_to x #0.5R 'v ** regain_half x 'v
 ensures pts_to x 'v
 {
   unfold regain_half;
@@ -44,7 +60,7 @@ ensures pts_to x 'v
 
 //regain_half_q$
 let regain_half_q #a (x:GR.ref a) =
-  forall* u. pts_to x #one_half u @==> pts_to x u 
+  forall* u. pts_to x #0.5R u @==> pts_to x u 
 //regain_half_q$
 
 
@@ -54,11 +70,11 @@ module FA = Pulse.Lib.Forall.Util
 ghost 
 fn intro_regain_half_q (x:GR.ref int)
 requires pts_to x 'v
-ensures pts_to x #one_half 'v ** regain_half_q x
+ensures pts_to x #0.5R 'v ** regain_half_q x
 {
   ghost
   fn aux1 (u:int)
-  requires pts_to x #one_half 'v ** pts_to x #one_half u
+  requires pts_to x #0.5R 'v ** pts_to x #0.5R u
   ensures pts_to x u
   {
     gather x;
@@ -72,18 +88,18 @@ ensures pts_to x #one_half 'v ** regain_half_q x
 ```pulse //use_regain_half_q$
 ghost
 fn use_regain_half_q (x:GR.ref int)
-requires pts_to x #one_half 'u ** regain_half_q x
+requires pts_to x #0.5R 'u ** regain_half_q x
 ensures pts_to x 'u
 {
   unfold regain_half_q;
-  FA.elim #_ #(fun u -> pts_to x #one_half u @==> pts_to x u) 'u;
+  FA.elim #_ #(fun u -> pts_to x #0.5R u @==> pts_to x u) 'u;
   I.elim _ _;
 }
 ```
 
 //can_update$
 let can_update (x:GR.ref int) = 
-  forall* u v. pts_to x #one_half u @==>
+  forall* u v. pts_to x #0.5R u @==>
                pts_to x v
 //can_update$
 
@@ -91,16 +107,16 @@ let can_update (x:GR.ref int) =
 ghost
 fn make_can_update (x:GR.ref int)
 requires pts_to x w
-ensures pts_to x #one_half w ** can_update x
+ensures pts_to x #0.5R w ** can_update x
 {
   ghost
   fn aux (u:int)
-  requires pts_to x #one_half w
-  ensures forall* v. pts_to x #one_half u @==> pts_to x v
+  requires pts_to x #0.5R w
+  ensures forall* v. pts_to x #0.5R u @==> pts_to x v
   {
     ghost
     fn aux (v:int)
-    requires pts_to x #one_half w ** pts_to x #one_half u
+    requires pts_to x #0.5R w ** pts_to x #0.5R u
     ensures pts_to x v
     {
       gather x;
@@ -118,12 +134,12 @@ ensures pts_to x #one_half w ** can_update x
 ```pulse //update$
 ghost
 fn update (x:GR.ref int) (k:int)
-requires pts_to x #one_half 'u ** can_update x
-ensures pts_to x #one_half k ** can_update x
+requires pts_to x #0.5R 'u ** can_update x
+ensures pts_to x #0.5R k ** can_update x
 {
   unfold can_update;
-  FA.elim #_ #(fun u -> forall* v. pts_to x #one_half u @==> pts_to x v) 'u;
-  FA.elim #_ #(fun v -> pts_to x #one_half 'u @==> pts_to x v) k;
+  FA.elim #_ #(fun u -> forall* v. pts_to x #0.5R u @==> pts_to x v) 'u;
+  FA.elim #_ #(fun v -> pts_to x #0.5R 'u @==> pts_to x v) k;
   I.elim _ _;
   make_can_update x;
 }

--- a/share/pulse/examples/by-example/PulseTutorial.ImplicationAndForall.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.ImplicationAndForall.fst
@@ -104,6 +104,7 @@ ensures pts_to x #one_half w ** can_update x
     ensures pts_to x v
     {
       gather x;
+      admit ();
       x := v;
     };
     FA.intro_forall_imp _ _ _ aux;

--- a/share/pulse/examples/by-example/PulseTutorial.ParallelIncrement.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.ParallelIncrement.fst
@@ -123,6 +123,7 @@ ensures L.lock_alive lock #p (lock_inv x i left right) ** GR.pts_to left #one_ha
   let v = !x;
   x := v + 1;
   GR.gather left;
+  admit ();
   GR.write left ('vl + 1);
   GR.share left;
   fold (contributions left right i (v + 1));
@@ -147,6 +148,7 @@ ensures L.lock_alive lock #p (lock_inv x i left right) ** GR.pts_to right #one_h
   let v = !x;
   x := v + 1;
   GR.gather right;
+  admit ();
   GR.write right ('vl + 1);
   GR.share right;
   fold (contributions left right i (v + 1));
@@ -177,6 +179,7 @@ ensures  pts_to x ('i + 2)
   unfold contributions;
   GR.gather left;
   GR.gather right;
+  admit ();
   GR.free left;
   GR.free right;
 }
@@ -247,6 +250,7 @@ ensures pts_to x ('i + 2)
       {
         with _p _v. rewrite (GR.pts_to lr #_p _v) as (GR.pts_to left #_p _v);
         GR.gather left;
+        admit ();
         GR.write left (vq + 1);
         GR.share left;      
         with _p _v. rewrite (GR.pts_to left #_p _v) as (GR.pts_to lr #_p _v);
@@ -256,6 +260,7 @@ ensures pts_to x ('i + 2)
       {
         with _p _v. rewrite (GR.pts_to lr #_p _v) as (GR.pts_to right #_p _v);
         GR.gather right;
+        admit ();
         GR.write right (vq + 1);
         GR.share right;      
         with _p _v. rewrite (GR.pts_to right #_p _v) as (GR.pts_to lr #_p _v);
@@ -271,6 +276,7 @@ ensures pts_to x ('i + 2)
     unfold (contributions left right 'i);
     GR.gather left;
     GR.gather right;
+    admit ();
     GR.free left;
     GR.free right;
 }
@@ -421,6 +427,7 @@ ensures pts_to x ('i + 2)
       {
         with _p _v. rewrite (GR.pts_to lr #_p _v) as (GR.pts_to left #_p _v);
         GR.gather left;
+        admit ();
         GR.write left (vq + 1);
         GR.share left;      
         with _p _v. rewrite (GR.pts_to left #_p _v) as (GR.pts_to lr #_p _v);
@@ -430,6 +437,7 @@ ensures pts_to x ('i + 2)
       {
         with _p _v. rewrite (GR.pts_to lr #_p _v) as (GR.pts_to right #_p _v);
         GR.gather right;
+        admit ();
         GR.write right (vq + 1);
         GR.share right;      
         with _p _v. rewrite (GR.pts_to right #_p _v) as (GR.pts_to lr #_p _v);
@@ -447,6 +455,7 @@ ensures pts_to x ('i + 2)
     unfold contributions;
     GR.gather left;
     GR.gather right;
+    admit ();
     GR.free left;
     GR.free right;
     drop_ (inv _ _)

--- a/share/pulse/examples/by-example/PulseTutorial.ParallelIncrement.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.ParallelIncrement.fst
@@ -78,15 +78,15 @@ ensures exists* v. pts_to x v
 {
   let l = L.new_lock (exists* v. pts_to x v);
   fn incr ()
-  requires L.lock_alive l #(half_perm full_perm) (exists* v. pts_to x v)
-  ensures L.lock_alive l #(half_perm full_perm) (exists* v. pts_to x v)
+  requires L.lock_alive l #0.5R (exists* v. pts_to x v)
+  ensures L.lock_alive l #0.5R (exists* v. pts_to x v)
   {
     L.acquire l;
     let v = !x;
     x := v + 1;
     L.release l
   };
-  L.share l;
+  L.share2 l;
   par incr incr;
   L.gather2 l;
   L.acquire l;
@@ -97,8 +97,8 @@ ensures exists* v. pts_to x v
 //lock_inv$
 let contributions (left right: GR.ref int) (i v:int) : v:vprop { is_big v }=
   exists* (vl vr:int).
-    GR.pts_to left #one_half vl **
-    GR.pts_to right #one_half vr **
+    GR.pts_to left #0.5R vl **
+    GR.pts_to right #0.5R vr **
     pure (v == i + vl + vr)
 
 let lock_inv (x:ref int) (init:int) (left right:GR.ref int) : v:vprop { is_big v } =
@@ -114,8 +114,8 @@ fn incr_left (x:ref int)
              (#right:GR.ref int)
              (#i:erased int)
              (lock:L.lock )
-requires L.lock_alive lock #p (lock_inv x i left right) ** GR.pts_to left #one_half 'vl
-ensures L.lock_alive lock #p (lock_inv x i left right) ** GR.pts_to left #one_half ('vl + 1)
+requires L.lock_alive lock #p (lock_inv x i left right) ** GR.pts_to left #0.5R 'vl
+ensures L.lock_alive lock #p (lock_inv x i left right) ** GR.pts_to left #0.5R ('vl + 1)
 {
   L.acquire lock;
   unfold lock_inv;
@@ -123,7 +123,6 @@ ensures L.lock_alive lock #p (lock_inv x i left right) ** GR.pts_to left #one_ha
   let v = !x;
   x := v + 1;
   GR.gather left;
-  admit ();
   GR.write left ('vl + 1);
   GR.share left;
   fold (contributions left right i (v + 1));
@@ -139,8 +138,8 @@ fn incr_right (x:ref int)
               (#right:GR.ref int)
               (#i:erased int)
               (lock:L.lock)
-requires L.lock_alive lock #p (lock_inv x i left right) ** GR.pts_to right #one_half 'vl
-ensures L.lock_alive lock #p (lock_inv x i left right) ** GR.pts_to right #one_half ('vl + 1)
+requires L.lock_alive lock #p (lock_inv x i left right) ** GR.pts_to right #0.5R 'vl
+ensures L.lock_alive lock #p (lock_inv x i left right) ** GR.pts_to right #0.5R ('vl + 1)
 {
   L.acquire lock;
   unfold lock_inv;
@@ -169,7 +168,7 @@ ensures  pts_to x ('i + 2)
   fold (contributions left right 'i 'i);
   fold (lock_inv x 'i left right);
   let lock = L.new_lock (lock_inv x 'i left right);
-  L.share lock;
+  L.share2 lock;
   par (fun _ -> incr_left x lock)
       (fun _ -> incr_right x lock);
   L.gather2 lock;
@@ -179,7 +178,6 @@ ensures  pts_to x ('i + 2)
   unfold contributions;
   GR.gather left;
   GR.gather right;
-  admit ();
   GR.free left;
   GR.free right;
 }
@@ -238,11 +236,11 @@ ensures pts_to x ('i + 2)
         (v vq:int)
       requires 
         contributions left right 'i v **
-        GR.pts_to lr #one_half vq **
+        GR.pts_to lr #0.5R vq **
         pts_to x (v + 1)
       ensures
         contributions left right 'i (v + 1) **
-        GR.pts_to lr #one_half (vq + 1) **
+        GR.pts_to lr #0.5R (vq + 1) **
         pts_to x (v + 1)
     { 
       unfold contributions;
@@ -250,7 +248,6 @@ ensures pts_to x ('i + 2)
       {
         with _p _v. rewrite (GR.pts_to lr #_p _v) as (GR.pts_to left #_p _v);
         GR.gather left;
-        admit ();
         GR.write left (vq + 1);
         GR.share left;      
         with _p _v. rewrite (GR.pts_to left #_p _v) as (GR.pts_to lr #_p _v);
@@ -260,14 +257,13 @@ ensures pts_to x ('i + 2)
       {
         with _p _v. rewrite (GR.pts_to lr #_p _v) as (GR.pts_to right #_p _v);
         GR.gather right;
-        admit ();
         GR.write right (vq + 1);
         GR.share right;      
         with _p _v. rewrite (GR.pts_to right #_p _v) as (GR.pts_to lr #_p _v);
         fold (contributions left right 'i (v + 1));
       }
     };
-    L.share lock;
+    L.share2 lock;
     par (fun _ -> incr x lock (step left true))
         (fun _ -> incr x lock (step right false));
     L.gather2 lock;
@@ -276,7 +272,6 @@ ensures pts_to x ('i + 2)
     unfold (contributions left right 'i);
     GR.gather left;
     GR.gather right;
-    admit ();
     GR.free left;
     GR.free right;
 }
@@ -415,11 +410,11 @@ ensures pts_to x ('i + 2)
         (v vq:int)
       requires 
         contributions left right 'i v **
-        GR.pts_to lr #one_half vq **
+        GR.pts_to lr #0.5R vq **
         pts_to x (v + 1)
       ensures
         contributions left right 'i (v + 1) **
-        GR.pts_to lr #one_half (vq + 1) **
+        GR.pts_to lr #0.5R (vq + 1) **
         pts_to x (v + 1)
     { 
       unfold contributions;
@@ -427,7 +422,6 @@ ensures pts_to x ('i + 2)
       {
         with _p _v. rewrite (GR.pts_to lr #_p _v) as (GR.pts_to left #_p _v);
         GR.gather left;
-        admit ();
         GR.write left (vq + 1);
         GR.share left;      
         with _p _v. rewrite (GR.pts_to left #_p _v) as (GR.pts_to lr #_p _v);
@@ -437,14 +431,13 @@ ensures pts_to x ('i + 2)
       {
         with _p _v. rewrite (GR.pts_to lr #_p _v) as (GR.pts_to right #_p _v);
         GR.gather right;
-        admit ();
         GR.write right (vq + 1);
         GR.share right;      
         with _p _v. rewrite (GR.pts_to right #_p _v) as (GR.pts_to lr #_p _v);
         fold (contributions left right 'i (v + 1));
       }
     };
-    C.share c;
+    C.share2 c;
     with pred. assert (inv (C.iref_of c) (C.cinv_vp c (exists* v. pts_to x v ** pred v)));
     dup_inv (C.iref_of c) (C.cinv_vp c (exists* v. pts_to x v ** pred v));
     par (fun _ -> incr_atomic x c (step left true))
@@ -455,7 +448,6 @@ ensures pts_to x ('i + 2)
     unfold contributions;
     GR.gather left;
     GR.gather right;
-    admit ();
     GR.free left;
     GR.free right;
     drop_ (inv _ _)

--- a/share/pulse/examples/by-example/PulseTutorial.Ref.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.Ref.fst
@@ -147,10 +147,10 @@ ensures pts_to r (4 * 'v)
 
 
 
-```pulse //assign_full_perm$
+```pulse //assign_1.0R$
 fn assign_full_perm (#a:Type) (r:ref a) (v:a)
-requires pts_to r #full_perm 'v
-ensures pts_to r #full_perm v
+requires pts_to r #1.0R 'v
+ensures pts_to r #1.0R v
 {
     r := v;
 }
@@ -184,28 +184,28 @@ ensures pts_to r #p w
 ```pulse //share_ref$
 fn share_ref #a #p (r:ref a)
 requires pts_to r #p 'v
-ensures pts_to r #(half_perm p) 'v ** pts_to r #(half_perm p) 'v
+ensures pts_to r #(p /. 2.0R) 'v ** pts_to r #(p /. 2.0R) 'v
 {
     share r;
 }
 ```
 
 ```pulse //gather_ref$
-fn gather_ref #a #p (r:ref a)
+fn gather_ref #a (#p:perm) (r:ref a)
 requires
-    pts_to r #(half_perm p) 'v0 **
-    pts_to r #(half_perm p) 'v1
+    pts_to r #(p /. 2.0R) 'v0 **
+    pts_to r #(p /. 2.0R) 'v1
 ensures
     pts_to r #p 'v0 **
     pure ('v0 == 'v1)
 {
-    gather r;
+    gather r
 }
 ```
 
 ```pulse
 fn max_perm #a (r:ref a) #p anything
-requires pts_to r #p 'v ** pure (~ (p `lesser_equal_perm` full_perm))
+requires pts_to r #p 'v ** pure (~ (p <=. 1.0R))
 returns _:squash False
 ensures anything
 {
@@ -219,8 +219,8 @@ fn alias_ref #a #p (r:ref a)
 requires pts_to r #p 'v
 returns s:ref a
 ensures
-    pts_to r #(half_perm p) 'v **
-    pts_to s #(half_perm p) 'v **
+    pts_to r #(p /. 2.0R) 'v **
+    pts_to s #(p /. 2.0R) 'v **
     pure (r == s)
 {
     share r;

--- a/share/pulse/examples/by-example/PulseTutorial.Ref.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.Ref.fst
@@ -205,7 +205,7 @@ ensures
 
 ```pulse
 fn max_perm #a (r:ref a) #p anything
-requires pts_to r #p 'v ** pure (not (p `lesser_equal_perm` full_perm))
+requires pts_to r #p 'v ** pure (~ (p `lesser_equal_perm` full_perm))
 returns _:squash False
 ensures anything
 {

--- a/share/pulse/examples/c/PulsePointStruct.fst
+++ b/share/pulse/examples/c/PulsePointStruct.fst
@@ -1,3 +1,19 @@
+(*
+   Copyright 2023 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
 module PulsePointStruct
 open Pulse.Lib.Pervasives
 open Pulse.C.Types
@@ -12,7 +28,7 @@ requires
 ensures
   ((r1 `pts_to` mk_scalar (Ghost.reveal v2)) ** (r2 `pts_to` mk_scalar (Ghost.reveal v1)))
 {
-  let _ : squash (mk_scalar (Ghost.reveal v1) == mk_fraction (scalar U32.t) (mk_scalar (Ghost.reveal v1)) full_perm) = (); // FIXME: WHY WHY WHY does the pattern on mk_fraction_full_scalar not trigger?
+  let _ : squash (mk_scalar (Ghost.reveal v1) == mk_fraction (scalar U32.t) (mk_scalar (Ghost.reveal v1)) 1.0R) = (); // FIXME: WHY WHY WHY does the pattern on mk_fraction_full_scalar not trigger?
   let x1 = read r1;
   let x2 = read r2;
   write r1 x2;

--- a/share/pulse/examples/dice/cbor/CBOR.Pulse.Extern.fsti
+++ b/share/pulse/examples/dice/cbor/CBOR.Pulse.Extern.fsti
@@ -123,9 +123,9 @@ let cbor_read_success_post
   (c: cbor_read_t)
 : Tot vprop
 = exists* v rem.
-    raw_data_item_match full_perm c.cbor_read_payload v **
+    raw_data_item_match 1.0R c.cbor_read_payload v **
     A.pts_to c.cbor_read_remainder #p rem **
-    ((raw_data_item_match full_perm c.cbor_read_payload v ** A.pts_to c.cbor_read_remainder #p rem) @==>
+    ((raw_data_item_match 1.0R c.cbor_read_payload v ** A.pts_to c.cbor_read_remainder #p rem) @==>
       A.pts_to a #p va) **
     pure (cbor_read_success_postcond va c v rem)
 
@@ -181,9 +181,9 @@ let cbor_read_deterministically_encoded_success_post
   (c: cbor_read_t)
 : Tot vprop
 = ((exists* v rem.
-    raw_data_item_match full_perm c.cbor_read_payload v **
+    raw_data_item_match 1.0R c.cbor_read_payload v **
     A.pts_to c.cbor_read_remainder #p rem **
-    ((raw_data_item_match full_perm c.cbor_read_payload v ** A.pts_to c.cbor_read_remainder #p rem) @==>
+    ((raw_data_item_match 1.0R c.cbor_read_payload v ** A.pts_to c.cbor_read_remainder #p rem) @==>
       A.pts_to a #p va) **
     pure (cbor_read_deterministically_encoded_success_postcond va c v rem)
   ))
@@ -239,7 +239,7 @@ val cbor_constr_int64
   (value: U64.t)
 : stt cbor
     emp
-    (fun c -> raw_data_item_match full_perm c (Cbor.Int64 ty value))
+    (fun c -> raw_data_item_match 1.0R c (Cbor.Int64 ty value))
 
 val cbor_destr_simple_value
   (c: cbor)
@@ -258,7 +258,7 @@ val cbor_constr_simple_value
   (value: Cbor.simple_value)
 : stt cbor
     emp
-    (fun c -> raw_data_item_match full_perm c (Cbor.Simple value))
+    (fun c -> raw_data_item_match 1.0R c (Cbor.Simple value))
 
 noextract
 let cbor_destr_string_post
@@ -297,8 +297,8 @@ val cbor_constr_string
       U64.v len == Seq.length va
     ))
     (fun c' -> exists* vc'.
-      raw_data_item_match full_perm c' vc' **
-      (raw_data_item_match full_perm c' vc' @==>
+      raw_data_item_match 1.0R c' vc' **
+      (raw_data_item_match 1.0R c' vc' @==>
         A.pts_to a #p va
       ) ** pure (
       U64.v len == Seq.length va /\
@@ -312,15 +312,15 @@ val cbor_constr_array
   (#v': Ghost.erased (list Cbor.raw_data_item))
 : stt cbor
     (A.pts_to a c' **
-      raw_data_item_array_match full_perm c' v' **
+      raw_data_item_array_match 1.0R c' v' **
       pure (
         U64.v len == List.Tot.length v'
     ))
     (fun res -> exists* vres.
-      raw_data_item_match full_perm res vres **
-      (raw_data_item_match full_perm res vres @==>
+      raw_data_item_match 1.0R res vres **
+      (raw_data_item_match 1.0R res vres @==>
         (A.pts_to a c' **
-          raw_data_item_array_match full_perm c' v')
+          raw_data_item_array_match 1.0R c' v')
       ) ** pure (
       U64.v len == List.Tot.length v' /\
       vres == Cbor.Array v'
@@ -441,7 +441,7 @@ val cbor_read_array
       ((A.pts_to res vres **
         raw_data_item_array_match p vres (maybe_cbor_array v)) @==> (
         raw_data_item_match p a v **
-        (exists* _x. (A.pts_to dest #full_perm _x))
+        (exists* _x. (A.pts_to dest #1.0R _x))
       )) ** pure (
       Cbor.Array? v /\
       U64.v len == A.length dest /\
@@ -496,12 +496,12 @@ val cbor_constr_tagged
   (#v': Ghost.erased (Cbor.raw_data_item))
 : stt cbor
     (R.pts_to a c' **
-      raw_data_item_match full_perm c' v')
+      raw_data_item_match 1.0R c' v')
     (fun res ->
-      raw_data_item_match full_perm res (Cbor.Tagged tag v') **
-      (raw_data_item_match full_perm res (Cbor.Tagged tag v') @==>
+      raw_data_item_match 1.0R res (Cbor.Tagged tag v') **
+      (raw_data_item_match 1.0R res (Cbor.Tagged tag v') @==>
         (R.pts_to a c' **
-          raw_data_item_match full_perm c' v')
+          raw_data_item_match 1.0R c' v')
       )
     )
 
@@ -512,15 +512,15 @@ val cbor_constr_map
   (#v': Ghost.erased (list (Cbor.raw_data_item & Cbor.raw_data_item)))
 : stt cbor
     (A.pts_to a c' **
-      raw_data_item_map_match full_perm c' v' **
+      raw_data_item_map_match 1.0R c' v' **
       pure (
         U64.v len == List.Tot.length v'
     ))
     (fun res -> exists* vres.
-      raw_data_item_match full_perm res vres **
-      (raw_data_item_match full_perm res vres @==>
+      raw_data_item_match 1.0R res vres **
+      (raw_data_item_match 1.0R res vres @==>
         (A.pts_to a c' **
-          raw_data_item_map_match full_perm c' v')
+          raw_data_item_map_match 1.0R c' v')
       ) ** pure (
       U64.v len == List.Tot.length v' /\
       vres == Cbor.Map v'
@@ -676,12 +676,12 @@ val cbor_gather
   (p1 p2: perm)
 : stt_ghost unit emp_inames
     (raw_data_item_match p1 c v1 ** raw_data_item_match p2 c v2)
-    (fun _ -> raw_data_item_match (p1 `sum_perm` p2) c v1 ** pure (v1 == v2))
+    (fun _ -> raw_data_item_match (p1 +. p2) c v1 ** pure (v1 == v2))
 
 val cbor_share
   (c: cbor)
   (v1: Cbor.raw_data_item)
   (p p1 p2: perm)
 : stt_ghost unit emp_inames
-    (raw_data_item_match p c v1 ** pure (p == p1 `sum_perm` p2))
+    (raw_data_item_match p c v1 ** pure (p == p1 +. p2))
     (fun _ -> raw_data_item_match p1 c v1 ** raw_data_item_match p2 c v1)

--- a/share/pulse/examples/parix/ParallelFor.fst
+++ b/share/pulse/examples/parix/ParallelFor.fst
@@ -48,7 +48,7 @@ fn squash_pledge (f v : vprop)
 
 let div_perm (p:perm) (n:pos) : perm =
   let open PulseCore.FractionalPermission in
-  MkPerm ((MkPerm?.v p) /. of_int n)
+  p /. (of_int n)
 
 (* Basic sketch of a parallel for *)
 

--- a/share/pulse/examples/parix/Promises.Examples3.fst
+++ b/share/pulse/examples/parix/Promises.Examples3.fst
@@ -27,36 +27,36 @@ assume val claimed : GR.ref bool
 
 let inv_p : v:vprop { is_big v } =
   exists* (v_done:bool) (v_res:option int) (v_claimed:bool).
-       pts_to done #one_half v_done
-    ** pts_to res #one_half v_res
-    ** GR.pts_to claimed #one_half v_claimed
-    ** (if not v_claimed then pts_to res #one_half v_res else emp)
+       pts_to done #0.5R v_done
+    ** pts_to res #0.5R v_res
+    ** GR.pts_to claimed #0.5R v_claimed
+    ** (if not v_claimed then pts_to res #0.5R v_res else emp)
     ** pure (v_claimed ==> v_done)
     ** pure (v_done ==> Some? v_res)
 
 let goal : vprop =
-  exists* v_res. pts_to res #one_half v_res ** pure (Some? v_res)
+  exists* v_res. pts_to res #0.5R v_res ** pure (Some? v_res)
 
 
 ```pulse
 atomic
 fn proof
    (i : iref) (_:unit)
-   requires inv i inv_p ** pts_to done #one_half true ** GR.pts_to claimed #one_half false
-   ensures inv i inv_p ** pts_to done #one_half true ** goal
+   requires inv i inv_p ** pts_to done #0.5R true ** GR.pts_to claimed #0.5R false
+   ensures inv i inv_p ** pts_to done #0.5R true ** goal
    opens add_inv emp_inames i
 {
   with_invariants i {
     unfold inv_p;
     with v_done v_res v_claimed.
-      assert (pts_to done #one_half v_done
-              ** pts_to res #one_half v_res
-              ** GR.pts_to claimed #one_half v_claimed
-              ** (if not v_claimed then pts_to res #one_half v_res else emp)
+      assert (pts_to done #0.5R v_done
+              ** pts_to res #0.5R v_res
+              ** GR.pts_to claimed #0.5R v_claimed
+              ** (if not v_claimed then pts_to res #0.5R v_res else emp)
               ** pure (v_claimed ==> v_done)
               ** pure (v_done ==> Some? v_res));
 
-    pts_to_injective_eq #_ #one_half #one_half #v_done #true done;
+    pts_to_injective_eq #_ #0.5R #0.5R #v_done #true done;
     assert (pure (v_done == true));
     
     GR.gather2 #bool
@@ -65,8 +65,8 @@ fn proof
     assert (pure (v_claimed == false));
 
     // NB: this step is very sensitive to ordering
-    rewrite ((if not v_claimed then pts_to res #one_half v_res else emp) ** emp)
-         as (pts_to res #one_half v_res ** (if not true then pts_to res #one_half v_res else emp));
+    rewrite ((if not v_claimed then pts_to res #0.5R v_res else emp) ** emp)
+         as (pts_to res #0.5R v_res ** (if not true then pts_to res #0.5R v_res else emp));
 
     GR.op_Colon_Equals claimed true;
     
@@ -76,7 +76,7 @@ fn proof
     
     fold inv_p;
     
-    drop_ (GR.pts_to claimed #one_half true);
+    drop_ (GR.pts_to claimed #0.5R true);
 
     ()
   }
@@ -88,8 +88,8 @@ let is (i:iref) : invlist = [(inv_p <: vprop), i]
 let cheat_proof (i:iref)
   : (_:unit) ->
       stt_ghost unit (add_inv emp_inames i)
-        (requires pts_to done #one_half true ** (inv i inv_p ** GR.pts_to claimed #one_half false))
-        (ensures fun _ -> pts_to done #one_half true ** goal)
+        (requires pts_to done #0.5R true ** (inv i inv_p ** GR.pts_to claimed #0.5R false))
+        (ensures fun _ -> pts_to done #0.5R true ** goal)
   = admit() //proof is atomic, not ghost
 
 #set-options "--debug Promises.Examples3 --debug_level SMTQuery"
@@ -98,8 +98,8 @@ let cheat_proof (i:iref)
 fn setup (_:unit)
    requires pts_to done v_done ** pts_to res v_res ** GR.pts_to claimed v_claimed
    returns i:iref
-   ensures pts_to done #one_half false **
-           pledge (add_inv emp_inames i) (pts_to done #one_half true) goal
+   ensures pts_to done #0.5R false **
+           pledge (add_inv emp_inames i) (pts_to done #0.5R true) goal
 {
   done := false;
   res := None;
@@ -109,8 +109,8 @@ fn setup (_:unit)
   share2 #_ res;
   GR.share2 #_ claimed;
   
-  rewrite (pts_to res #one_half None)
-       as (if not false then  pts_to res #one_half None else emp);
+  rewrite (pts_to res #0.5R None)
+       as (if not false then  pts_to res #0.5R None else emp);
        
   fold inv_p;
   
@@ -118,9 +118,9 @@ fn setup (_:unit)
 
   make_pledge
     (add_inv emp_inames i)
-    (pts_to done #one_half true) //f
+    (pts_to done #0.5R true) //f
     goal  //v
-    (inv i inv_p ** GR.pts_to claimed #one_half false)  //extra
+    (inv i inv_p ** GR.pts_to claimed #0.5R false)  //extra
     (cheat_proof i);
 
   i
@@ -130,16 +130,16 @@ fn setup (_:unit)
 [@@expect_failure] // block is not atomic/ghost
 ```pulse
 fn worker (i : inv inv_p) (_:unit)
-   requires pts_to done #one_half false
-   ensures pts_to done #one_half true
+   requires pts_to done #0.5R false
+   ensures pts_to done #0.5R true
 {
   with_invariants i {
     unfold inv_p;
     with v_done v_res v_claimed.
-      assert (pts_to done #one_half v_done
-              ** pts_to res #one_half v_res
-              ** GR.pts_to claimed #one_half v_claimed
-              ** (if not v_claimed then pts_to res #one_half v_res else emp)
+      assert (pts_to done #0.5R v_done
+              ** pts_to res #0.5R v_res
+              ** GR.pts_to claimed #0.5R v_claimed
+              ** (if not v_claimed then pts_to res #0.5R v_res else emp)
               ** pure (v_claimed ==> v_done)
               ** pure (v_done ==> Some? v_res));
 
@@ -148,8 +148,8 @@ fn worker (i : inv inv_p) (_:unit)
     
     assert (pure (not v_claimed)); // contrapositive from v_done=false
 
-    rewrite (if not v_claimed then pts_to res #one_half v_res else emp)
-         as pts_to res #one_half v_res;
+    rewrite (if not v_claimed then pts_to res #0.5R v_res else emp)
+         as pts_to res #0.5R v_res;
          
     gather2 #_ res #v_res #v_res;
     assert (pts_to res v_res);
@@ -168,8 +168,8 @@ fn worker (i : inv inv_p) (_:unit)
     
     share2 #_ res;
 
-    rewrite (pts_to res #one_half (Some 42))
-        as (if not v_claimed then pts_to res #one_half (Some 42) else emp);
+    rewrite (pts_to res #0.5R (Some 42))
+        as (if not v_claimed then pts_to res #0.5R (Some 42) else emp);
         
     share2 #_ done;
     

--- a/share/pulse/examples/parix/TaskPool.Examples.fst
+++ b/share/pulse/examples/parix/TaskPool.Examples.fst
@@ -25,7 +25,7 @@ val qsv : nat -> vprop
 assume
 val qsc : n:nat -> stt unit emp (fun _ -> qsv n)
 
-let spawn_ #pre #post p f = spawn_ #pre #post p #full_perm f
+let spawn_ #pre #post p f = spawn_ #pre #post p #1.0R f
 
 ```pulse
 fn qs (n:nat)

--- a/src/checker/Pulse.Lib.Core.Typing.fsti
+++ b/src/checker/Pulse.Lib.Core.Typing.fsti
@@ -344,10 +344,10 @@ val rewrite_typing
               p
               (mk_abs unit_tm Q_Explicit q)))
 
-// mk_star pre (mk_pts_to a (RT.bound_var 0) full_perm_tm init
+// mk_star pre (mk_pts_to a (RT.bound_var 0) tm_full_perm init
 let with_local_body_pre (pre:term) (a:term) (x:term) (init:term) : term =
   let pts_to : term =
-    mk_pts_to a x full_perm_tm init in
+    mk_pts_to a x tm_full_perm init in
   mk_star pre pts_to
 
 //
@@ -358,7 +358,7 @@ let with_local_body_post_body (post:term) (a:term) (x:term) : term =
   let exists_tm =
     mk_exists (pack_universe Uv_Zero) a
       (mk_abs a Q_Explicit
-         (mk_pts_to a x full_perm_tm (RT.bound_var 0))) in
+         (mk_pts_to a x tm_full_perm (RT.bound_var 0))) in
   mk_star post exists_tm
 
 let with_local_body_post (post:term) (a:term) (ret_t:term) (x:term) : term =
@@ -392,7 +392,7 @@ val with_local_typing
 
 let with_localarray_body_pre (pre:term) (a:term) (arr:term) (init:term) (len:term) : term =
   let pts_to : term =
-    mk_array_pts_to a arr full_perm_tm (mk_seq_create uzero a (mk_szv len) init) in
+    mk_array_pts_to a arr tm_full_perm (mk_seq_create uzero a (mk_szv len) init) in
   let len_vp : term =
     mk_pure (mk_eq2 uzero nat_tm (mk_array_length a arr) (mk_szv len)) in
   mk_star pre (mk_star pts_to len_vp)
@@ -405,7 +405,7 @@ let with_localarray_body_post_body (post:term) (a:term) (arr:term) : term =
   let exists_tm =
     mk_exists uzero (mk_seq uzero a)
       (mk_abs (mk_seq uzero a) Q_Explicit
-         (mk_array_pts_to a arr full_perm_tm (RT.bound_var 0))) in
+         (mk_array_pts_to a arr tm_full_perm (RT.bound_var 0))) in
   mk_star post exists_tm
 
 let with_localarray_body_post (post:term) (a:term) (ret_t:term) (arr:term) : term =

--- a/src/checker/Pulse.Reflection.Util.fst
+++ b/src/checker/Pulse.Reflection.Util.fst
@@ -636,7 +636,6 @@ let mk_stt_ghost_comp_equiv (g:R.env) (u:R.universe) (res inames pre1 post1 pre2
 
 let ref_lid = mk_pulse_lib_reference_lid "ref"
 let pts_to_lid = mk_pulse_lib_reference_lid "pts_to"
-let full_perm_lid = ["PulseCore"; "FractionalPermission"; "full_perm"]
 
 let mk_ref (a:R.term) : R.term =
   let open R in
@@ -651,9 +650,6 @@ let mk_pts_to (a:R.term) (r:R.term) (perm:R.term) (v:R.term) : R.term =
   let t = pack_ln (Tv_App t (perm, Q_Implicit)) in
   pack_ln (Tv_App t (v, Q_Explicit))
 
-let full_perm_tm : R.term =
-  let open R in
-  pack_ln (Tv_FVar (pack_fv full_perm_lid))
 let pulse_lib_array_core = ["Pulse"; "Lib"; "Array"; "Core"]
 let mk_pulse_lib_array_core_lid s = pulse_lib_array_core @ [s]
 

--- a/src/checker/Pulse.Syntax.Pure.fst
+++ b/src/checker/Pulse.Syntax.Pure.fst
@@ -351,6 +351,8 @@ let tm_all_inames = tm_fvar (as_fv all_inames_lid)
 let tm_add_inv (is iref:R.term) : R.term =
   let h = R.pack_ln (R.Tv_FVar (R.pack_fv add_inv_lid)) in
   R.mk_app h [ex is; ex iref]
+let tm_full_perm = tm_constant (R.C_Real "1.0")
+
 
 let is_view_of (tv:term_view) (t:term) : prop =
   match tv with

--- a/src/checker/Pulse.Typing.fst
+++ b/src/checker/Pulse.Typing.fst
@@ -82,7 +82,7 @@ let mk_pts_to (ty:term) (r:term) (v:term) : term =
   let t = tm_fvar (as_fv pts_to_lid) in
   let t = tm_pureapp t (Some Implicit) ty in
   let t = tm_pureapp t None r in
-  let t = tm_pureapp t (Some Implicit) (tm_fvar (as_fv full_perm_lid)) in
+  let t = tm_pureapp t (Some Implicit) tm_full_perm in
   tm_pureapp t None v
 
 let comp_return (c:ctag) (use_eq:bool) (u:universe) (t:term) (e:term) (post:term) (x:var)
@@ -449,7 +449,7 @@ let mk_array_pts_to (a:term) (arr:term) (v:term) : term =
   let t = tm_fvar (as_fv array_pts_to_lid) in
   let t = tm_pureapp t (Some Implicit) a in
   let t = tm_pureapp t None arr in
-  let t = tm_pureapp t (Some Implicit) (tm_fvar (as_fv full_perm_lid)) in
+  let t = tm_pureapp t (Some Implicit) tm_full_perm in
   tm_pureapp t None v
 
 // let mk_array_is_full (a:term) (arr:term) : term =

--- a/src/ocaml/plugin/generated/Pulse_Lib_Core_Typing.ml
+++ b/src/ocaml/plugin/generated/Pulse_Lib_Core_Typing.ml
@@ -217,7 +217,7 @@ let (with_local_body_pre :
         fun init ->
           let pts_to =
             Pulse_Reflection_Util.mk_pts_to a x
-              Pulse_Reflection_Util.full_perm_tm init in
+              Pulse_Syntax_Pure.tm_full_perm init in
           Pulse_Reflection_Util.mk_star pre pts_to
 let (with_local_body_post_body :
   FStar_Reflection_Types.term ->
@@ -234,7 +234,7 @@ let (with_local_body_post_body :
             (Pulse_Reflection_Util.mk_abs a
                FStar_Reflection_V2_Data.Q_Explicit
                (Pulse_Reflection_Util.mk_pts_to a x
-                  Pulse_Reflection_Util.full_perm_tm
+                  Pulse_Syntax_Pure.tm_full_perm
                   (FStar_Reflection_Typing.bound_var Prims.int_zero))) in
         Pulse_Reflection_Util.mk_star post exists_tm
 let (with_local_body_post :
@@ -264,7 +264,7 @@ let (with_localarray_body_pre :
           fun len ->
             let pts_to =
               Pulse_Reflection_Util.mk_array_pts_to a arr
-                Pulse_Reflection_Util.full_perm_tm
+                Pulse_Syntax_Pure.tm_full_perm
                 (Pulse_Reflection_Util.mk_seq_create
                    Pulse_Reflection_Util.uzero a
                    (Pulse_Reflection_Util.mk_szv len) init) in
@@ -291,7 +291,7 @@ let (with_localarray_body_post_body :
                (Pulse_Reflection_Util.mk_seq Pulse_Reflection_Util.uzero a)
                FStar_Reflection_V2_Data.Q_Explicit
                (Pulse_Reflection_Util.mk_array_pts_to a arr
-                  Pulse_Reflection_Util.full_perm_tm
+                  Pulse_Syntax_Pure.tm_full_perm
                   (FStar_Reflection_Typing.bound_var Prims.int_zero))) in
         Pulse_Reflection_Util.mk_star post exists_tm
 let (with_localarray_body_post :

--- a/src/ocaml/plugin/generated/Pulse_Reflection_Util.ml
+++ b/src/ocaml/plugin/generated/Pulse_Reflection_Util.ml
@@ -1868,8 +1868,6 @@ let (mk_stt_ghost_comp_equiv :
 let (ref_lid : Prims.string Prims.list) = mk_pulse_lib_reference_lid "ref"
 let (pts_to_lid : Prims.string Prims.list) =
   mk_pulse_lib_reference_lid "pts_to"
-let (full_perm_lid : Prims.string Prims.list) =
-  ["PulseCore"; "FractionalPermission"; "full_perm"]
 let (mk_ref : FStar_Reflection_Types.term -> FStar_Reflection_Types.term) =
   fun a ->
     let t =
@@ -1908,10 +1906,6 @@ let (mk_pts_to :
           FStar_Reflection_V2_Builtins.pack_ln
             (FStar_Reflection_V2_Data.Tv_App
                (t3, (v, FStar_Reflection_V2_Data.Q_Explicit)))
-let (full_perm_tm : FStar_Reflection_Types.term) =
-  FStar_Reflection_V2_Builtins.pack_ln
-    (FStar_Reflection_V2_Data.Tv_FVar
-       (FStar_Reflection_V2_Builtins.pack_fv full_perm_lid))
 let (pulse_lib_array_core : Prims.string Prims.list) =
   ["Pulse"; "Lib"; "Array"; "Core"]
 let (mk_pulse_lib_array_core_lid : Prims.string -> Prims.string Prims.list) =
@@ -2093,39 +2087,39 @@ let (mk_opaque_let :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Reflection.Util.fst"
-                     (Prims.of_int (720)) (Prims.of_int (11))
-                     (Prims.of_int (720)) (Prims.of_int (45)))))
+                     (Prims.of_int (716)) (Prims.of_int (11))
+                     (Prims.of_int (716)) (Prims.of_int (45)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Reflection.Util.fst"
-                     (Prims.of_int (720)) (Prims.of_int (48))
-                     (Prims.of_int (726)) (Prims.of_int (18)))))
+                     (Prims.of_int (716)) (Prims.of_int (48))
+                     (Prims.of_int (722)) (Prims.of_int (18)))))
             (Obj.magic
                (FStar_Tactics_Effect.tac_bind
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Reflection.Util.fst"
-                           (Prims.of_int (720)) (Prims.of_int (21))
-                           (Prims.of_int (720)) (Prims.of_int (45)))))
+                           (Prims.of_int (716)) (Prims.of_int (21))
+                           (Prims.of_int (716)) (Prims.of_int (45)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Reflection.Util.fst"
-                           (Prims.of_int (720)) (Prims.of_int (11))
-                           (Prims.of_int (720)) (Prims.of_int (45)))))
+                           (Prims.of_int (716)) (Prims.of_int (11))
+                           (Prims.of_int (716)) (Prims.of_int (45)))))
                   (Obj.magic
                      (FStar_Tactics_Effect.tac_bind
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range
                                  "Pulse.Reflection.Util.fst"
-                                 (Prims.of_int (720)) (Prims.of_int (22))
-                                 (Prims.of_int (720)) (Prims.of_int (37)))))
+                                 (Prims.of_int (716)) (Prims.of_int (22))
+                                 (Prims.of_int (716)) (Prims.of_int (37)))))
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range
                                  "Pulse.Reflection.Util.fst"
-                                 (Prims.of_int (720)) (Prims.of_int (21))
-                                 (Prims.of_int (720)) (Prims.of_int (45)))))
+                                 (Prims.of_int (716)) (Prims.of_int (21))
+                                 (Prims.of_int (716)) (Prims.of_int (45)))))
                         (Obj.magic (FStar_Tactics_V2_Derived.cur_module ()))
                         (fun uu___ ->
                            FStar_Tactics_Effect.lift_div_tac

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Pure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Pure.ml
@@ -578,6 +578,8 @@ let (tm_add_inv :
                 Pulse_Reflection_Util.add_inv_lid)) in
       FStar_Reflection_V2_Derived.mk_app h
         [Pulse_Reflection_Util.ex is; Pulse_Reflection_Util.ex iref]
+let (tm_full_perm : Pulse_Syntax_Base.term) =
+  tm_constant (FStar_Reflection_V2_Data.C_Real "1.0")
 type ('tv, 't) is_view_of = Obj.t
 let rec (inspect_term : FStar_Reflection_Types.term -> term_view) =
   fun t ->

--- a/src/ocaml/plugin/generated/Pulse_Typing.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing.ml
@@ -187,8 +187,7 @@ let (mk_pts_to :
         let t3 =
           Pulse_Syntax_Pure.tm_pureapp t2
             (FStar_Pervasives_Native.Some Pulse_Syntax_Base.Implicit)
-            (Pulse_Syntax_Pure.tm_fvar
-               (Pulse_Syntax_Base.as_fv Pulse_Reflection_Util.full_perm_lid)) in
+            Pulse_Syntax_Pure.tm_full_perm in
         Pulse_Syntax_Pure.tm_pureapp t3 FStar_Pervasives_Native.None v
 let (comp_return :
   Pulse_Syntax_Base.ctag ->
@@ -727,8 +726,7 @@ let (mk_array_pts_to :
         let t3 =
           Pulse_Syntax_Pure.tm_pureapp t2
             (FStar_Pervasives_Native.Some Pulse_Syntax_Base.Implicit)
-            (Pulse_Syntax_Pure.tm_fvar
-               (Pulse_Syntax_Base.as_fv Pulse_Reflection_Util.full_perm_lid)) in
+            Pulse_Syntax_Pure.tm_full_perm in
         Pulse_Syntax_Pure.tm_pureapp t3 FStar_Pervasives_Native.None v
 let (mk_seq_create :
   Pulse_Syntax_Base.universe ->


### PR DESCRIPTION
With https://github.com/FStarLang/FStar/pull/3242 making F* reals as erasable, we can define permissions as reals with a refinement:

```
[@@ erasable]
type perm : Type0 = r:real { r >. zero }
```

This allows using real constants and operators directly as permission expressions.