### PR TITLE
Misc usablity improvement

### DIFF
--- a/share/pulse/examples/DropEmp.fst
+++ b/share/pulse/examples/DropEmp.fst
@@ -1,0 +1,41 @@
+module DropEmp
+
+open Pulse.Lib.Pervasives
+
+```pulse
+fn test0 (p:vprop)
+  requires (if true then emp else p)
+  ensures emp
+{
+  ();
+}
+```
+
+```pulse
+fn test1 (p:vprop)
+  requires (if false then emp else p)
+  ensures p
+{
+  ();
+}
+```
+
+[@@expect_failure]
+```pulse
+fn test2 (p:vprop)
+  requires (if true then emp else p)
+  ensures p
+{
+  ();
+}
+```
+
+[@@expect_failure]
+```pulse
+fn test3 (p:vprop)
+  requires (if false then emp else p)
+  ensures emp
+{
+  ();
+}
+```

--- a/src/checker/Pulse.Checker.AssertWithBinders.fst
+++ b/src/checker/Pulse.Checker.AssertWithBinders.fst
@@ -337,7 +337,7 @@ let check
     let open Pulse.PP in
     let msg = [
       text "Current context:" ^^
-            indent (P.term_to_doc (VPropEquiv.canon_vprop pre))
+            indent (pp (VPropEquiv.canon_vprop pre))
     ] in
     fail_doc_env true g (Some r) msg
   | RENAME { pairs; goal } ->

--- a/src/checker/Pulse.Checker.Prover.IntroPure.fst
+++ b/src/checker/Pulse.Checker.Prover.IntroPure.fst
@@ -25,6 +25,7 @@ open Pulse.Checker.VPropEquiv
 open Pulse.Checker.Prover.Base
 open Pulse.Checker.Base
 open Pulse.Checker.Prover.Util
+open Pulse.PP
 module RU = Pulse.RuntimeUtils
 module T = FStar.Tactics.V2
 module P = Pulse.Syntax.Printer
@@ -235,8 +236,8 @@ let intro_pure (#preamble:_) (pst:prover_state preamble)
     then ()
     else 
       fail_doc pst.pg (Some (Pulse.RuntimeUtils.range_of_term t_ss))
-        [Pulse.PP.text "Could not resolve all free variables in the proposition: ";
-         P.term_to_doc t_ss;]
+        [prefix 2 1 (text "Could not resolve all free variables in the proposition:")
+                    (pp t_ss);]
   in
   let d = core_check_tot_term pst.pg t_ss tm_prop in
   let d_valid = check_prop_validity pst.pg t_ss d in

--- a/src/checker/Pulse.Checker.Prover.fst
+++ b/src/checker/Pulse.Checker.Prover.fst
@@ -169,7 +169,7 @@ let rec prover
               let open Pulse.PP in
               let msg = [
                 text "Cannot prove:" ^^
-                    indent (pp q);
+                    indent (pp pst.ss.(q));
                 text "In the context:" ^^
                     indent (P.term_to_doc (list_as_vprop pst.remaining_ctxt))
               ] @ (if Pulse.Config.debug_flag "initial_solver_state" then [

--- a/src/checker/Pulse.Checker.Prover.fst
+++ b/src/checker/Pulse.Checker.Prover.fst
@@ -171,7 +171,7 @@ let rec prover
                 text "Cannot prove:" ^^
                     indent (pp pst.ss.(q));
                 text "In the context:" ^^
-                    indent (P.term_to_doc (list_as_vprop pst.remaining_ctxt))
+                    indent (pp (list_as_vprop pst.remaining_ctxt))
               ] @ (if Pulse.Config.debug_flag "initial_solver_state" then [
                     text "The prover was started with goal:" ^^
                         indent (pp preamble.goals);

--- a/src/checker/Pulse.PP.fst
+++ b/src/checker/Pulse.PP.fst
@@ -72,7 +72,7 @@ instance printable_list (a:Type) (_ : printable a) : printable (list a) = {
   pp = (fun l -> brackets (separate_map comma pp l))
 }
 
-instance printable_term     : printable term = from_show
+instance printable_term     : printable term = { pp = term_to_doc; }
 instance printable_st_term  : printable st_term = from_show
 instance printable_universe : printable universe = from_show
 instance printable_comp     : printable comp = from_show
@@ -96,11 +96,6 @@ instance printable_post_hint_t : printable post_hint_t = {
                     ; "ret_ty", pp h.ret_ty
                     ; "u", pp h.u
                     ; "post", pp h.post ]);
-}
-
-// FIXME: use term_to_doc when available
-instance printable_fstar_term : printable Reflection.V2.term = {
-  pp = (fun t -> doc_of_string (Tactics.V2.term_to_string t))
 }
 
 instance printable_tuple2 (a b:Type)

--- a/src/checker/Pulse.PP.fsti
+++ b/src/checker/Pulse.PP.fsti
@@ -49,7 +49,11 @@ instance val printable_ctag   : printable ctag
 instance val printable_option (a:Type) (_ : printable a) : printable (option a)
 instance val printable_list (a:Type) (_ : printable a) : printable (list a)
 
+(* NOTE!! Pulse.term and FStar.Reflection.term are the same type. This instance
+is used to pretty-print pulse terms and fstar terms. Its implementation is Pulse-aware,
+however, and will use the view to show the pulse term structure. *)
 instance val printable_term     : printable term
+
 instance val printable_st_term  : printable st_term
 instance val printable_universe : printable universe
 instance val printable_comp     : printable comp
@@ -59,8 +63,6 @@ instance val printable_env : printable env
 instance val pp_effect_annot : printable effect_annot
 
 instance val printable_post_hint_t : printable post_hint_t
-
-instance val printable_fstar_term : printable Reflection.V2.term
 
 instance val printable_tuple2 (a b:Type)
           (_:printable a) (_:printable b)

--- a/src/checker/Pulse.Typing.Env.fst
+++ b/src/checker/Pulse.Typing.Env.fst
@@ -375,8 +375,9 @@ let rec separate_map (sep: document) (f : 'a -> T.Tac document) (l : list 'a) : 
 let env_to_doc (e:env) : T.Tac document =
   let pp1 : ((var & typ) & ppname) -> T.Tac document =
     fun ((n, t), x) ->
-      doc_of_string (T.unseal x.name) ^^ doc_of_string "#" ^^ doc_of_string (string_of_int n)
-        ^^ doc_of_string " : " ^^ Pulse.Syntax.Printer.term_to_doc t
+      infix 2 1 colon
+        (doc_of_string (T.unseal x.name ^ "#" ^ string_of_int n))
+        (align (Pulse.Syntax.Printer.term_to_doc t))
   in
   brackets (separate_map comma pp1 (T.zip e.bs e.names))
 

--- a/src/checker/Pulse.Typing.Util.fst
+++ b/src/checker/Pulse.Typing.Util.fst
@@ -21,9 +21,18 @@ module T = FStar.Tactics.V2
 module RU = Pulse.RuntimeUtils
 (* Call check_equiv under a SMTSync guard policy *)
 let check_equiv_now tcenv t0 t1 =
-  RU.disable_admit_smt_queries (fun _ -> 
+  RU.disable_admit_smt_queries (fun _ ->
     T.with_policy SMTSync (fun () ->
       T.check_equiv tcenv t0 t1))
+
+(* Call check_equiv without allowing
+it to generate guards nor unfold. It's a very
+simple use of the core checker + unifier.
+The Force guard_policy is probably unneeded, as no
+guards should appear. *)
+let check_equiv_now_nosmt tcenv t0 t1 =
+  RU.disable_admit_smt_queries (fun _ ->
+      T.check_equiv_nosmt tcenv t0 t1)
 
 let universe_of_now g e =
   T.with_policy SMTSync (fun () ->

--- a/src/checker/Pulse.Typing.Util.fsti
+++ b/src/checker/Pulse.Typing.Util.fsti
@@ -22,6 +22,9 @@ open FStar.Tactics.V2
 val check_equiv_now : g:env -> t1:term -> t2:term ->
   Tac (option (equiv_token g t1 t2) & issues)
 
+val check_equiv_now_nosmt : g:env -> t1:term -> t2:term ->
+  Tac (option (equiv_token g t1 t2) & issues)
+
 (* Like T.universe_of, but will make sure to not delay any VC. *)
 val universe_of_now : g:env -> e:term ->
   Tac (option (u:universe{typing_token g e (E_Total, pack_ln (Reflection.V2.Tv_Type u))}) & issues)

--- a/src/ocaml/plugin/generated/Pulse_Checker_Abs.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Abs.ml
@@ -1718,7 +1718,7 @@ let (check_effect_annotation :
                                                                     (Prims.of_int (80)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     i))
                                                                     (fun
                                                                     uu___1 ->
@@ -1791,7 +1791,7 @@ let (check_effect_annotation :
                                                                     (Prims.of_int (93)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     j))
                                                                     (fun
                                                                     uu___2 ->
@@ -2093,7 +2093,7 @@ let (check_effect_annotation :
                                                                     (Prims.of_int (80)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     i))
                                                                     (fun
                                                                     uu___1 ->
@@ -2166,7 +2166,7 @@ let (check_effect_annotation :
                                                                     (Prims.of_int (93)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     j))
                                                                     (fun
                                                                     uu___2 ->

--- a/src/ocaml/plugin/generated/Pulse_Checker_AssertWithBinders.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_AssertWithBinders.ml
@@ -2284,7 +2284,7 @@ let (check :
                                                                 (Prims.of_int (339))
                                                                 (Prims.of_int (6))
                                                                 (Prims.of_int (340))
-                                                                (Prims.of_int (63)))))
+                                                                (Prims.of_int (52)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
@@ -2302,7 +2302,7 @@ let (check :
                                                                     (Prims.of_int (340))
                                                                     (Prims.of_int (12))
                                                                     (Prims.of_int (340))
-                                                                    (Prims.of_int (63)))))
+                                                                    (Prims.of_int (52)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
@@ -2310,7 +2310,7 @@ let (check :
                                                                     (Prims.of_int (339))
                                                                     (Prims.of_int (6))
                                                                     (Prims.of_int (340))
-                                                                    (Prims.of_int (63)))))
+                                                                    (Prims.of_int (52)))))
                                                              (Obj.magic
                                                                 (FStar_Tactics_Effect.tac_bind
                                                                    (FStar_Sealed.seal
@@ -2320,7 +2320,7 @@ let (check :
                                                                     (Prims.of_int (340))
                                                                     (Prims.of_int (19))
                                                                     (Prims.of_int (340))
-                                                                    (Prims.of_int (63)))))
+                                                                    (Prims.of_int (52)))))
                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -2328,9 +2328,10 @@ let (check :
                                                                     (Prims.of_int (340))
                                                                     (Prims.of_int (12))
                                                                     (Prims.of_int (340))
-                                                                    (Prims.of_int (63)))))
+                                                                    (Prims.of_int (52)))))
                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_doc
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.printable_term
                                                                     (Pulse_Checker_VPropEquiv.canon_vprop
                                                                     pre)))
                                                                    (fun

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover.ml
@@ -219,7 +219,7 @@ let rec (prove_pures :
                                                                (Prims.of_int (17)))))
                                                       (Obj.magic
                                                          (Pulse_PP.pp
-                                                            Pulse_PP.printable_fstar_term
+                                                            Pulse_PP.printable_term
                                                             p1))
                                                       (fun uu___ ->
                                                          FStar_Tactics_Effect.lift_div_tac
@@ -992,7 +992,7 @@ let rec (prover :
                                                                     (Prims.of_int (171))
                                                                     (Prims.of_int (16))
                                                                     (Prims.of_int (172))
-                                                                    (Prims.of_int (33)))))
+                                                                    (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1010,7 +1010,7 @@ let rec (prover :
                                                                     (Prims.of_int (172))
                                                                     (Prims.of_int (20))
                                                                     (Prims.of_int (172))
-                                                                    (Prims.of_int (33)))))
+                                                                    (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1018,7 +1018,7 @@ let rec (prover :
                                                                     (Prims.of_int (171))
                                                                     (Prims.of_int (16))
                                                                     (Prims.of_int (172))
-                                                                    (Prims.of_int (33)))))
+                                                                    (Prims.of_int (42)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
@@ -1028,7 +1028,7 @@ let rec (prover :
                                                                     (Prims.of_int (172))
                                                                     (Prims.of_int (27))
                                                                     (Prims.of_int (172))
-                                                                    (Prims.of_int (33)))))
+                                                                    (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1036,11 +1036,13 @@ let rec (prover :
                                                                     (Prims.of_int (172))
                                                                     (Prims.of_int (20))
                                                                     (Prims.of_int (172))
-                                                                    (Prims.of_int (33)))))
+                                                                    (Prims.of_int (42)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
-                                                                    q))
+                                                                    Pulse_PP.printable_term
+                                                                    (Pulse_Checker_Prover_Base.op_Array_Access
+                                                                    pst3.Pulse_Checker_Prover_Base.ss
+                                                                    q)))
                                                                     (fun
                                                                     uu___10
                                                                     ->
@@ -1094,7 +1096,7 @@ let rec (prover :
                                                                     (Prims.of_int (173))
                                                                     (Prims.of_int (16))
                                                                     (Prims.of_int (174))
-                                                                    (Prims.of_int (77)))))
+                                                                    (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1112,7 +1114,7 @@ let rec (prover :
                                                                     (Prims.of_int (174))
                                                                     (Prims.of_int (20))
                                                                     (Prims.of_int (174))
-                                                                    (Prims.of_int (77)))))
+                                                                    (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1120,7 +1122,7 @@ let rec (prover :
                                                                     (Prims.of_int (173))
                                                                     (Prims.of_int (16))
                                                                     (Prims.of_int (174))
-                                                                    (Prims.of_int (77)))))
+                                                                    (Prims.of_int (66)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
@@ -1130,7 +1132,7 @@ let rec (prover :
                                                                     (Prims.of_int (174))
                                                                     (Prims.of_int (27))
                                                                     (Prims.of_int (174))
-                                                                    (Prims.of_int (77)))))
+                                                                    (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1138,9 +1140,10 @@ let rec (prover :
                                                                     (Prims.of_int (174))
                                                                     (Prims.of_int (20))
                                                                     (Prims.of_int (174))
-                                                                    (Prims.of_int (77)))))
+                                                                    (Prims.of_int (66)))))
                                                                     (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_doc
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.printable_term
                                                                     (Pulse_Typing_Combinators.list_as_vprop
                                                                     pst3.Pulse_Checker_Prover_Base.remaining_ctxt)))
                                                                     (fun
@@ -1293,7 +1296,7 @@ let rec (prover :
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     preamble.Pulse_Checker_Prover_Base.goals))
                                                                     (fun
                                                                     uu___12
@@ -1395,7 +1398,7 @@ let rec (prover :
                                                                     (Prims.of_int (49)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     preamble.Pulse_Checker_Prover_Base.ctxt))
                                                                     (fun
                                                                     uu___13
@@ -2633,6 +2636,49 @@ let (try_frame_pre :
                  (fun uvs ->
                     Obj.magic (try_frame_pre_uvs g ctxt () uvs d res_ppname))
                    uu___)
+let (check_equiv_emp' :
+  Pulse_Typing_Env.env ->
+    Pulse_Syntax_Base.vprop ->
+      (unit FStar_Pervasives_Native.option, unit)
+        FStar_Tactics_Effect.tac_repr)
+  =
+  fun uu___1 ->
+    fun uu___ ->
+      (fun g ->
+         fun p ->
+           match Pulse_Checker_Base.check_equiv_emp g p with
+           | FStar_Pervasives_Native.Some t ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.lift_div_tac
+                       (fun uu___ -> FStar_Pervasives_Native.Some ())))
+           | FStar_Pervasives_Native.None ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
+                                (Prims.of_int (404)) (Prims.of_int (10))
+                                (Prims.of_int (404)) (Prims.of_int (71)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
+                                (Prims.of_int (404)) (Prims.of_int (4))
+                                (Prims.of_int (407)) (Prims.of_int (21)))))
+                       (Obj.magic
+                          (Pulse_Typing_Util.check_equiv_now_nosmt
+                             (Pulse_Typing.elab_env g) p
+                             Pulse_Syntax_Pure.tm_emp))
+                       (fun uu___ ->
+                          FStar_Tactics_Effect.lift_div_tac
+                            (fun uu___1 ->
+                               match uu___ with
+                               | (FStar_Pervasives_Native.Some tok, uu___2)
+                                   -> FStar_Pervasives_Native.Some ()
+                               | (FStar_Pervasives_Native.None, uu___2) ->
+                                   FStar_Pervasives_Native.None))))) uu___1
+        uu___
 let (prove_post_hint :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.vprop ->
@@ -2651,13 +2697,13 @@ let (prove_post_hint :
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                       (Prims.of_int (406)) (Prims.of_int (10))
-                       (Prims.of_int (406)) (Prims.of_int (46)))))
+                       (Prims.of_int (416)) (Prims.of_int (10))
+                       (Prims.of_int (416)) (Prims.of_int (46)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                       (Prims.of_int (408)) (Prims.of_int (2))
-                       (Prims.of_int (463)) (Prims.of_int (99)))))
+                       (Prims.of_int (418)) (Prims.of_int (2))
+                       (Prims.of_int (473)) (Prims.of_int (99)))))
               (FStar_Tactics_Effect.lift_div_tac
                  (fun uu___ ->
                     Pulse_Typing_Env.push_context g "prove_post_hint" rng))
