### PR TITLE
Add a cached devcontainer and update script

### DIFF
--- a/.devcontainer/fromscratch/devcontainer.json
+++ b/.devcontainer/fromscratch/devcontainer.json
@@ -1,6 +1,8 @@
 {
-  "name": "Pulse devcontainer (from cached base container)",
-  "image": "mtzguido/pulse-devcontainer:latest",
+  "name": "Pulse devcontainer (from scratch)"
+  "build": {
+    "dockerfile": "minimal.Dockerfile"
+  },
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/fromscratch/minimal.Dockerfile
+++ b/.devcontainer/fromscratch/minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:23.10
 
 SHELL ["/bin/bash", "-c"]
 
@@ -16,7 +16,6 @@ RUN apt-get update \
       sudo \
       python3 \
       python-is-python3 \
-      libicu70 \
       libgmp-dev \
       opam \
       vim \
@@ -37,11 +36,11 @@ RUN mkdir -p $HOME/bin
 RUN echo 'export PATH=$HOME/bin:$PATH' | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile
 
 # Install OCaml
-ARG OCAML_VERSION=4.12.0
+ARG OCAML_VERSION=4.12.1
 RUN opam init --compiler=$OCAML_VERSION --disable-sandboxing
 RUN opam option depext-run-installs=true
 ENV OPAMYES=1
-RUN opam install --yes batteries zarith stdint yojson dune menhir menhirLib pprint sedlex ppxlib process ppx_deriving ppx_deriving_yojson
+RUN opam install --yes batteries zarith stdint yojson dune menhir menhirLib pprint sedlex ppxlib process ppx_deriving ppx_deriving_yojson memtrace
 
 # Get compiled Z3
 RUN wget -nv https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-ubuntu-16.04.zip \
@@ -68,8 +67,11 @@ RUN eval $(opam env) \
 ENV FSTAR_HOME $HOME/FStar
 ENV KRML_HOME $HOME/karamel
 
-# Instrument .bashrc to set the opam switch. Note that this
+# Instrument .profile and .bashrc to set the opam switch. Note that this
 # just appends the *call* to eval $(opam env) in these files, so we
-# compute the new environments fter the fact. Calling opam env here
-# would perhaps thrash some variables set by the devcontainer infra.
+# compute the new environments after the fact.
+RUN echo 'eval $(opam env --set-switch)' | tee --append $HOME/.profile
 RUN echo 'eval $(opam env --set-switch)' | tee --append $HOME/.bashrc
+
+# We do not build Pulse itself, the devcontainer does that on spinup,
+# on the up-to-date files.

--- a/.devcontainer/rebuild-container-and-deploy.sh
+++ b/.devcontainer/rebuild-container-and-deploy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eux
+
+DOCKERFILE=.devcontainer/fromscratch/minimal.Dockerfile
+REPO=mtzguido/pulse-base-devcontainer
+
+# -f to detect worktrees too, where .git is not a directory
+if ! [ -d .git ] && ! [ -f .git ]; then
+	echo "This script must be run from the root of the repo" >&2
+	exit 1
+fi
+
+if ! [ x"$(git clean -dnx)" == x"" ]; then
+	echo "Repository seems dirty: aborting" >&2
+	exit 1
+fi
+
+docker build --no-cache -f "${DOCKERFILE}" -t "${REPO}" .
+
+docker push "${REPO}"
+
+echo Done
+exit 0


### PR DESCRIPTION
This adds a new devcontainer that starts from a cached docker container (from dockerhub) and a script to update it. It's under my username for now.. but we can change that.

This devcontainer only installs dependencies, and does not build pulse itself. See https://github.com/FStarLang/pulse-sandbox for a devcontainer that quickly sets up a Pulse environment.