### PR TITLE
Adding only tick variables as implicit binders

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.HigherArray.fst
+++ b/lib/pulse/lib/Pulse.Lib.HigherArray.fst
@@ -660,6 +660,7 @@ fn split_l_slice #elt
      (a : array elt)
      (i m j: nat)
      (#s:Seq.seq elt)
+     (#p:perm)
      (_:squash (i <= m /\ m <= j /\ j <= length a))
 requires pts_to (split_l (array_slice a i j) (m - i)) #p s
 ensures  pts_to (array_slice a i m) #p s
@@ -675,6 +676,7 @@ fn split_r_slice #elt
      (a:array elt)
      (i m j: nat)
      (#s:Seq.seq elt)
+     (#p:perm)
      (_:squash (i <= m /\ m <= j /\ j <= length a))
 requires pts_to (split_r (array_slice a i j) (m - i)) #p s
 ensures pts_to (array_slice a m j) #p s

--- a/share/pulse/examples/CustomSyntax.fst
+++ b/share/pulse/examples/CustomSyntax.fst
@@ -46,7 +46,7 @@ fn test_write_10 (x:ref U32.t)
 ```
 
 ```pulse
-fn test_read (r:ref U32.t)
+fn test_read (r:ref U32.t) (#pm:perm)
    requires pts_to r #pm 'n
    returns x : U32.t
    ensures pts_to r #pm x

--- a/share/pulse/examples/Example.ImplicitBinders.fst
+++ b/share/pulse/examples/Example.ImplicitBinders.fst
@@ -17,10 +17,13 @@
 module Example.ImplicitBinders
 open Pulse.Lib.Pervasives
 module U32 = FStar.UInt32
-#push-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection'"
+#push-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection' --print_implicits"
 
 
-
+//
+// Pulse checker adds implicit binders for 'n1 and 'n2
+//   at erased types
+//
 ```pulse
 fn swap (r1 r2:ref U32.t)
   requires 
@@ -37,9 +40,14 @@ fn swap (r1 r2:ref U32.t)
 }
 ```
 
+//
+// Since p and n are non tick variables,
+//   this gives an error "Identifiers (n, p) not found, consider adding them as binders"
+//
+[@@ expect_failure]
 ```pulse
 fn test_read (r:ref U32.t)
-   requires pts_to r #p 'n
+   requires pts_to r #p n
    returns x : U32.t
    ensures pts_to r #p x
 {

--- a/share/pulse/examples/ZetaHashAccumulator.fst
+++ b/share/pulse/examples/ZetaHashAccumulator.fst
@@ -184,11 +184,11 @@ ghost
 fn fold_ha_val_core (#acc:Seq.lseq U8.t 32) (h:ha_core)
   requires
    A.pts_to h.acc acc **
-   pts_to h.ctr n
+   pts_to h.ctr 'n
   ensures
-   ha_val_core h (acc, U32.v n)
+   ha_val_core h (acc, U32.v 'n)
 {
-  fold (ha_val_core h (acc, U32.v n));
+  fold (ha_val_core h (acc, U32.v 'n));
 }
 ```
 
@@ -239,14 +239,14 @@ ghost
 fn fold_ha_val (#acc #s:Seq.lseq U8.t 32) (h:ha)
   requires
    A.pts_to h.core.acc acc **
-   pts_to h.core.ctr n **
+   pts_to h.core.ctr 'n **
    A.pts_to h.tmp s **
    A.pts_to h.dummy (Seq.create 1 0uy)
   ensures
-   ha_val h (acc, U32.v n)
+   ha_val h (acc, U32.v 'n)
 {
     fold_ha_val_core h.core; //fails with ill-typed subst, in case of missing implicit arg
-    fold (ha_val h (acc, U32.v n))
+    fold (ha_val h (acc, U32.v 'n))
 }
 ```
 
@@ -429,6 +429,7 @@ fn compare (b1 b2:ha)
 ```pulse
 fn add (ha:ha) (input:hashable_buffer) (l:(l:SZ.t {SZ.v l <= blake2_max_input_length}))
        (#s:(s:erased bytes {Seq.length s == SZ.v l}))
+       (#p:perm)
   requires
     ha_val ha 'h **
     A.pts_to input #p s

--- a/share/pulse/examples/bug-reports/Bug.Invariants.fst
+++ b/share/pulse/examples/bug-reports/Bug.Invariants.fst
@@ -32,7 +32,7 @@ ensures emp ** pts_to x 1ul
 
 ```pulse
 atomic
-fn return_atomic2 ()
+fn return_atomic2 (x:ref U32.t)
 requires emp ** pts_to x 1ul
 returns n:U32.t
 ensures emp ** pts_to x 1ul

--- a/share/pulse/examples/by-example/PulseTutorial.Array.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.Array.fst
@@ -120,6 +120,7 @@ fn copy
   (#[@@@ Rust_generics_bounds ["Copy"]] t:Type0)
   (a1 a2:A.array t)
   (l:SZ.t)
+  (#p2:perm)
   requires (
     A.pts_to a1 's1 **
     A.pts_to a2 #p2 's2 **
@@ -162,6 +163,7 @@ fn copy2
   (#[@@@ Rust_generics_bounds ["Copy"]] t:Type0)
   (a1 a2:A.array t)
   (l:SZ.t)
+  (#p2:perm)
   requires (
     A.pts_to a1 's1 **
     A.pts_to a2 #p2 's2 **

--- a/share/pulse/examples/by-example/PulseTutorial.ImplicationAndForall.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.ImplicationAndForall.fst
@@ -106,17 +106,17 @@ let can_update (x:GR.ref int) =
 ```pulse //make_can_update$
 ghost
 fn make_can_update (x:GR.ref int)
-requires pts_to x w
-ensures pts_to x #0.5R w ** can_update x
+requires pts_to x 'w
+ensures pts_to x #0.5R 'w ** can_update x
 {
   ghost
   fn aux (u:int)
-  requires pts_to x #0.5R w
+  requires pts_to x #0.5R 'w
   ensures forall* v. pts_to x #0.5R u @==> pts_to x v
   {
     ghost
     fn aux (v:int)
-    requires pts_to x #0.5R w ** pts_to x #0.5R u
+    requires pts_to x #0.5R 'w ** pts_to x #0.5R u
     ensures pts_to x v
     {
       gather x;

--- a/share/pulse/examples/by-example/PulseTutorial.LinkedList.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.LinkedList.fst
@@ -1,3 +1,20 @@
+(*
+   Copyright 2024 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+
 module PulseTutorial.LinkedList
 open Pulse.Lib.Pervasives
 module S = Pulse.Lib.Stick.Util
@@ -33,10 +50,10 @@ let rec is_list #t (x:llist t) (l:list t)
 ```pulse
 ghost
 fn elim_is_list_nil (#t:Type0) (x:llist t)
-requires is_list x l ** pure (l == [])
+requires is_list x 'l ** pure ('l == [])
 ensures pure (x == None)
 {
-   rewrite each l as Nil #t;
+   rewrite each 'l as Nil #t;
    unfold (is_list x [])
 }
 ```

--- a/share/pulse/examples/dice/cbor/CDDLExtractionTest.Assume.fst
+++ b/share/pulse/examples/dice/cbor/CDDLExtractionTest.Assume.fst
@@ -28,6 +28,7 @@ assume val impl_mytype: impl_typ mytype
 fn test
     (c: cbor)
     (v: Ghost.erased raw_data_item)
+    #full_perm
 requires
     raw_data_item_match full_perm c v
 ensures

--- a/share/pulse/examples/dice/cbor/CDDLExtractionTest.Bytes.fst
+++ b/share/pulse/examples/dice/cbor/CDDLExtractionTest.Bytes.fst
@@ -28,6 +28,7 @@ let impl_mytype = impl_bytes ()
 fn test
     (c: cbor)
     (v: Ghost.erased raw_data_item)
+    #full_perm
 requires
     raw_data_item_match full_perm c v
 ensures

--- a/share/pulse/examples/dice/cbor/CDDLExtractionTest.BytesDirect.fst
+++ b/share/pulse/examples/dice/cbor/CDDLExtractionTest.BytesDirect.fst
@@ -27,6 +27,7 @@ let impl_mytype : impl_typ bytes = impl_bytes ()
 fn test
     (c: cbor)
     (v: Ghost.erased raw_data_item)
+    #full_perm
 requires
     raw_data_item_match full_perm c v
 ensures

--- a/share/pulse/examples/dice/cbor/CDDLExtractionTest.BytesUnwrapped.fst
+++ b/share/pulse/examples/dice/cbor/CDDLExtractionTest.BytesUnwrapped.fst
@@ -27,6 +27,7 @@ let impl_mytype : impl_typ bytes = impl_bytes ()
 fn test
     (c: cbor)
     (v: Ghost.erased raw_data_item)
+    #full_perm
 requires
     raw_data_item_match full_perm c v
 ensures

--- a/share/pulse/examples/dice/cbor/CDDLExtractionTest.BytesVeryDirect.fst
+++ b/share/pulse/examples/dice/cbor/CDDLExtractionTest.BytesVeryDirect.fst
@@ -24,6 +24,7 @@ open CDDL.Pulse
 fn test
     (c: cbor)
     (v: Ghost.erased raw_data_item)
+    #full_perm
 requires
     raw_data_item_match full_perm c v
 ensures

--- a/share/pulse/examples/dice/cbor/CDDLExtractionTest.BytesVeryDirectFail.fst
+++ b/share/pulse/examples/dice/cbor/CDDLExtractionTest.BytesVeryDirectFail.fst
@@ -24,6 +24,7 @@ open CDDL.Pulse
 fn test
     (c: cbor)
     (v: Ghost.erased raw_data_item)
+    #full_perm
 requires
     raw_data_item_match full_perm c v
 ensures

--- a/share/pulse/examples/dice/cbor/CDDLExtractionTest.Choice.fst
+++ b/share/pulse/examples/dice/cbor/CDDLExtractionTest.Choice.fst
@@ -27,6 +27,7 @@ let impl_mytype = impl_bytes () `impl_t_choice_none` impl_uint ()
 fn test
     (c: cbor)
     (v: Ghost.erased raw_data_item)
+    #full_perm
 requires
     raw_data_item_match full_perm c v
 ensures

--- a/share/pulse/examples/dice/dpe/DPE_CBOR.fst
+++ b/share/pulse/examples/dice/dpe/DPE_CBOR.fst
@@ -55,6 +55,7 @@ fn elim_implies () (#p #q:vprop)
 
 ```pulse
 fn finish (c:cbor_read_t)
+          (input:_)
           (#p:perm)
           (#v:erased (raw_data_item))
           (#s:erased (Seq.seq U8.t))
@@ -64,14 +65,14 @@ fn finish (c:cbor_read_t)
               A.pts_to input #p s) **
             raw_data_item_match 1.0R c.cbor_read_payload v **
             A.pts_to c.cbor_read_remainder #p rem **
-            uds_is_enabled
+            'uds_is_enabled
   returns _:option ctxt_hndl_t
   ensures A.pts_to input #p s
 {
    elim_implies ()  #(raw_data_item_match 1.0R c.cbor_read_payload v **
                             A.pts_to c.cbor_read_remainder #p rem)
                             #(A.pts_to input #p s);
-    drop uds_is_enabled;
+    drop 'uds_is_enabled;
     None #ctxt_hndl_t
 }
 ```

--- a/share/pulse/examples/parix/Promises.Examples3.fst
+++ b/share/pulse/examples/parix/Promises.Examples3.fst
@@ -96,7 +96,7 @@ let cheat_proof (i:iref)
 
 ```pulse
 fn setup (_:unit)
-   requires pts_to done v_done ** pts_to res v_res ** GR.pts_to claimed v_claimed
+   requires pts_to done 'v_done ** pts_to res 'v_res ** GR.pts_to claimed 'v_claimed
    returns i:iref
    ensures pts_to done #0.5R false **
            pledge (add_inv emp_inames i) (pts_to done #0.5R true) goal


### PR DESCRIPTION
```
//
// Pulse checker adds implicit binders for 'n1 and 'n2
//   at erased types
//
fn swap (r1 r2:ref U32.t)
  requires
      pts_to r1 'n1 **
      pts_to r2 'n2
  ensures
      pts_to r1 'n2 **
      pts_to r2 'n1



//
// Since p and n are non tick variables,
//   this gives an error "Identifiers (n, p) not found, consider adding them as binders"
//
[@@ expect_failure]
fn test_read (r:ref U32.t)
   requires pts_to r #p n
   returns x : U32.t
   ensures pts_to r #p x
```