@@ -2677,17 +2723,17 @@ let (prove_post_hint :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Prover.fst"
-                                         (Prims.of_int (411))
+                                         (Prims.of_int (421))
                                          (Prims.of_int (79))
-                                         (Prims.of_int (411))
+                                         (Prims.of_int (421))
                                          (Prims.of_int (80)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Prover.fst"
-                                         (Prims.of_int (410))
+                                         (Prims.of_int (420))
                                          (Prims.of_int (21))
-                                         (Prims.of_int (463))
+                                         (Prims.of_int (473))
                                          (Prims.of_int (99)))))
                                 (FStar_Tactics_Effect.lift_div_tac
                                    (fun uu___ -> r))
@@ -2706,17 +2752,17 @@ let (prove_post_hint :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.fst"
-                                                        (Prims.of_int (413))
+                                                        (Prims.of_int (423))
                                                         (Prims.of_int (17))
-                                                        (Prims.of_int (413))
+                                                        (Prims.of_int (423))
                                                         (Prims.of_int (44)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.fst"
-                                                        (Prims.of_int (413))
+                                                        (Prims.of_int (423))
                                                         (Prims.of_int (47))
-                                                        (Prims.of_int (463))
+                                                        (Prims.of_int (473))
                                                         (Prims.of_int (99)))))
                                                (FStar_Tactics_Effect.lift_div_tac
                                                   (fun uu___1 ->
@@ -2730,17 +2776,17 @@ let (prove_post_hint :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Prover.fst"
-                                                                   (Prims.of_int (414))
+                                                                   (Prims.of_int (424))
                                                                    (Prims.of_int (27))
-                                                                   (Prims.of_int (414))
+                                                                   (Prims.of_int (424))
                                                                    (Prims.of_int (66)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Prover.fst"
-                                                                   (Prims.of_int (417))
+                                                                   (Prims.of_int (427))
                                                                    (Prims.of_int (4))
-                                                                   (Prims.of_int (463))
+                                                                   (Prims.of_int (473))
                                                                    (Prims.of_int (99)))))
                                                           (FStar_Tactics_Effect.lift_div_tac
                                                              (fun uu___1 ->
@@ -2766,17 +2812,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (420))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (426))
+                                                                    (Prims.of_int (436))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (420))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (426))
+                                                                    (Prims.of_int (436))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2784,17 +2830,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (420))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (426))
+                                                                    (Prims.of_int (436))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (420))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (426))
+                                                                    (Prims.of_int (436))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2802,17 +2848,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (432))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (425))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (420))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (426))
+                                                                    (Prims.of_int (436))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2820,17 +2866,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (425))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (432))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (425))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2838,17 +2884,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (425))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2856,21 +2902,21 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (24)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     ty))
                                                                     (fun
                                                                     uu___1 ->
@@ -2889,17 +2935,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (424))
+                                                                    (Prims.of_int (434))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (425))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (425))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2907,17 +2953,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (425))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (425))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (424))
+                                                                    (Prims.of_int (434))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (425))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2925,21 +2971,21 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (425))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (425))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (425))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (425))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     post_hint1.Pulse_Typing.ret_ty))
                                                                     (fun
                                                                     uu___2 ->
@@ -3028,17 +3074,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (431))
+                                                                    (Prims.of_int (441))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (431))
+                                                                    (Prims.of_int (441))
                                                                     (Prims.of_int (93)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (439))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (463))
+                                                                    (Prims.of_int (473))
                                                                     (Prims.of_int (99)))))
                                                                     (Obj.magic
                                                                     (prove g2
@@ -3067,17 +3113,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (436))
+                                                                    (Prims.of_int (446))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (436))
+                                                                    (Prims.of_int (446))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (438))
+                                                                    (Prims.of_int (448))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (463))
+                                                                    (Prims.of_int (473))
                                                                     (Prims.of_int (99)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3089,10 +3135,33 @@ let (prove_post_hint :
                                                                     (fun
                                                                     k_post1
                                                                     ->
-                                                                    match 
-                                                                    Pulse_Checker_Base.check_equiv_emp
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (448))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (448))
+                                                                    (Prims.of_int (46)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (448))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (473))
+                                                                    (Prims.of_int (99)))))
+                                                                    (Obj.magic
+                                                                    (check_equiv_emp'
                                                                     g3
-                                                                    remaining_ctxt
+                                                                    remaining_ctxt))
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    match uu___5
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.None
@@ -3104,17 +3173,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (441))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (449))
+                                                                    (Prims.of_int (459))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (441))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (449))
+                                                                    (Prims.of_int (459))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3122,17 +3191,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (441))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (449))
+                                                                    (Prims.of_int (459))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (441))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (449))
+                                                                    (Prims.of_int (459))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3140,17 +3209,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (443))
+                                                                    (Prims.of_int (453))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (444))
-                                                                    (Prims.of_int (38)))))
+                                                                    (Prims.of_int (454))
+                                                                    (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (441))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (449))
+                                                                    (Prims.of_int (459))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3158,62 +3227,63 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (444))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (444))
-                                                                    (Prims.of_int (38)))))
+                                                                    (Prims.of_int (454))
+                                                                    (Prims.of_int (21))
+                                                                    (Prims.of_int (454))
+                                                                    (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (443))
+                                                                    (Prims.of_int (453))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (444))
-                                                                    (Prims.of_int (38)))))
+                                                                    (Prims.of_int (454))
+                                                                    (Prims.of_int (59)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (444))
-                                                                    (Prims.of_int (19))
-                                                                    (Prims.of_int (444))
-                                                                    (Prims.of_int (38)))))
+                                                                    (Prims.of_int (454))
+                                                                    (Prims.of_int (28))
+                                                                    (Prims.of_int (454))
+                                                                    (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (444))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (444))
-                                                                    (Prims.of_int (38)))))
+                                                                    (Prims.of_int (454))
+                                                                    (Prims.of_int (21))
+                                                                    (Prims.of_int (454))
+                                                                    (Prims.of_int (59)))))
                                                                     (Obj.magic
-                                                                    (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    (Pulse_Syntax_Printer.term_to_doc
                                                                     remaining_ctxt))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___6 ->
-                                                                    Pulse_PP.indent
-                                                                    uu___5))))
+                                                                    uu___7 ->
+                                                                    FStar_Pprint.align
+                                                                    uu___6))))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___6 ->
-                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___7 ->
+                                                                    FStar_Pprint.prefix
+                                                                    (Prims.of_int (2))
+                                                                    Prims.int_one
                                                                     (Pulse_PP.text
                                                                     "Inferred postcondition additionally contains")
-                                                                    uu___5))))
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    uu___6))))
                                                                     (fun
                                                                     uu___6 ->
-                                                                    [uu___5;
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    [uu___6;
                                                                     if
                                                                     Pulse_Syntax_Pure.uu___is_Tm_Star
                                                                     (Pulse_Syntax_Pure.inspect_term
@@ -3225,24 +3295,24 @@ let (prove_post_hint :
                                                                     Pulse_PP.text
                                                                     "Did you forget to free this resource?"]))))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___7 ->
                                                                     (Pulse_PP.text
                                                                     "Error in proving postcondition")
-                                                                    :: uu___5))))
+                                                                    :: uu___6))))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     Obj.magic
                                                                     (Pulse_Typing_Env.fail_doc
                                                                     g1
                                                                     (FStar_Pervasives_Native.Some
                                                                     rng)
-                                                                    uu___5))
-                                                                    uu___5)))
+                                                                    uu___6))
+                                                                    uu___6)))
                                                                     | 
                                                                     FStar_Pervasives_Native.Some
                                                                     d ->
@@ -3250,7 +3320,7 @@ let (prove_post_hint :
                                                                     (Obj.repr
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     FStar_Pervasives.Mkdtuple5
                                                                     (x, g3,
                                                                     (FStar_Pervasives.Mkdtuple3
@@ -3278,6 +3348,7 @@ let (prove_post_hint :
                                                                     post_hint_opened
                                                                     k_post1
                                                                     () ())))))))
+                                                                    uu___5)))
                                                                     uu___5)))
                                                                     uu___3)))))
                                                                uu___1)))

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_IntroPure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_IntroPure.ml
@@ -21,14 +21,14 @@ let (k_intro_pure :
                  (Obj.magic
                     (FStar_Range.mk_range
                        "Pulse.Checker.Prover.IntroPure.fst"
-                       (Prims.of_int (41)) (Prims.of_int (10))
-                       (Prims.of_int (41)) (Prims.of_int (50)))))
+                       (Prims.of_int (42)) (Prims.of_int (10))
+                       (Prims.of_int (42)) (Prims.of_int (50)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range
                        "Pulse.Checker.Prover.IntroPure.fst"
-                       (Prims.of_int (41)) (Prims.of_int (53))
-                       (Prims.of_int (75)) (Prims.of_int (30)))))
+                       (Prims.of_int (42)) (Prims.of_int (53))
+                       (Prims.of_int (76)) (Prims.of_int (30)))))
               (FStar_Tactics_Effect.lift_div_tac
                  (fun uu___ ->
                     Pulse_Typing.wtag
@@ -44,14 +44,14 @@ let (k_intro_pure :
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Checker.Prover.IntroPure.fst"
-                                  (Prims.of_int (42)) (Prims.of_int (10))
-                                  (Prims.of_int (42)) (Prims.of_int (27)))))
+                                  (Prims.of_int (43)) (Prims.of_int (10))
+                                  (Prims.of_int (43)) (Prims.of_int (27)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Checker.Prover.IntroPure.fst"
-                                  (Prims.of_int (42)) (Prims.of_int (30))
-                                  (Prims.of_int (75)) (Prims.of_int (30)))))
+                                  (Prims.of_int (43)) (Prims.of_int (30))
+                                  (Prims.of_int (76)) (Prims.of_int (30)))))
                          (FStar_Tactics_Effect.lift_div_tac
                             (fun uu___ -> Pulse_Typing.comp_intro_pure p))
                          (fun uu___ ->
@@ -62,17 +62,17 @@ let (k_intro_pure :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Prover.IntroPure.fst"
-                                             (Prims.of_int (43))
+                                             (Prims.of_int (44))
                                              (Prims.of_int (28))
-                                             (Prims.of_int (43))
+                                             (Prims.of_int (44))
                                              (Prims.of_int (51)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Prover.IntroPure.fst"
-                                             (Prims.of_int (43))
+                                             (Prims.of_int (44))
                                              (Prims.of_int (54))
-                                             (Prims.of_int (75))
+                                             (Prims.of_int (76))
                                              (Prims.of_int (30)))))
                                     (FStar_Tactics_Effect.lift_div_tac
                                        (fun uu___ ->
@@ -86,17 +86,17 @@ let (k_intro_pure :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.IntroPure.fst"
-                                                        (Prims.of_int (45))
+                                                        (Prims.of_int (46))
                                                         (Prims.of_int (10))
-                                                        (Prims.of_int (45))
+                                                        (Prims.of_int (46))
                                                         (Prims.of_int (17)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.IntroPure.fst"
-                                                        (Prims.of_int (48))
+                                                        (Prims.of_int (49))
                                                         (Prims.of_int (30))
-                                                        (Prims.of_int (75))
+                                                        (Prims.of_int (76))
                                                         (Prims.of_int (30)))))
                                                (FStar_Tactics_Effect.lift_div_tac
                                                   (fun uu___ ->
@@ -109,17 +109,17 @@ let (k_intro_pure :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Prover.IntroPure.fst"
-                                                                   (Prims.of_int (50))
+                                                                   (Prims.of_int (51))
                                                                    (Prims.of_int (15))
-                                                                   (Prims.of_int (50))
+                                                                   (Prims.of_int (51))
                                                                    (Prims.of_int (44)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Prover.IntroPure.fst"
-                                                                   (Prims.of_int (50))
+                                                                   (Prims.of_int (51))
                                                                    (Prims.of_int (47))
-                                                                   (Prims.of_int (75))
+                                                                   (Prims.of_int (76))
                                                                    (Prims.of_int (30)))))
                                                           (FStar_Tactics_Effect.lift_div_tac
                                                              (fun uu___ ->
@@ -133,17 +133,17 @@ let (k_intro_pure :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (55))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (54))
+                                                                    (Prims.of_int (55))
                                                                     (Prims.of_int (71)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (61))
+                                                                    (Prims.of_int (62))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (75))
+                                                                    (Prims.of_int (76))
                                                                     (Prims.of_int (30)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.continuation_elaborator_with_bind
@@ -164,17 +164,17 @@ let (k_intro_pure :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (62))
+                                                                    (Prims.of_int (63))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (62))
+                                                                    (Prims.of_int (63))
                                                                     (Prims.of_int (26)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (61))
+                                                                    (Prims.of_int (62))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (75))
+                                                                    (Prims.of_int (76))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -196,17 +196,17 @@ let (k_intro_pure :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (64))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (64))
                                                                     (Prims.of_int (33)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (64))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (75))
+                                                                    (Prims.of_int (76))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -222,17 +222,17 @@ let (k_intro_pure :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (64))
+                                                                    (Prims.of_int (65))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (64))
+                                                                    (Prims.of_int (65))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (67))
+                                                                    (Prims.of_int (68))
                                                                     (Prims.of_int (59))
-                                                                    (Prims.of_int (75))
+                                                                    (Prims.of_int (76))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -251,17 +251,17 @@ let (k_intro_pure :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (70))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (73))
+                                                                    (Prims.of_int (74))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (75))
+                                                                    (Prims.of_int (76))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (75))
+                                                                    (Prims.of_int (76))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -369,12 +369,12 @@ let (is_uvar_implication : pure_uv_heuristic_t) =
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Prover.IntroPure.fst"
-                 (Prims.of_int (126)) (Prims.of_int (4)) (Prims.of_int (126))
+                 (Prims.of_int (127)) (Prims.of_int (4)) (Prims.of_int (127))
                  (Prims.of_int (90)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Prover.IntroPure.fst"
-                 (Prims.of_int (127)) (Prims.of_int (4)) (Prims.of_int (168))
+                 (Prims.of_int (128)) (Prims.of_int (4)) (Prims.of_int (169))
                  (Prims.of_int (15)))))
         (Obj.magic
            (Pulse_Checker_Base.debug uvs
@@ -384,8 +384,8 @@ let (is_uvar_implication : pure_uv_heuristic_t) =
                       (Obj.magic
                          (FStar_Range.mk_range
                             "Pulse.Checker.Prover.IntroPure.fst"
-                            (Prims.of_int (126)) (Prims.of_int (69))
-                            (Prims.of_int (126)) (Prims.of_int (89)))))
+                            (Prims.of_int (127)) (Prims.of_int (69))
+                            (Prims.of_int (127)) (Prims.of_int (89)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -408,14 +408,14 @@ let (is_uvar_implication : pure_uv_heuristic_t) =
                              (Obj.magic
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Prover.IntroPure.fst"
-                                   (Prims.of_int (129)) (Prims.of_int (15))
-                                   (Prims.of_int (129)) (Prims.of_int (16)))))
+                                   (Prims.of_int (130)) (Prims.of_int (15))
+                                   (Prims.of_int (130)) (Prims.of_int (16)))))
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Prover.IntroPure.fst"
-                                   (Prims.of_int (129)) (Prims.of_int (19))
-                                   (Prims.of_int (166)) (Prims.of_int (17)))))
+                                   (Prims.of_int (130)) (Prims.of_int (19))
+                                   (Prims.of_int (167)) (Prims.of_int (17)))))
                           (FStar_Tactics_Effect.lift_div_tac
                              (fun uu___2 -> t))
                           (fun uu___2 ->
@@ -426,17 +426,17 @@ let (is_uvar_implication : pure_uv_heuristic_t) =
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.Prover.IntroPure.fst"
-                                              (Prims.of_int (130))
+                                              (Prims.of_int (131))
                                               (Prims.of_int (14))
-                                              (Prims.of_int (130))
+                                              (Prims.of_int (131))
                                               (Prims.of_int (36)))))
                                      (FStar_Sealed.seal
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.Prover.IntroPure.fst"
-                                              (Prims.of_int (131))
+                                              (Prims.of_int (132))
                                               (Prims.of_int (6))
-                                              (Prims.of_int (166))
+                                              (Prims.of_int (167))
                                               (Prims.of_int (17)))))
                                      (Obj.magic
                                         (FStar_Reflection_V2_Formula.term_as_formula'
@@ -453,17 +453,17 @@ let (is_uvar_implication : pure_uv_heuristic_t) =
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Prover.IntroPure.fst"
-                                                                (Prims.of_int (133))
+                                                                (Prims.of_int (134))
                                                                 (Prims.of_int (8))
-                                                                (Prims.of_int (133))
+                                                                (Prims.of_int (134))
                                                                 (Prims.of_int (99)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Prover.IntroPure.fst"
-                                                                (Prims.of_int (134))
+                                                                (Prims.of_int (135))
                                                                 (Prims.of_int (8))
-                                                                (Prims.of_int (164))
+                                                                (Prims.of_int (165))
                                                                 (Prims.of_int (11)))))
                                                        (Obj.magic
                                                           (Pulse_Checker_Base.debug
@@ -474,9 +474,9 @@ let (is_uvar_implication : pure_uv_heuristic_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (77))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (98)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -520,17 +520,17 @@ let (is_uvar_implication : pure_uv_heuristic_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (138))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (138))
                                                                     (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (139))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (163))
+                                                                    (Prims.of_int (164))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -578,17 +578,17 @@ let (is_uvar_implication : pure_uv_heuristic_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (145))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (162))
                                                                     (Prims.of_int (22)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -666,17 +666,17 @@ let (is_uvar_implication : pure_uv_heuristic_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (162))
                                                                     (Prims.of_int (22)))))
                                                                     (Obj.magic
                                                                     (try_negated
@@ -745,14 +745,14 @@ let (pure_uvar_heursitics : pure_uv_heuristic_t) =
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "Pulse.Checker.Prover.IntroPure.fst"
-                                (Prims.of_int (178)) (Prims.of_int (16))
-                                (Prims.of_int (178)) (Prims.of_int (23)))))
+                                (Prims.of_int (179)) (Prims.of_int (16))
+                                (Prims.of_int (179)) (Prims.of_int (23)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "Pulse.Checker.Prover.IntroPure.fst"
-                                (Prims.of_int (178)) (Prims.of_int (16))
-                                (Prims.of_int (178)) (Prims.of_int (23)))))
+                                (Prims.of_int (179)) (Prims.of_int (16))
+                                (Prims.of_int (179)) (Prims.of_int (23)))))
                        (Obj.magic (h2 uvs t))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -787,14 +787,14 @@ let rec (try_collect_substs :
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "Pulse.Checker.Prover.IntroPure.fst"
-                                (Prims.of_int (188)) (Prims.of_int (13))
-                                (Prims.of_int (188)) (Prims.of_int (14)))))
+                                (Prims.of_int (189)) (Prims.of_int (13))
+                                (Prims.of_int (189)) (Prims.of_int (14)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "Pulse.Checker.Prover.IntroPure.fst"
-                                (Prims.of_int (188)) (Prims.of_int (17))
-                                (Prims.of_int (208)) (Prims.of_int (7)))))
+                                (Prims.of_int (189)) (Prims.of_int (17))
+                                (Prims.of_int (209)) (Prims.of_int (7)))))
                        (FStar_Tactics_Effect.lift_div_tac (fun uu___1 -> t))
                        (fun uu___1 ->
                           (fun rt ->
@@ -804,17 +804,17 @@ let rec (try_collect_substs :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Prover.IntroPure.fst"
-                                           (Prims.of_int (189))
+                                           (Prims.of_int (190))
                                            (Prims.of_int (12))
-                                           (Prims.of_int (189))
+                                           (Prims.of_int (190))
                                            (Prims.of_int (34)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Prover.IntroPure.fst"
-                                           (Prims.of_int (191))
+                                           (Prims.of_int (192))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (207))
+                                           (Prims.of_int (208))
                                            (Prims.of_int (26)))))
                                   (Obj.magic
                                      (FStar_Reflection_V2_Formula.term_as_formula'
@@ -830,17 +830,17 @@ let rec (try_collect_substs :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Prover.IntroPure.fst"
-                                                          (Prims.of_int (193))
+                                                          (Prims.of_int (194))
                                                           (Prims.of_int (18))
-                                                          (Prims.of_int (193))
+                                                          (Prims.of_int (194))
                                                           (Prims.of_int (69)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Prover.IntroPure.fst"
-                                                          (Prims.of_int (193))
+                                                          (Prims.of_int (194))
                                                           (Prims.of_int (72))
-                                                          (Prims.of_int (199))
+                                                          (Prims.of_int (200))
                                                           (Prims.of_int (21)))))
                                                  (Obj.magic
                                                     (try_collect_substs uvs
@@ -855,17 +855,17 @@ let rec (try_collect_substs :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (194))
+                                                                    (Prims.of_int (195))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (194))
+                                                                    (Prims.of_int (195))
                                                                     (Prims.of_int (69)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (196))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (199))
+                                                                    (Prims.of_int (200))
                                                                     (Prims.of_int (21)))))
                                                             (Obj.magic
                                                                (try_collect_substs
@@ -893,17 +893,17 @@ let rec (try_collect_substs :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Prover.IntroPure.fst"
-                                                          (Prims.of_int (201))
+                                                          (Prims.of_int (202))
                                                           (Prims.of_int (14))
-                                                          (Prims.of_int (201))
+                                                          (Prims.of_int (202))
                                                           (Prims.of_int (40)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Prover.IntroPure.fst"
-                                                          (Prims.of_int (201))
+                                                          (Prims.of_int (202))
                                                           (Prims.of_int (8))
-                                                          (Prims.of_int (207))
+                                                          (Prims.of_int (208))
                                                           (Prims.of_int (26)))))
                                                  (Obj.magic
                                                     (pure_uvar_heursitics uvs
@@ -948,14 +948,14 @@ let (intro_pure :
                  (Obj.magic
                     (FStar_Range.mk_range
                        "Pulse.Checker.Prover.IntroPure.fst"
-                       (Prims.of_int (218)) (Prims.of_int (13))
-                       (Prims.of_int (218)) (Prims.of_int (23)))))
+                       (Prims.of_int (219)) (Prims.of_int (13))
+                       (Prims.of_int (219)) (Prims.of_int (23)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range
                        "Pulse.Checker.Prover.IntroPure.fst"
-                       (Prims.of_int (220)) (Prims.of_int (2))
-                       (Prims.of_int (359)) (Prims.of_int (14)))))
+                       (Prims.of_int (221)) (Prims.of_int (2))
+                       (Prims.of_int (360)) (Prims.of_int (14)))))
               (FStar_Tactics_Effect.lift_div_tac
                  (fun uu___1 ->
                     Pulse_Checker_Prover_Base.op_Array_Access
@@ -968,14 +968,14 @@ let (intro_pure :
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Checker.Prover.IntroPure.fst"
-                                  (Prims.of_int (220)) (Prims.of_int (2))
-                                  (Prims.of_int (223)) (Prims.of_int (30)))))
+                                  (Prims.of_int (221)) (Prims.of_int (2))
+                                  (Prims.of_int (224)) (Prims.of_int (30)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Checker.Prover.IntroPure.fst"
-                                  (Prims.of_int (223)) (Prims.of_int (31))
-                                  (Prims.of_int (359)) (Prims.of_int (14)))))
+                                  (Prims.of_int (224)) (Prims.of_int (31))
+                                  (Prims.of_int (360)) (Prims.of_int (14)))))
                          (Obj.magic
                             (Pulse_Checker_Prover_Util.debug_prover
                                pst.Pulse_Checker_Prover_Base.pg
@@ -985,17 +985,17 @@ let (intro_pure :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Prover.IntroPure.fst"
-                                             (Prims.of_int (223))
+                                             (Prims.of_int (224))
                                              (Prims.of_int (6))
-                                             (Prims.of_int (223))
+                                             (Prims.of_int (224))
                                              (Prims.of_int (29)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Prover.IntroPure.fst"
-                                             (Prims.of_int (221))
+                                             (Prims.of_int (222))
                                              (Prims.of_int (4))
-                                             (Prims.of_int (223))
+                                             (Prims.of_int (224))
                                              (Prims.of_int (29)))))
                                     (Obj.magic
                                        (Pulse_Typing_Env.env_to_string
@@ -1008,17 +1008,17 @@ let (intro_pure :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.IntroPure.fst"
-                                                        (Prims.of_int (221))
+                                                        (Prims.of_int (222))
                                                         (Prims.of_int (4))
-                                                        (Prims.of_int (223))
+                                                        (Prims.of_int (224))
                                                         (Prims.of_int (29)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.IntroPure.fst"
-                                                        (Prims.of_int (221))
+                                                        (Prims.of_int (222))
                                                         (Prims.of_int (4))
-                                                        (Prims.of_int (223))
+                                                        (Prims.of_int (224))
                                                         (Prims.of_int (29)))))
                                                (Obj.magic
                                                   (FStar_Tactics_Effect.tac_bind
@@ -1026,9 +1026,9 @@ let (intro_pure :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Prover.IntroPure.fst"
-                                                              (Prims.of_int (222))
+                                                              (Prims.of_int (223))
                                                               (Prims.of_int (6))
-                                                              (Prims.of_int (222))
+                                                              (Prims.of_int (223))
                                                               (Prims.of_int (29)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
@@ -1067,17 +1067,17 @@ let (intro_pure :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Prover.IntroPure.fst"
-                                             (Prims.of_int (226))
+                                             (Prims.of_int (227))
                                              (Prims.of_int (12))
-                                             (Prims.of_int (226))
+                                             (Prims.of_int (227))
                                              (Prims.of_int (43)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Prover.IntroPure.fst"
-                                             (Prims.of_int (227))
+                                             (Prims.of_int (228))
                                              (Prims.of_int (51))
-                                             (Prims.of_int (359))
+                                             (Prims.of_int (360))
                                              (Prims.of_int (14)))))
                                     (Obj.magic
                                        (try_collect_substs
@@ -1091,17 +1091,17 @@ let (intro_pure :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.IntroPure.fst"
-                                                        (Prims.of_int (228))
+                                                        (Prims.of_int (229))
                                                         (Prims.of_int (15))
-                                                        (Prims.of_int (228))
+                                                        (Prims.of_int (229))
                                                         (Prims.of_int (36)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.IntroPure.fst"
-                                                        (Prims.of_int (229))
+                                                        (Prims.of_int (230))
                                                         (Prims.of_int (38))
-                                                        (Prims.of_int (359))
+                                                        (Prims.of_int (360))
                                                         (Prims.of_int (14)))))
                                                (FStar_Tactics_Effect.lift_div_tac
                                                   (fun uu___2 ->
@@ -1116,17 +1116,17 @@ let (intro_pure :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Prover.IntroPure.fst"
-                                                                   (Prims.of_int (231))
+                                                                   (Prims.of_int (232))
                                                                    (Prims.of_int (13))
-                                                                   (Prims.of_int (231))
+                                                                   (Prims.of_int (232))
                                                                    (Prims.of_int (23)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Prover.IntroPure.fst"
-                                                                   (Prims.of_int (231))
+                                                                   (Prims.of_int (232))
                                                                    (Prims.of_int (26))
-                                                                   (Prims.of_int (359))
+                                                                   (Prims.of_int (360))
                                                                    (Prims.of_int (14)))))
                                                           (FStar_Tactics_Effect.lift_div_tac
                                                              (fun uu___2 ->
@@ -1140,17 +1140,17 @@ let (intro_pure :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (233))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (239))
-                                                                    (Prims.of_int (29)))))
+                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (359))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (14)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1158,18 +1158,18 @@ let (intro_pure :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (239))
-                                                                    (Prims.of_int (29)))))
+                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (31)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___2 ->
@@ -1198,36 +1198,18 @@ let (intro_pure :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (238))
-                                                                    (Prims.of_int (8))
                                                                     (Prims.of_int (239))
-                                                                    (Prims.of_int (29)))))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (239))
-                                                                    (Prims.of_int (29)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (238))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (239))
-                                                                    (Prims.of_int (29)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (238))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (239))
-                                                                    (Prims.of_int (29)))))
+                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
@@ -1236,33 +1218,55 @@ let (intro_pure :
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
                                                                     (Prims.of_int (239))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (239))
-                                                                    (Prims.of_int (27)))))
+                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (238))
-                                                                    (Prims.of_int (8))
                                                                     (Prims.of_int (239))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (31)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.IntroPure.fst"
+                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (29)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.IntroPure.fst"
+                                                                    (Prims.of_int (239))
+                                                                    (Prims.of_int (9))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_doc
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.printable_term
                                                                     t_ss1))
                                                                     (fun
                                                                     uu___3 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___4 ->
-                                                                    [uu___3]))))
+                                                                    FStar_Pprint.prefix
+                                                                    (Prims.of_int (2))
+                                                                    Prims.int_one
+                                                                    (Pulse_PP.text
+                                                                    "Could not resolve all free variables in the proposition:")
+                                                                    uu___3))))
                                                                     (fun
                                                                     uu___3 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___4 ->
-                                                                    (Pulse_PP.text
-                                                                    "Could not resolve all free variables in the proposition: ")
-                                                                    :: uu___3))))
+                                                                    [uu___3]))))
                                                                     (fun
                                                                     uu___3 ->
                                                                     (fun
@@ -1286,17 +1290,17 @@ let (intro_pure :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (359))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (14)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.core_check_tot_term
@@ -1312,17 +1316,17 @@ let (intro_pure :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (359))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (14)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_prop_validity
@@ -1339,17 +1343,17 @@ let (intro_pure :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (276))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (276))
                                                                     (Prims.of_int (41)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (276))
                                                                     (Prims.of_int (44))
-                                                                    (Prims.of_int (359))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (14)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1367,17 +1371,17 @@ let (intro_pure :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (46))
-                                                                    (Prims.of_int (359))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (14)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1397,17 +1401,17 @@ let (intro_pure :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (33))
-                                                                    (Prims.of_int (359))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (14)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1424,17 +1428,17 @@ let (intro_pure :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (283))
                                                                     (Prims.of_int (96))
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (359))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (359))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (14)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1442,17 +1446,17 @@ let (intro_pure :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (89)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (92))
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1475,17 +1479,17 @@ let (intro_pure :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroPure.fst"
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (k_intro_pure

--- a/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
@@ -316,7 +316,7 @@ let (check_ln :
                                                                     (Prims.of_int (37)))))
                                                                    (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     t))
                                                                    (fun
                                                                     uu___2 ->
@@ -2039,7 +2039,7 @@ let (ill_typed_term :
                           (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
                              (Prims.of_int (169)) (Prims.of_int (5))
                              (Prims.of_int (169)) (Prims.of_int (36)))))
-                    (Obj.magic (Pulse_PP.pp Pulse_PP.printable_fstar_term t))
+                    (Obj.magic (Pulse_PP.pp Pulse_PP.printable_term t))
                     (fun uu___1 ->
                        FStar_Tactics_Effect.lift_div_tac
                          (fun uu___2 ->
@@ -2104,8 +2104,7 @@ let (ill_typed_term :
                                          (Prims.of_int (171))
                                          (Prims.of_int (51)))))
                                 (Obj.magic
-                                   (Pulse_PP.pp Pulse_PP.printable_fstar_term
-                                      ty))
+                                   (Pulse_PP.pp Pulse_PP.printable_term ty))
                                 (fun uu___ ->
                                    FStar_Tactics_Effect.lift_div_tac
                                      (fun uu___1 ->
@@ -2173,8 +2172,7 @@ let (ill_typed_term :
                                                     (Prims.of_int (37)))))
                                            (Obj.magic
                                               (Pulse_PP.pp
-                                                 Pulse_PP.printable_fstar_term
-                                                 t))
+                                                 Pulse_PP.printable_term t))
                                            (fun uu___1 ->
                                               FStar_Tactics_Effect.lift_div_tac
                                                 (fun uu___2 ->
@@ -2250,8 +2248,7 @@ let (ill_typed_term :
                                          (Prims.of_int (174))
                                          (Prims.of_int (51)))))
                                 (Obj.magic
-                                   (Pulse_PP.pp Pulse_PP.printable_fstar_term
-                                      ty))
+                                   (Pulse_PP.pp Pulse_PP.printable_term ty))
                                 (fun uu___ ->
                                    FStar_Tactics_Effect.lift_div_tac
                                      (fun uu___1 ->
@@ -2337,7 +2334,7 @@ let (ill_typed_term :
                                                           (Prims.of_int (37)))))
                                                  (Obj.magic
                                                     (Pulse_PP.pp
-                                                       Pulse_PP.printable_fstar_term
+                                                       Pulse_PP.printable_term
                                                        t))
                                                  (fun uu___1 ->
                                                     FStar_Tactics_Effect.lift_div_tac
@@ -2408,7 +2405,7 @@ let (ill_typed_term :
                                                                     (Prims.of_int (38)))))
                                                             (Obj.magic
                                                                (Pulse_PP.pp
-                                                                  Pulse_PP.printable_fstar_term
+                                                                  Pulse_PP.printable_term
                                                                   ty'))
                                                             (fun uu___2 ->
                                                                FStar_Tactics_Effect.lift_div_tac
@@ -2690,7 +2687,7 @@ let (instantiate_term_implicits :
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     t0))
                                                                     (fun
                                                                     uu___2 ->
@@ -2788,7 +2785,7 @@ let (instantiate_term_implicits :
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     t0))
                                                                     (fun
                                                                     uu___2 ->
@@ -3020,7 +3017,7 @@ let (instantiate_term_implicits_uvs :
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     t0))
                                                                     (fun
                                                                     uu___2 ->
@@ -4626,7 +4623,7 @@ let (get_non_informative_witness :
                                                            (Prims.of_int (18)))))
                                                   (Obj.magic
                                                      (Pulse_PP.pp
-                                                        Pulse_PP.printable_fstar_term
+                                                        Pulse_PP.printable_term
                                                         t))
                                                   (fun uu___2 ->
                                                      FStar_Tactics_Effect.lift_div_tac
@@ -4792,7 +4789,7 @@ let (check_prop_validity :
                                                                 (Prims.of_int (63)))))
                                                        (Obj.magic
                                                           (Pulse_PP.pp
-                                                             Pulse_PP.printable_fstar_term
+                                                             Pulse_PP.printable_term
                                                              p))
                                                        (fun uu___3 ->
                                                           FStar_Tactics_Effect.lift_div_tac
@@ -5156,7 +5153,7 @@ let (check_subtyping :
                                                                     (Prims.of_int (46)))))
                                                                   (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     t1))
                                                                   (fun uu___3
                                                                     ->
@@ -5200,7 +5197,7 @@ let (check_subtyping :
                                                                     (Prims.of_int (46)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     t2))
                                                                     (fun
                                                                     uu___4 ->

--- a/src/ocaml/plugin/generated/Pulse_Checker_Rewrite.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Rewrite.ml
@@ -104,7 +104,7 @@ let (check_vprop_equiv_ext :
                                                                   (Prims.of_int (17)))))
                                                          (Obj.magic
                                                             (Pulse_PP.pp
-                                                               Pulse_PP.printable_fstar_term
+                                                               Pulse_PP.printable_term
                                                                p))
                                                          (fun uu___2 ->
                                                             (fun uu___2 ->
@@ -149,7 +149,7 @@ let (check_vprop_equiv_ext :
                                                                     (Prims.of_int (17)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     q))
                                                                     (fun
                                                                     uu___3 ->

--- a/src/ocaml/plugin/generated/Pulse_Checker_WithInv.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_WithInv.ml
@@ -221,7 +221,7 @@ let (add_remove_inverse :
                                                                     (Prims.of_int (15)))))
                                                                    (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     (add_iname
                                                                     (remove_iname
                                                                     inames i)
@@ -278,7 +278,7 @@ let (add_remove_inverse :
                                                                     (Prims.of_int (65)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     inames))
                                                                     (fun
                                                                     uu___2 ->
@@ -820,7 +820,7 @@ let (check :
                                                                     (Prims.of_int (75)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     i1))
                                                                     (fun
                                                                     uu___3 ->
@@ -875,7 +875,7 @@ let (check :
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     pre))
                                                                     (fun
                                                                     uu___4 ->
@@ -1094,7 +1094,7 @@ let (check :
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     post))
                                                                     (fun
                                                                     uu___7 ->
@@ -1555,7 +1555,7 @@ let (check :
                                                                     (Prims.of_int (75)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     i1))
                                                                     (fun
                                                                     uu___5 ->
@@ -1610,7 +1610,7 @@ let (check :
                                                                     (Prims.of_int (70)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
-                                                                    Pulse_PP.printable_fstar_term
+                                                                    Pulse_PP.printable_term
                                                                     post_hint1.Pulse_Typing.post))
                                                                     (fun
                                                                     uu___6 ->

--- a/src/ocaml/plugin/generated/Pulse_PP.ml
+++ b/src/ocaml/plugin/generated/Pulse_PP.ml
@@ -194,7 +194,7 @@ let printable_list : 'a . 'a printable -> 'a Prims.list printable =
                   (fun uu___2 -> FStar_Pprint.brackets uu___1)))
     }
 let (printable_term : Pulse_Syntax_Base.term printable) =
-  from_show Pulse_Show.tac_showable_r_term
+  { pp = Pulse_Syntax_Printer.term_to_doc }
 let (printable_st_term : Pulse_Syntax_Base.st_term printable) =
   from_show Pulse_Show.tac_showable_st_term
 let (printable_universe : Pulse_Syntax_Base.universe printable) =
@@ -572,26 +572,6 @@ let (printable_post_hint_t : Pulse_Typing.post_hint_t printable) =
                                  (fun uu___2 -> uu___ :: uu___1)))) uu___)))
            (fun uu___ -> (fun uu___ -> Obj.magic (pp_record uu___)) uu___))
   }
-let (printable_fstar_term : FStar_Reflection_Types.term printable) =
-  {
-    pp =
-      (fun t ->
-         FStar_Tactics_Effect.tac_bind
-           (FStar_Sealed.seal
-              (Obj.magic
-                 (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (103))
-                    (Prims.of_int (31)) (Prims.of_int (103))
-                    (Prims.of_int (60)))))
-           (FStar_Sealed.seal
-              (Obj.magic
-                 (FStar_Range.mk_range "Pulse.PP.fst" (Prims.of_int (103))
-                    (Prims.of_int (17)) (Prims.of_int (103))
-                    (Prims.of_int (60)))))
-           (Obj.magic (FStar_Tactics_V2_Builtins.term_to_string t))
-           (fun uu___ ->
-              FStar_Tactics_Effect.lift_div_tac
-                (fun uu___1 -> FStar_Pprint.doc_of_string uu___)))
-  }
 let printable_tuple2 :
   'a 'b . 'a printable -> 'b printable -> ('a * 'b) printable =
   fun uu___ ->
@@ -605,25 +585,25 @@ let printable_tuple2 :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.PP.fst"
-                            (Prims.of_int (108)) (Prims.of_int (29))
-                            (Prims.of_int (108)) (Prims.of_int (53)))))
+                            (Prims.of_int (103)) (Prims.of_int (29))
+                            (Prims.of_int (103)) (Prims.of_int (53)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.PP.fst"
-                            (Prims.of_int (108)) (Prims.of_int (22))
-                            (Prims.of_int (108)) (Prims.of_int (53)))))
+                            (Prims.of_int (103)) (Prims.of_int (22))
+                            (Prims.of_int (103)) (Prims.of_int (53)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.PP.fst"
-                                  (Prims.of_int (108)) (Prims.of_int (30))
-                                  (Prims.of_int (108)) (Prims.of_int (34)))))
+                                  (Prims.of_int (103)) (Prims.of_int (30))
+                                  (Prims.of_int (103)) (Prims.of_int (34)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.PP.fst"
-                                  (Prims.of_int (108)) (Prims.of_int (29))
-                                  (Prims.of_int (108)) (Prims.of_int (53)))))
+                                  (Prims.of_int (103)) (Prims.of_int (29))
+                                  (Prims.of_int (103)) (Prims.of_int (53)))))
                          (Obj.magic (pp uu___ x))
                          (fun uu___3 ->
                             (fun uu___3 ->
@@ -633,17 +613,17 @@ let printable_tuple2 :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.PP.fst"
-                                             (Prims.of_int (108))
+                                             (Prims.of_int (103))
                                              (Prims.of_int (38))
-                                             (Prims.of_int (108))
+                                             (Prims.of_int (103))
                                              (Prims.of_int (52)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.PP.fst"
-                                             (Prims.of_int (108))
+                                             (Prims.of_int (103))
                                              (Prims.of_int (29))
-                                             (Prims.of_int (108))
+                                             (Prims.of_int (103))
                                              (Prims.of_int (53)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -651,17 +631,17 @@ let printable_tuple2 :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.PP.fst"
-                                                   (Prims.of_int (108))
+                                                   (Prims.of_int (103))
                                                    (Prims.of_int (48))
-                                                   (Prims.of_int (108))
+                                                   (Prims.of_int (103))
                                                    (Prims.of_int (52)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.PP.fst"
-                                                   (Prims.of_int (108))
+                                                   (Prims.of_int (103))
                                                    (Prims.of_int (38))
-                                                   (Prims.of_int (108))
+                                                   (Prims.of_int (103))
                                                    (Prims.of_int (52)))))
                                           (Obj.magic (pp uu___1 y))
                                           (fun uu___4 ->
@@ -694,25 +674,25 @@ let printable_tuple3 :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.PP.fst"
-                              (Prims.of_int (113)) (Prims.of_int (32))
-                              (Prims.of_int (113)) (Prims.of_int (74)))))
+                              (Prims.of_int (108)) (Prims.of_int (32))
+                              (Prims.of_int (108)) (Prims.of_int (74)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.PP.fst"
-                              (Prims.of_int (113)) (Prims.of_int (25))
-                              (Prims.of_int (113)) (Prims.of_int (74)))))
+                              (Prims.of_int (108)) (Prims.of_int (25))
+                              (Prims.of_int (108)) (Prims.of_int (74)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.PP.fst"
-                                    (Prims.of_int (113)) (Prims.of_int (33))
-                                    (Prims.of_int (113)) (Prims.of_int (37)))))
+                                    (Prims.of_int (108)) (Prims.of_int (33))
+                                    (Prims.of_int (108)) (Prims.of_int (37)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.PP.fst"
-                                    (Prims.of_int (113)) (Prims.of_int (32))
-                                    (Prims.of_int (113)) (Prims.of_int (74)))))
+                                    (Prims.of_int (108)) (Prims.of_int (32))
+                                    (Prims.of_int (108)) (Prims.of_int (74)))))
                            (Obj.magic (pp uu___ x))
                            (fun uu___4 ->
                               (fun uu___4 ->
@@ -722,17 +702,17 @@ let printable_tuple3 :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.PP.fst"
-                                               (Prims.of_int (113))
+                                               (Prims.of_int (108))
                                                (Prims.of_int (41))
-                                               (Prims.of_int (113))
+                                               (Prims.of_int (108))
                                                (Prims.of_int (73)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.PP.fst"
-                                               (Prims.of_int (113))
+                                               (Prims.of_int (108))
                                                (Prims.of_int (32))
-                                               (Prims.of_int (113))
+                                               (Prims.of_int (108))
                                                (Prims.of_int (74)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -740,17 +720,17 @@ let printable_tuple3 :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.PP.fst"
-                                                     (Prims.of_int (113))
+                                                     (Prims.of_int (108))
                                                      (Prims.of_int (51))
-                                                     (Prims.of_int (113))
+                                                     (Prims.of_int (108))
                                                      (Prims.of_int (73)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.PP.fst"
-                                                     (Prims.of_int (113))
+                                                     (Prims.of_int (108))
                                                      (Prims.of_int (41))
-                                                     (Prims.of_int (113))
+                                                     (Prims.of_int (108))
                                                      (Prims.of_int (73)))))
                                             (Obj.magic
                                                (FStar_Tactics_Effect.tac_bind
@@ -758,17 +738,17 @@ let printable_tuple3 :
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.PP.fst"
-                                                           (Prims.of_int (113))
+                                                           (Prims.of_int (108))
                                                            (Prims.of_int (51))
-                                                           (Prims.of_int (113))
+                                                           (Prims.of_int (108))
                                                            (Prims.of_int (55)))))
                                                   (FStar_Sealed.seal
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.PP.fst"
-                                                           (Prims.of_int (113))
+                                                           (Prims.of_int (108))
                                                            (Prims.of_int (51))
-                                                           (Prims.of_int (113))
+                                                           (Prims.of_int (108))
                                                            (Prims.of_int (73)))))
                                                   (Obj.magic (pp uu___1 y))
                                                   (fun uu___5 ->
@@ -779,17 +759,17 @@ let printable_tuple3 :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (113))
+                                                                    (Prims.of_int (108))
                                                                     (Prims.of_int (59))
-                                                                    (Prims.of_int (113))
+                                                                    (Prims.of_int (108))
                                                                     (Prims.of_int (73)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (113))
+                                                                    (Prims.of_int (108))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (113))
+                                                                    (Prims.of_int (108))
                                                                     (Prims.of_int (73)))))
                                                              (Obj.magic
                                                                 (FStar_Tactics_Effect.tac_bind
@@ -797,17 +777,17 @@ let printable_tuple3 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (113))
+                                                                    (Prims.of_int (108))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (113))
+                                                                    (Prims.of_int (108))
                                                                     (Prims.of_int (73)))))
                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (113))
+                                                                    (Prims.of_int (108))
                                                                     (Prims.of_int (59))
-                                                                    (Prims.of_int (113))
+                                                                    (Prims.of_int (108))
                                                                     (Prims.of_int (73)))))
                                                                    (Obj.magic
                                                                     (pp
@@ -862,28 +842,28 @@ let printable_tuple4 :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.PP.fst"
-                                (Prims.of_int (118)) (Prims.of_int (35))
-                                (Prims.of_int (118)) (Prims.of_int (95)))))
+                                (Prims.of_int (113)) (Prims.of_int (35))
+                                (Prims.of_int (113)) (Prims.of_int (95)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.PP.fst"
-                                (Prims.of_int (118)) (Prims.of_int (28))
-                                (Prims.of_int (118)) (Prims.of_int (95)))))
+                                (Prims.of_int (113)) (Prims.of_int (28))
+                                (Prims.of_int (113)) (Prims.of_int (95)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range "Pulse.PP.fst"
-                                      (Prims.of_int (118))
+                                      (Prims.of_int (113))
                                       (Prims.of_int (36))
-                                      (Prims.of_int (118))
+                                      (Prims.of_int (113))
                                       (Prims.of_int (40)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range "Pulse.PP.fst"
-                                      (Prims.of_int (118))
+                                      (Prims.of_int (113))
                                       (Prims.of_int (35))
-                                      (Prims.of_int (118))
+                                      (Prims.of_int (113))
                                       (Prims.of_int (95)))))
                              (Obj.magic (pp uu___ x))
                              (fun uu___5 ->
@@ -894,17 +874,17 @@ let printable_tuple4 :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.PP.fst"
-                                                 (Prims.of_int (118))
+                                                 (Prims.of_int (113))
                                                  (Prims.of_int (44))
-                                                 (Prims.of_int (118))
+                                                 (Prims.of_int (113))
                                                  (Prims.of_int (94)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.PP.fst"
-                                                 (Prims.of_int (118))
+                                                 (Prims.of_int (113))
                                                  (Prims.of_int (35))
-                                                 (Prims.of_int (118))
+                                                 (Prims.of_int (113))
                                                  (Prims.of_int (95)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -912,17 +892,17 @@ let printable_tuple4 :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.PP.fst"
-                                                       (Prims.of_int (118))
+                                                       (Prims.of_int (113))
                                                        (Prims.of_int (54))
-                                                       (Prims.of_int (118))
+                                                       (Prims.of_int (113))
                                                        (Prims.of_int (94)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.PP.fst"
-                                                       (Prims.of_int (118))
+                                                       (Prims.of_int (113))
                                                        (Prims.of_int (44))
-                                                       (Prims.of_int (118))
+                                                       (Prims.of_int (113))
                                                        (Prims.of_int (94)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -930,17 +910,17 @@ let printable_tuple4 :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.PP.fst"
-                                                             (Prims.of_int (118))
+                                                             (Prims.of_int (113))
                                                              (Prims.of_int (54))
-                                                             (Prims.of_int (118))
+                                                             (Prims.of_int (113))
                                                              (Prims.of_int (58)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.PP.fst"
-                                                             (Prims.of_int (118))
+                                                             (Prims.of_int (113))
                                                              (Prims.of_int (54))
-                                                             (Prims.of_int (118))
+                                                             (Prims.of_int (113))
                                                              (Prims.of_int (94)))))
                                                     (Obj.magic (pp uu___1 y))
                                                     (fun uu___6 ->
@@ -951,17 +931,17 @@ let printable_tuple4 :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (62))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (94)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (54))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (94)))))
                                                                (Obj.magic
                                                                   (FStar_Tactics_Effect.tac_bind
@@ -969,17 +949,17 @@ let printable_tuple4 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (72))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (94)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (62))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (94)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -987,17 +967,17 @@ let printable_tuple4 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (72))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (72))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (94)))))
                                                                     (Obj.magic
                                                                     (pp
@@ -1012,17 +992,17 @@ let printable_tuple4 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (80))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (94)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (72))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (94)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1030,17 +1010,17 @@ let printable_tuple4 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (90))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (94)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (80))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (113))
                                                                     (Prims.of_int (94)))))
                                                                     (Obj.magic
                                                                     (pp
@@ -1115,28 +1095,28 @@ let printable_tuple5 :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.PP.fst"
-                                  (Prims.of_int (123)) (Prims.of_int (38))
-                                  (Prims.of_int (123)) (Prims.of_int (116)))))
+                                  (Prims.of_int (118)) (Prims.of_int (38))
+                                  (Prims.of_int (118)) (Prims.of_int (116)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.PP.fst"
-                                  (Prims.of_int (123)) (Prims.of_int (31))
-                                  (Prims.of_int (123)) (Prims.of_int (116)))))
+                                  (Prims.of_int (118)) (Prims.of_int (31))
+                                  (Prims.of_int (118)) (Prims.of_int (116)))))
                          (Obj.magic
                             (FStar_Tactics_Effect.tac_bind
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range "Pulse.PP.fst"
-                                        (Prims.of_int (123))
+                                        (Prims.of_int (118))
                                         (Prims.of_int (39))
-                                        (Prims.of_int (123))
+                                        (Prims.of_int (118))
                                         (Prims.of_int (43)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range "Pulse.PP.fst"
-                                        (Prims.of_int (123))
+                                        (Prims.of_int (118))
                                         (Prims.of_int (38))
-                                        (Prims.of_int (123))
+                                        (Prims.of_int (118))
                                         (Prims.of_int (116)))))
                                (Obj.magic (pp uu___ x))
                                (fun uu___6 ->
@@ -1147,17 +1127,17 @@ let printable_tuple5 :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.PP.fst"
-                                                   (Prims.of_int (123))
+                                                   (Prims.of_int (118))
                                                    (Prims.of_int (47))
-                                                   (Prims.of_int (123))
+                                                   (Prims.of_int (118))
                                                    (Prims.of_int (115)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.PP.fst"
-                                                   (Prims.of_int (123))
+                                                   (Prims.of_int (118))
                                                    (Prims.of_int (38))
-                                                   (Prims.of_int (123))
+                                                   (Prims.of_int (118))
                                                    (Prims.of_int (116)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -1165,17 +1145,17 @@ let printable_tuple5 :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.PP.fst"
-                                                         (Prims.of_int (123))
+                                                         (Prims.of_int (118))
                                                          (Prims.of_int (57))
-                                                         (Prims.of_int (123))
+                                                         (Prims.of_int (118))
                                                          (Prims.of_int (115)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.PP.fst"
-                                                         (Prims.of_int (123))
+                                                         (Prims.of_int (118))
                                                          (Prims.of_int (47))
-                                                         (Prims.of_int (123))
+                                                         (Prims.of_int (118))
                                                          (Prims.of_int (115)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_Effect.tac_bind
@@ -1183,17 +1163,17 @@ let printable_tuple5 :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.PP.fst"
-                                                               (Prims.of_int (123))
+                                                               (Prims.of_int (118))
                                                                (Prims.of_int (57))
-                                                               (Prims.of_int (123))
+                                                               (Prims.of_int (118))
                                                                (Prims.of_int (61)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.PP.fst"
-                                                               (Prims.of_int (123))
+                                                               (Prims.of_int (118))
                                                                (Prims.of_int (57))
-                                                               (Prims.of_int (123))
+                                                               (Prims.of_int (118))
                                                                (Prims.of_int (115)))))
                                                       (Obj.magic
                                                          (pp uu___1 y))
@@ -1206,18 +1186,18 @@ let printable_tuple5 :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (65))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (115)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (57))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (115)))))
                                                                  (Obj.magic
                                                                     (
@@ -1226,17 +1206,17 @@ let printable_tuple5 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (75))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (115)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (65))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (115)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1244,17 +1224,17 @@ let printable_tuple5 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (75))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (79)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (75))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (115)))))
                                                                     (Obj.magic
                                                                     (pp
@@ -1269,17 +1249,17 @@ let printable_tuple5 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (83))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (115)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (75))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (115)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1287,17 +1267,17 @@ let printable_tuple5 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (93))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (115)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (83))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (115)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1305,17 +1285,17 @@ let printable_tuple5 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (93))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (97)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (93))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (115)))))
                                                                     (Obj.magic
                                                                     (pp
@@ -1330,17 +1310,17 @@ let printable_tuple5 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (101))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (115)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (93))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (115)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1348,17 +1328,17 @@ let printable_tuple5 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (111))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (115)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (101))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (118))
                                                                     (Prims.of_int (115)))))
                                                                     (Obj.magic
                                                                     (pp
@@ -1459,28 +1439,28 @@ let printable_tuple6 :
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.PP.fst"
-                                    (Prims.of_int (128)) (Prims.of_int (41))
-                                    (Prims.of_int (128)) (Prims.of_int (137)))))
+                                    (Prims.of_int (123)) (Prims.of_int (41))
+                                    (Prims.of_int (123)) (Prims.of_int (137)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.PP.fst"
-                                    (Prims.of_int (128)) (Prims.of_int (34))
-                                    (Prims.of_int (128)) (Prims.of_int (137)))))
+                                    (Prims.of_int (123)) (Prims.of_int (34))
+                                    (Prims.of_int (123)) (Prims.of_int (137)))))
                            (Obj.magic
                               (FStar_Tactics_Effect.tac_bind
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "Pulse.PP.fst"
-                                          (Prims.of_int (128))
+                                          (Prims.of_int (123))
                                           (Prims.of_int (42))
-                                          (Prims.of_int (128))
+                                          (Prims.of_int (123))
                                           (Prims.of_int (46)))))
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "Pulse.PP.fst"
-                                          (Prims.of_int (128))
+                                          (Prims.of_int (123))
                                           (Prims.of_int (41))
-                                          (Prims.of_int (128))
+                                          (Prims.of_int (123))
                                           (Prims.of_int (137)))))
                                  (Obj.magic (pp uu___ x))
                                  (fun uu___7 ->
@@ -1491,17 +1471,17 @@ let printable_tuple6 :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.PP.fst"
-                                                     (Prims.of_int (128))
+                                                     (Prims.of_int (123))
                                                      (Prims.of_int (50))
-                                                     (Prims.of_int (128))
+                                                     (Prims.of_int (123))
                                                      (Prims.of_int (136)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.PP.fst"
-                                                     (Prims.of_int (128))
+                                                     (Prims.of_int (123))
                                                      (Prims.of_int (41))
-                                                     (Prims.of_int (128))
+                                                     (Prims.of_int (123))
                                                      (Prims.of_int (137)))))
                                             (Obj.magic
                                                (FStar_Tactics_Effect.tac_bind
@@ -1509,17 +1489,17 @@ let printable_tuple6 :
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.PP.fst"
-                                                           (Prims.of_int (128))
+                                                           (Prims.of_int (123))
                                                            (Prims.of_int (60))
-                                                           (Prims.of_int (128))
+                                                           (Prims.of_int (123))
                                                            (Prims.of_int (136)))))
                                                   (FStar_Sealed.seal
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.PP.fst"
-                                                           (Prims.of_int (128))
+                                                           (Prims.of_int (123))
                                                            (Prims.of_int (50))
-                                                           (Prims.of_int (128))
+                                                           (Prims.of_int (123))
                                                            (Prims.of_int (136)))))
                                                   (Obj.magic
                                                      (FStar_Tactics_Effect.tac_bind
@@ -1527,17 +1507,17 @@ let printable_tuple6 :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.PP.fst"
-                                                                 (Prims.of_int (128))
+                                                                 (Prims.of_int (123))
                                                                  (Prims.of_int (60))
-                                                                 (Prims.of_int (128))
+                                                                 (Prims.of_int (123))
                                                                  (Prims.of_int (64)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.PP.fst"
-                                                                 (Prims.of_int (128))
+                                                                 (Prims.of_int (123))
                                                                  (Prims.of_int (60))
-                                                                 (Prims.of_int (128))
+                                                                 (Prims.of_int (123))
                                                                  (Prims.of_int (136)))))
                                                         (Obj.magic
                                                            (pp uu___1 y))
@@ -1549,17 +1529,17 @@ let printable_tuple6 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (68))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (60))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                    (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1567,17 +1547,17 @@ let printable_tuple6 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (78))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (68))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1585,17 +1565,17 @@ let printable_tuple6 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (78))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (82)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (78))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (Obj.magic
                                                                     (pp
@@ -1610,17 +1590,17 @@ let printable_tuple6 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (86))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (78))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1628,17 +1608,17 @@ let printable_tuple6 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (96))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (86))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1646,17 +1626,17 @@ let printable_tuple6 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (96))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (100)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (96))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (Obj.magic
                                                                     (pp
@@ -1673,17 +1653,17 @@ let printable_tuple6 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (104))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (96))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1691,17 +1671,17 @@ let printable_tuple6 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (114))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (104))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1709,17 +1689,17 @@ let printable_tuple6 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (114))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (118)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (114))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (Obj.magic
                                                                     (pp
@@ -1736,17 +1716,17 @@ let printable_tuple6 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (122))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (114))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1754,17 +1734,17 @@ let printable_tuple6 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (132))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (122))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (136)))))
                                                                     (Obj.magic
                                                                     (pp
@@ -1893,32 +1873,32 @@ let printable_tuple7 :
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range "Pulse.PP.fst"
-                                      (Prims.of_int (133))
+                                      (Prims.of_int (128))
                                       (Prims.of_int (44))
-                                      (Prims.of_int (133))
+                                      (Prims.of_int (128))
                                       (Prims.of_int (158)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range "Pulse.PP.fst"
-                                      (Prims.of_int (133))
+                                      (Prims.of_int (128))
                                       (Prims.of_int (37))
-                                      (Prims.of_int (133))
+                                      (Prims.of_int (128))
                                       (Prims.of_int (158)))))
                              (Obj.magic
                                 (FStar_Tactics_Effect.tac_bind
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range "Pulse.PP.fst"
-                                            (Prims.of_int (133))
+                                            (Prims.of_int (128))
                                             (Prims.of_int (45))
-                                            (Prims.of_int (133))
+                                            (Prims.of_int (128))
                                             (Prims.of_int (49)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range "Pulse.PP.fst"
-                                            (Prims.of_int (133))
+                                            (Prims.of_int (128))
                                             (Prims.of_int (44))
-                                            (Prims.of_int (133))
+                                            (Prims.of_int (128))
                                             (Prims.of_int (158)))))
                                    (Obj.magic (pp uu___ x))
                                    (fun uu___8 ->
@@ -1929,17 +1909,17 @@ let printable_tuple7 :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.PP.fst"
-                                                       (Prims.of_int (133))
+                                                       (Prims.of_int (128))
                                                        (Prims.of_int (53))
-                                                       (Prims.of_int (133))
+                                                       (Prims.of_int (128))
                                                        (Prims.of_int (157)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.PP.fst"
-                                                       (Prims.of_int (133))
+                                                       (Prims.of_int (128))
                                                        (Prims.of_int (44))
-                                                       (Prims.of_int (133))
+                                                       (Prims.of_int (128))
                                                        (Prims.of_int (158)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -1947,17 +1927,17 @@ let printable_tuple7 :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.PP.fst"
-                                                             (Prims.of_int (133))
+                                                             (Prims.of_int (128))
                                                              (Prims.of_int (63))
-                                                             (Prims.of_int (133))
+                                                             (Prims.of_int (128))
                                                              (Prims.of_int (157)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.PP.fst"
-                                                             (Prims.of_int (133))
+                                                             (Prims.of_int (128))
                                                              (Prims.of_int (53))
-                                                             (Prims.of_int (133))
+                                                             (Prims.of_int (128))
                                                              (Prims.of_int (157)))))
                                                     (Obj.magic
                                                        (FStar_Tactics_Effect.tac_bind
@@ -1965,17 +1945,17 @@ let printable_tuple7 :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.PP.fst"
-                                                                   (Prims.of_int (133))
+                                                                   (Prims.of_int (128))
                                                                    (Prims.of_int (63))
-                                                                   (Prims.of_int (133))
+                                                                   (Prims.of_int (128))
                                                                    (Prims.of_int (67)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.PP.fst"
-                                                                   (Prims.of_int (133))
+                                                                   (Prims.of_int (128))
                                                                    (Prims.of_int (63))
-                                                                   (Prims.of_int (133))
+                                                                   (Prims.of_int (128))
                                                                    (Prims.of_int (157)))))
                                                           (Obj.magic
                                                              (pp uu___1 y))
@@ -1987,17 +1967,17 @@ let printable_tuple7 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (71))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2005,17 +1985,17 @@ let printable_tuple7 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (81))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (71))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2023,17 +2003,17 @@ let printable_tuple7 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (81))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (85)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (81))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (Obj.magic
                                                                     (pp
@@ -2050,17 +2030,17 @@ let printable_tuple7 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (89))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (81))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2068,17 +2048,17 @@ let printable_tuple7 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (99))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (89))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2086,17 +2066,17 @@ let printable_tuple7 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (99))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (103)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (99))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (Obj.magic
                                                                     (pp
@@ -2113,17 +2093,17 @@ let printable_tuple7 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (107))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (99))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2131,17 +2111,17 @@ let printable_tuple7 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (117))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (107))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2149,17 +2129,17 @@ let printable_tuple7 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (117))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (121)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (117))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (Obj.magic
                                                                     (pp
@@ -2176,17 +2156,17 @@ let printable_tuple7 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (125))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (117))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2194,17 +2174,17 @@ let printable_tuple7 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (135))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (125))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2212,17 +2192,17 @@ let printable_tuple7 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (135))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (139)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (135))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (Obj.magic
                                                                     (pp
@@ -2239,17 +2219,17 @@ let printable_tuple7 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (143))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (135))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2257,17 +2237,17 @@ let printable_tuple7 :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (153))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.PP.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (143))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (157)))))
                                                                     (Obj.magic
                                                                     (pp

--- a/src/ocaml/plugin/generated/Pulse_Typing_Combinators.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_Combinators.ml
@@ -467,7 +467,7 @@ let (lift_ghost_atomic :
                                                               (Prims.of_int (18)))))
                                                      (Obj.magic
                                                         (Pulse_PP.pp
-                                                           Pulse_PP.printable_fstar_term
+                                                           Pulse_PP.printable_term
                                                            t))
                                                      (fun uu___ ->
                                                         FStar_Tactics_Effect.lift_div_tac

--- a/src/ocaml/plugin/generated/Pulse_Typing_Env.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_Env.ml
@@ -1000,11 +1000,11 @@ let (env_to_doc :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (377))
-               (Prims.of_int (4)) (Prims.of_int (379)) (Prims.of_int (68)))))
+               (Prims.of_int (4)) (Prims.of_int (380)) (Prims.of_int (52)))))
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (381))
-               (Prims.of_int (2)) (Prims.of_int (381)) (Prims.of_int (56)))))
+            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (382))
+               (Prims.of_int (2)) (Prims.of_int (382)) (Prims.of_int (56)))))
       (FStar_Tactics_Effect.lift_div_tac
          (fun uu___ ->
             fun uu___1 ->
@@ -1014,28 +1014,51 @@ let (env_to_doc :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                             (Prims.of_int (378)) (Prims.of_int (6))
-                             (Prims.of_int (378)) (Prims.of_int (37)))))
+                             (Prims.of_int (379)) (Prims.of_int (8))
+                             (Prims.of_int (379)) (Prims.of_int (65)))))
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
                              (Prims.of_int (378)) (Prims.of_int (6))
-                             (Prims.of_int (379)) (Prims.of_int (68)))))
+                             (Prims.of_int (380)) (Prims.of_int (52)))))
                     (Obj.magic
                        (FStar_Tactics_Effect.tac_bind
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                   (Prims.of_int (378)) (Prims.of_int (20))
-                                   (Prims.of_int (378)) (Prims.of_int (37)))))
+                                   (Prims.of_int (379)) (Prims.of_int (23))
+                                   (Prims.of_int (379)) (Prims.of_int (64)))))
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                   (Prims.of_int (378)) (Prims.of_int (6))
-                                   (Prims.of_int (378)) (Prims.of_int (37)))))
+                                   (Prims.of_int (379)) (Prims.of_int (8))
+                                   (Prims.of_int (379)) (Prims.of_int (65)))))
                           (Obj.magic
-                             (FStar_Tactics_Unseal.unseal
-                                x.Pulse_Syntax_Base.name))
+                             (FStar_Tactics_Effect.tac_bind
+                                (FStar_Sealed.seal
+                                   (Obj.magic
+                                      (FStar_Range.mk_range
+                                         "Pulse.Typing.Env.fst"
+                                         (Prims.of_int (379))
+                                         (Prims.of_int (24))
+                                         (Prims.of_int (379))
+                                         (Prims.of_int (39)))))
+                                (FStar_Sealed.seal
+                                   (Obj.magic
+                                      (FStar_Range.mk_range "prims.fst"
+                                         (Prims.of_int (590))
+                                         (Prims.of_int (19))
+                                         (Prims.of_int (590))
+                                         (Prims.of_int (31)))))
+                                (Obj.magic
+                                   (FStar_Tactics_Unseal.unseal
+                                      x.Pulse_Syntax_Base.name))
+                                (fun uu___2 ->
+                                   FStar_Tactics_Effect.lift_div_tac
+                                     (fun uu___3 ->
+                                        Prims.strcat uu___2
+                                          (Prims.strcat "#"
+                                             (Prims.string_of_int n))))))
                           (fun uu___2 ->
                              FStar_Tactics_Effect.lift_div_tac
                                (fun uu___3 ->
@@ -1048,99 +1071,48 @@ let (env_to_doc :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Typing.Env.fst"
-                                        (Prims.of_int (378))
-                                        (Prims.of_int (41))
-                                        (Prims.of_int (379))
-                                        (Prims.of_int (68)))))
+                                        (Prims.of_int (380))
+                                        (Prims.of_int (8))
+                                        (Prims.of_int (380))
+                                        (Prims.of_int (52)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Typing.Env.fst"
                                         (Prims.of_int (378))
                                         (Prims.of_int (6))
-                                        (Prims.of_int (379))
-                                        (Prims.of_int (68)))))
+                                        (Prims.of_int (380))
+                                        (Prims.of_int (52)))))
                                (Obj.magic
                                   (FStar_Tactics_Effect.tac_bind
                                      (FStar_Sealed.seal
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Typing.Env.fst"
-                                              (Prims.of_int (378))
-                                              (Prims.of_int (62))
-                                              (Prims.of_int (379))
-                                              (Prims.of_int (68)))))
+                                              (Prims.of_int (380))
+                                              (Prims.of_int (15))
+                                              (Prims.of_int (380))
+                                              (Prims.of_int (51)))))
                                      (FStar_Sealed.seal
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Typing.Env.fst"
-                                              (Prims.of_int (378))
-                                              (Prims.of_int (41))
-                                              (Prims.of_int (379))
-                                              (Prims.of_int (68)))))
+                                              (Prims.of_int (380))
+                                              (Prims.of_int (8))
+                                              (Prims.of_int (380))
+                                              (Prims.of_int (52)))))
                                      (Obj.magic
-                                        (FStar_Tactics_Effect.tac_bind
-                                           (FStar_Sealed.seal
-                                              (Obj.magic
-                                                 (FStar_Range.mk_range
-                                                    "Pulse.Typing.Env.fst"
-                                                    (Prims.of_int (379))
-                                                    (Prims.of_int (11))
-                                                    (Prims.of_int (379))
-                                                    (Prims.of_int (68)))))
-                                           (FStar_Sealed.seal
-                                              (Obj.magic
-                                                 (FStar_Range.mk_range
-                                                    "Pulse.Typing.Env.fst"
-                                                    (Prims.of_int (378))
-                                                    (Prims.of_int (62))
-                                                    (Prims.of_int (379))
-                                                    (Prims.of_int (68)))))
-                                           (Obj.magic
-                                              (FStar_Tactics_Effect.tac_bind
-                                                 (FStar_Sealed.seal
-                                                    (Obj.magic
-                                                       (FStar_Range.mk_range
-                                                          "Pulse.Typing.Env.fst"
-                                                          (Prims.of_int (379))
-                                                          (Prims.of_int (34))
-                                                          (Prims.of_int (379))
-                                                          (Prims.of_int (68)))))
-                                                 (FStar_Sealed.seal
-                                                    (Obj.magic
-                                                       (FStar_Range.mk_range
-                                                          "Pulse.Typing.Env.fst"
-                                                          (Prims.of_int (379))
-                                                          (Prims.of_int (11))
-                                                          (Prims.of_int (379))
-                                                          (Prims.of_int (68)))))
-                                                 (Obj.magic
-                                                    (Pulse_Syntax_Printer.term_to_doc
-                                                       t))
-                                                 (fun uu___3 ->
-                                                    FStar_Tactics_Effect.lift_div_tac
-                                                      (fun uu___4 ->
-                                                         FStar_Pprint.op_Hat_Hat
-                                                           (FStar_Pprint.doc_of_string
-                                                              " : ") uu___3))))
-                                           (fun uu___3 ->
-                                              FStar_Tactics_Effect.lift_div_tac
-                                                (fun uu___4 ->
-                                                   FStar_Pprint.op_Hat_Hat
-                                                     (FStar_Pprint.doc_of_string
-                                                        (Prims.string_of_int
-                                                           n)) uu___3))))
+                                        (Pulse_Syntax_Printer.term_to_doc t))
                                      (fun uu___3 ->
                                         FStar_Tactics_Effect.lift_div_tac
                                           (fun uu___4 ->
-                                             FStar_Pprint.op_Hat_Hat
-                                               (FStar_Pprint.doc_of_string
-                                                  "#") uu___3))))
+                                             FStar_Pprint.align uu___3))))
                                (fun uu___3 ->
                                   FStar_Tactics_Effect.lift_div_tac
                                     (fun uu___4 ->
-                                       FStar_Pprint.op_Hat_Hat uu___2 uu___3))))
-                         uu___2)))
+                                       FStar_Pprint.infix (Prims.of_int (2))
+                                         Prims.int_one FStar_Pprint.colon
+                                         uu___2 uu___3)))) uu___2)))
       (fun uu___ ->
          (fun pp1 ->
             Obj.magic
@@ -1148,25 +1120,25 @@ let (env_to_doc :
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                          (Prims.of_int (381)) (Prims.of_int (11))
-                          (Prims.of_int (381)) (Prims.of_int (56)))))
+                          (Prims.of_int (382)) (Prims.of_int (11))
+                          (Prims.of_int (382)) (Prims.of_int (56)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                          (Prims.of_int (381)) (Prims.of_int (2))
-                          (Prims.of_int (381)) (Prims.of_int (56)))))
+                          (Prims.of_int (382)) (Prims.of_int (2))
+                          (Prims.of_int (382)) (Prims.of_int (56)))))
                  (Obj.magic
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                (Prims.of_int (381)) (Prims.of_int (35))
-                                (Prims.of_int (381)) (Prims.of_int (55)))))
+                                (Prims.of_int (382)) (Prims.of_int (35))
+                                (Prims.of_int (382)) (Prims.of_int (55)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                (Prims.of_int (381)) (Prims.of_int (11))
-                                (Prims.of_int (381)) (Prims.of_int (56)))))
+                                (Prims.of_int (382)) (Prims.of_int (11))
+                                (Prims.of_int (382)) (Prims.of_int (56)))))
                        (Obj.magic (FStar_Tactics_Util.zip e.bs e.names))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -1190,13 +1162,13 @@ let (get_range :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                     (Prims.of_int (387)) (Prims.of_int (9))
-                     (Prims.of_int (387)) (Prims.of_int (27)))))
+                     (Prims.of_int (388)) (Prims.of_int (9))
+                     (Prims.of_int (388)) (Prims.of_int (27)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                     (Prims.of_int (387)) (Prims.of_int (6))
-                     (Prims.of_int (389)) (Prims.of_int (12)))))
+                     (Prims.of_int (388)) (Prims.of_int (6))
+                     (Prims.of_int (390)) (Prims.of_int (12)))))
             (FStar_Tactics_Effect.lift_div_tac
                (fun uu___ -> Pulse_RuntimeUtils.is_range_zero r1))
             (fun uu___ ->
@@ -1224,13 +1196,13 @@ let fail_doc_env :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                     (Prims.of_int (392)) (Prims.of_int (10))
-                     (Prims.of_int (392)) (Prims.of_int (23)))))
+                     (Prims.of_int (393)) (Prims.of_int (10))
+                     (Prims.of_int (393)) (Prims.of_int (23)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                     (Prims.of_int (392)) (Prims.of_int (26))
-                     (Prims.of_int (405)) (Prims.of_int (31)))))
+                     (Prims.of_int (393)) (Prims.of_int (26))
+                     (Prims.of_int (406)) (Prims.of_int (31)))))
             (Obj.magic (get_range g r))
             (fun uu___ ->
                (fun r1 ->
@@ -1239,30 +1211,30 @@ let fail_doc_env :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                (Prims.of_int (393)) (Prims.of_int (11))
-                                (Prims.of_int (401)) (Prims.of_int (12)))))
+                                (Prims.of_int (394)) (Prims.of_int (11))
+                                (Prims.of_int (402)) (Prims.of_int (12)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                (Prims.of_int (402)) (Prims.of_int (4))
-                                (Prims.of_int (405)) (Prims.of_int (31)))))
+                                (Prims.of_int (403)) (Prims.of_int (4))
+                                (Prims.of_int (406)) (Prims.of_int (31)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Typing.Env.fst"
-                                      (Prims.of_int (394))
+                                      (Prims.of_int (395))
                                       (Prims.of_int (19))
-                                      (Prims.of_int (394))
+                                      (Prims.of_int (395))
                                       (Prims.of_int (47)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Typing.Env.fst"
-                                      (Prims.of_int (394))
+                                      (Prims.of_int (395))
                                       (Prims.of_int (50))
-                                      (Prims.of_int (401))
+                                      (Prims.of_int (402))
                                       (Prims.of_int (12)))))
                              (FStar_Tactics_Effect.lift_div_tac
                                 (fun uu___ ->
@@ -1279,17 +1251,17 @@ let fail_doc_env :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Typing.Env.fst"
-                                                 (Prims.of_int (396))
-                                                 (Prims.of_int (6))
                                                  (Prims.of_int (397))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (398))
                                                  (Prims.of_int (47)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Typing.Env.fst"
-                                                 (Prims.of_int (399))
+                                                 (Prims.of_int (400))
                                                  (Prims.of_int (4))
-                                                 (Prims.of_int (401))
+                                                 (Prims.of_int (402))
                                                  (Prims.of_int (12)))))
                                         (if with_env
                                          then
@@ -1313,17 +1285,17 @@ let fail_doc_env :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Typing.Env.fst"
-                                                                 (Prims.of_int (400))
+                                                                 (Prims.of_int (401))
                                                                  (Prims.of_int (15))
-                                                                 (Prims.of_int (400))
+                                                                 (Prims.of_int (401))
                                                                  (Prims.of_int (80)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Typing.Env.fst"
-                                                                 (Prims.of_int (400))
+                                                                 (Prims.of_int (401))
                                                                  (Prims.of_int (9))
-                                                                 (Prims.of_int (400))
+                                                                 (Prims.of_int (401))
                                                                  (Prims.of_int (80)))))
                                                         (Obj.magic
                                                            (FStar_Tactics_Effect.tac_bind
@@ -1332,18 +1304,18 @@ let fail_doc_env :
                                                                     (
                                                                     FStar_Range.mk_range
                                                                     "Pulse.Typing.Env.fst"
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (79)))))
                                                               (FStar_Sealed.seal
                                                                  (Obj.magic
                                                                     (
                                                                     FStar_Range.mk_range
                                                                     "Pulse.Typing.Env.fst"
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (80)))))
                                                               (Obj.magic
                                                                  (FStar_Tactics_Effect.tac_bind
@@ -1352,18 +1324,18 @@ let fail_doc_env :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Env.fst"
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (79)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Env.fst"
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (79)))))
                                                                     (
                                                                     Obj.magic
@@ -1372,17 +1344,17 @@ let fail_doc_env :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Env.fst"
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (65))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (79)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Env.fst"
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (79)))))
                                                                     (Obj.magic
                                                                     (env_to_doc
@@ -1428,17 +1400,17 @@ let fail_doc_env :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Typing.Env.fst"
-                                           (Prims.of_int (403))
+                                           (Prims.of_int (404))
                                            (Prims.of_int (14))
-                                           (Prims.of_int (403))
+                                           (Prims.of_int (404))
                                            (Prims.of_int (81)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Typing.Env.fst"
-                                           (Prims.of_int (404))
-                                           (Prims.of_int (2))
                                            (Prims.of_int (405))
+                                           (Prims.of_int (2))
+                                           (Prims.of_int (406))
                                            (Prims.of_int (31)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -1446,17 +1418,17 @@ let fail_doc_env :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Typing.Env.fst"
-                                                 (Prims.of_int (403))
+                                                 (Prims.of_int (404))
                                                  (Prims.of_int (65))
-                                                 (Prims.of_int (403))
+                                                 (Prims.of_int (404))
                                                  (Prims.of_int (81)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Typing.Env.fst"
-                                                 (Prims.of_int (403))
+                                                 (Prims.of_int (404))
                                                  (Prims.of_int (14))
-                                                 (Prims.of_int (403))
+                                                 (Prims.of_int (404))
                                                  (Prims.of_int (81)))))
                                         (Obj.magic (ctxt_to_list g))
                                         (fun uu___ ->
@@ -1476,17 +1448,17 @@ let fail_doc_env :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Typing.Env.fst"
-                                                      (Prims.of_int (404))
+                                                      (Prims.of_int (405))
                                                       (Prims.of_int (2))
-                                                      (Prims.of_int (404))
+                                                      (Prims.of_int (405))
                                                       (Prims.of_int (22)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Typing.Env.fst"
-                                                      (Prims.of_int (405))
+                                                      (Prims.of_int (406))
                                                       (Prims.of_int (2))
-                                                      (Prims.of_int (405))
+                                                      (Prims.of_int (406))
                                                       (Prims.of_int (31)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.log_issues
@@ -1515,13 +1487,13 @@ let (warn_doc :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (408)) (Prims.of_int (10))
-                   (Prims.of_int (408)) (Prims.of_int (23)))))
+                   (Prims.of_int (409)) (Prims.of_int (10))
+                   (Prims.of_int (409)) (Prims.of_int (23)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (408)) (Prims.of_int (26))
-                   (Prims.of_int (410)) (Prims.of_int (22)))))
+                   (Prims.of_int (409)) (Prims.of_int (26))
+                   (Prims.of_int (411)) (Prims.of_int (22)))))
           (Obj.magic (get_range g r))
           (fun uu___ ->
              (fun r1 ->
@@ -1530,25 +1502,25 @@ let (warn_doc :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (409)) (Prims.of_int (14))
-                              (Prims.of_int (409)) (Prims.of_int (83)))))
+                              (Prims.of_int (410)) (Prims.of_int (14))
+                              (Prims.of_int (410)) (Prims.of_int (83)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (410)) (Prims.of_int (2))
-                              (Prims.of_int (410)) (Prims.of_int (22)))))
+                              (Prims.of_int (411)) (Prims.of_int (2))
+                              (Prims.of_int (411)) (Prims.of_int (22)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                    (Prims.of_int (409)) (Prims.of_int (67))
-                                    (Prims.of_int (409)) (Prims.of_int (83)))))
+                                    (Prims.of_int (410)) (Prims.of_int (67))
+                                    (Prims.of_int (410)) (Prims.of_int (83)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                    (Prims.of_int (409)) (Prims.of_int (14))
-                                    (Prims.of_int (409)) (Prims.of_int (83)))))
+                                    (Prims.of_int (410)) (Prims.of_int (14))
+                                    (Prims.of_int (410)) (Prims.of_int (83)))))
                            (Obj.magic (ctxt_to_list g))
                            (fun uu___ ->
                               FStar_Tactics_Effect.lift_div_tac
@@ -1574,13 +1546,13 @@ let (info_doc :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (413)) (Prims.of_int (10))
-                   (Prims.of_int (413)) (Prims.of_int (23)))))
+                   (Prims.of_int (414)) (Prims.of_int (10))
+                   (Prims.of_int (414)) (Prims.of_int (23)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (413)) (Prims.of_int (26))
-                   (Prims.of_int (415)) (Prims.of_int (22)))))
+                   (Prims.of_int (414)) (Prims.of_int (26))
+                   (Prims.of_int (416)) (Prims.of_int (22)))))
           (Obj.magic (get_range g r))
           (fun uu___ ->
              (fun r1 ->
@@ -1589,25 +1561,25 @@ let (info_doc :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (414)) (Prims.of_int (14))
-                              (Prims.of_int (414)) (Prims.of_int (80)))))
+                              (Prims.of_int (415)) (Prims.of_int (14))
+                              (Prims.of_int (415)) (Prims.of_int (80)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (415)) (Prims.of_int (2))
-                              (Prims.of_int (415)) (Prims.of_int (22)))))
+                              (Prims.of_int (416)) (Prims.of_int (2))
+                              (Prims.of_int (416)) (Prims.of_int (22)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                    (Prims.of_int (414)) (Prims.of_int (64))
-                                    (Prims.of_int (414)) (Prims.of_int (80)))))
+                                    (Prims.of_int (415)) (Prims.of_int (64))
+                                    (Prims.of_int (415)) (Prims.of_int (80)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                    (Prims.of_int (414)) (Prims.of_int (14))
-                                    (Prims.of_int (414)) (Prims.of_int (80)))))
+                                    (Prims.of_int (415)) (Prims.of_int (14))
+                                    (Prims.of_int (415)) (Prims.of_int (80)))))
                            (Obj.magic (ctxt_to_list g))
                            (fun uu___ ->
                               FStar_Tactics_Effect.lift_div_tac

--- a/src/ocaml/plugin/generated/Pulse_Typing_Util.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_Util.ml
@@ -15,6 +15,20 @@ let (check_equiv_now :
              FStar_Tactics_V2_Derived.with_policy FStar_Tactics_Types.SMTSync
                (fun uu___1 ->
                   FStar_Tactics_V2_Derived.check_equiv tcenv t0 t1))
+let (check_equiv_now_nosmt :
+  FStar_Reflection_Types.env ->
+    FStar_Tactics_NamedView.term ->
+      FStar_Tactics_NamedView.term ->
+        (((unit, unit, unit) FStar_Tactics_Types.equiv_token
+           FStar_Pervasives_Native.option * FStar_Issue.issue Prims.list),
+          unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun tcenv ->
+    fun t0 ->
+      fun t1 ->
+        Pulse_RuntimeUtils.disable_admit_smt_queries
+          (fun uu___ ->
+             FStar_Tactics_V2_Derived.check_equiv_nosmt tcenv t0 t1)
 let (universe_of_now :
   FStar_Reflection_Types.env ->
     FStar_Tactics_NamedView.term ->


### PR DESCRIPTION
- Printing the substituted vprop when the prover fails.
- A better check for empty vprops at the end of a function, using core_check_equiv_nosmt
- Pretty printing improvements