### PR TITLE
Give a name starting with '?' to uvars introduced by the Pulse checker

### DIFF
--- a/src/checker/Pulse.Checker.Prover.IntroExists.fst
+++ b/src/checker/Pulse.Checker.Prover.IntroExists.fst
@@ -94,7 +94,8 @@ let intro_exists (#preamble:_) (pst:prover_state preamble)
                                         is_terminal pst' }) =
 
   let x = fresh (push_env pst.pg pst.uvs) in
-  let px = b.binder_ppname, x in
+  let ppname = ppname_for_uvar b.binder_ppname in
+  let px = ppname, x in
   let preamble_sub = {
     g0 = pst.pg;
     ctxt = list_as_vprop pst.remaining_ctxt;
@@ -121,7 +122,7 @@ let intro_exists (#preamble:_) (pst:prover_state preamble)
     pg = pst.pg;
     remaining_ctxt = vprop_as_list preamble_sub.ctxt;
     remaining_ctxt_frame_typing = RU.magic ();
-    uvs = push_binding pst.uvs x b.binder_ppname b.binder_ty;
+    uvs = push_binding pst.uvs x ppname b.binder_ty;
     ss = pst.ss;
     nts = None;
     solved = tm_emp;

--- a/src/checker/Pulse.Syntax.Base.fsti
+++ b/src/checker/Pulse.Syntax.Base.fsti
@@ -389,3 +389,8 @@ let comp_inames (c:comp { C_STAtomic? c || C_STGhost? c }) : term =
 let nvar = ppname & var 
 let v_as_nv x : nvar = ppname_default, x
 let as_binder (t:term) = null_binder t
+
+let ppname_for_uvar (p : ppname) : T.Tac ppname =
+  {
+    p with name = T.seal ("?" ^ T.unseal p.name);
+  }

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_IntroExists.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_IntroExists.ml
@@ -392,7 +392,7 @@ let (intro_exists :
                           (FStar_Range.mk_range
                              "Pulse.Checker.Prover.IntroExists.fst"
                              (Prims.of_int (96)) (Prims.of_int (44))
-                             (Prims.of_int (349)) (Prims.of_int (6)))))
+                             (Prims.of_int (350)) (Prims.of_int (6)))))
                     (FStar_Tactics_Effect.lift_div_tac
                        (fun uu___1 ->
                           Pulse_Typing_Env.fresh
@@ -408,139 +408,164 @@ let (intro_exists :
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.Prover.IntroExists.fst"
                                         (Prims.of_int (97))
-                                        (Prims.of_int (11))
+                                        (Prims.of_int (15))
                                         (Prims.of_int (97))
-                                        (Prims.of_int (29)))))
+                                        (Prims.of_int (46)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.Prover.IntroExists.fst"
                                         (Prims.of_int (97))
-                                        (Prims.of_int (32))
-                                        (Prims.of_int (349))
+                                        (Prims.of_int (49))
+                                        (Prims.of_int (350))
                                         (Prims.of_int (6)))))
-                               (FStar_Tactics_Effect.lift_div_tac
-                                  (fun uu___1 ->
-                                     ((b.Pulse_Syntax_Base.binder_ppname), x)))
+                               (Obj.magic
+                                  (Pulse_Syntax_Base.ppname_for_uvar
+                                     b.Pulse_Syntax_Base.binder_ppname))
                                (fun uu___1 ->
-                                  (fun px ->
+                                  (fun ppname ->
                                      Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Prover.IntroExists.fst"
-                                                   (Prims.of_int (99))
-                                                   (Prims.of_int (4))
-                                                   (Prims.of_int (103))
-                                                   (Prims.of_int (61)))))
+                                                   (Prims.of_int (98))
+                                                   (Prims.of_int (11))
+                                                   (Prims.of_int (98))
+                                                   (Prims.of_int (20)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Prover.IntroExists.fst"
-                                                   (Prims.of_int (104))
-                                                   (Prims.of_int (6))
-                                                   (Prims.of_int (349))
+                                                   (Prims.of_int (98))
+                                                   (Prims.of_int (23))
+                                                   (Prims.of_int (350))
                                                    (Prims.of_int (6)))))
                                           (FStar_Tactics_Effect.lift_div_tac
-                                             (fun uu___1 ->
-                                                {
-                                                  Pulse_Checker_Prover_Base.g0
-                                                    =
-                                                    (pst.Pulse_Checker_Prover_Base.pg);
-                                                  Pulse_Checker_Prover_Base.ctxt
-                                                    =
-                                                    (Pulse_Typing_Combinators.list_as_vprop
-                                                       pst.Pulse_Checker_Prover_Base.remaining_ctxt);
-                                                  Pulse_Checker_Prover_Base.frame
-                                                    =
-                                                    (Pulse_Checker_Prover_Base.op_Star
-                                                       preamble.Pulse_Checker_Prover_Base.frame
-                                                       (Pulse_Checker_Prover_Base.op_Array_Access
-                                                          pst.Pulse_Checker_Prover_Base.ss
-                                                          pst.Pulse_Checker_Prover_Base.solved));
-                                                  Pulse_Checker_Prover_Base.ctxt_frame_typing
-                                                    = ();
-                                                  Pulse_Checker_Prover_Base.goals
-                                                    =
-                                                    (Pulse_Checker_Prover_Base.op_Star
-                                                       (Pulse_Syntax_Naming.open_term_nv
-                                                          body px)
-                                                       (Pulse_Typing_Combinators.list_as_vprop
-                                                          unsolved'))
-                                                }))
+                                             (fun uu___1 -> (ppname, x)))
                                           (fun uu___1 ->
-                                             (fun preamble_sub ->
+                                             (fun px ->
                                                 Obj.magic
                                                   (FStar_Tactics_Effect.tac_bind
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Prover.IntroExists.fst"
-                                                              (Prims.of_int (108))
-                                                              (Prims.of_int (105))
-                                                              (Prims.of_int (117))
-                                                              (Prims.of_int (18)))))
+                                                              (Prims.of_int (100))
+                                                              (Prims.of_int (4))
+                                                              (Prims.of_int (104))
+                                                              (Prims.of_int (61)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Prover.IntroExists.fst"
-                                                              (Prims.of_int (119))
-                                                              (Prims.of_int (37))
-                                                              (Prims.of_int (349))
+                                                              (Prims.of_int (105))
+                                                              (Prims.of_int (6))
+                                                              (Prims.of_int (350))
                                                               (Prims.of_int (6)))))
                                                      (FStar_Tactics_Effect.lift_div_tac
                                                         (fun uu___1 ->
-                                                           coerce_eq
-                                                             (Pulse_Checker_Base.k_elab_equiv
-                                                                preamble_sub.Pulse_Checker_Prover_Base.g0
-                                                                preamble_sub.Pulse_Checker_Prover_Base.g0
-                                                                (Pulse_Checker_Prover_Base.op_Star
-                                                                   preamble_sub.Pulse_Checker_Prover_Base.ctxt
-                                                                   preamble_sub.Pulse_Checker_Prover_Base.frame)
-                                                                (Pulse_Checker_Prover_Base.op_Star
-                                                                   preamble_sub.Pulse_Checker_Prover_Base.ctxt
-                                                                   preamble_sub.Pulse_Checker_Prover_Base.frame)
-                                                                (Pulse_Checker_Prover_Base.op_Star
-                                                                   preamble_sub.Pulse_Checker_Prover_Base.ctxt
-                                                                   preamble_sub.Pulse_Checker_Prover_Base.frame)
-                                                                (Pulse_Checker_Prover_Base.op_Star
-                                                                   (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
-                                                                    (Pulse_Typing_Combinators.vprop_as_list
-                                                                    preamble_sub.Pulse_Checker_Prover_Base.ctxt))
-                                                                    preamble_sub.Pulse_Checker_Prover_Base.frame)
-                                                                   (Pulse_Checker_Prover_Base.op_Array_Access
+                                                           {
+                                                             Pulse_Checker_Prover_Base.g0
+                                                               =
+                                                               (pst.Pulse_Checker_Prover_Base.pg);
+                                                             Pulse_Checker_Prover_Base.ctxt
+                                                               =
+                                                               (Pulse_Typing_Combinators.list_as_vprop
+                                                                  pst.Pulse_Checker_Prover_Base.remaining_ctxt);
+                                                             Pulse_Checker_Prover_Base.frame
+                                                               =
+                                                               (Pulse_Checker_Prover_Base.op_Star
+                                                                  preamble.Pulse_Checker_Prover_Base.frame
+                                                                  (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst.Pulse_Checker_Prover_Base.ss
-                                                                    Pulse_Syntax_Pure.tm_emp))
-                                                                (Pulse_Checker_Base.k_elab_unit
-                                                                   preamble_sub.Pulse_Checker_Prover_Base.g0
-                                                                   (Pulse_Checker_Prover_Base.op_Star
-                                                                    preamble_sub.Pulse_Checker_Prover_Base.ctxt
-                                                                    preamble_sub.Pulse_Checker_Prover_Base.frame))
-                                                                () ()) ()))
+                                                                    pst.Pulse_Checker_Prover_Base.solved));
+                                                             Pulse_Checker_Prover_Base.ctxt_frame_typing
+                                                               = ();
+                                                             Pulse_Checker_Prover_Base.goals
+                                                               =
+                                                               (Pulse_Checker_Prover_Base.op_Star
+                                                                  (Pulse_Syntax_Naming.open_term_nv
+                                                                    body px)
+                                                                  (Pulse_Typing_Combinators.list_as_vprop
+                                                                    unsolved'))
+                                                           }))
                                                      (fun uu___1 ->
-                                                        (fun k_sub ->
+                                                        (fun preamble_sub ->
                                                            Obj.magic
                                                              (FStar_Tactics_Effect.tac_bind
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (121))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (131))
-                                                                    (Prims.of_int (20)))))
+                                                                    (Prims.of_int (109))
+                                                                    (Prims.of_int (105))
+                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (18)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (132))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (120))
+                                                                    (Prims.of_int (37))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (6)))))
                                                                 (FStar_Tactics_Effect.lift_div_tac
                                                                    (fun
+                                                                    uu___1 ->
+                                                                    coerce_eq
+                                                                    (Pulse_Checker_Base.k_elab_equiv
+                                                                    preamble_sub.Pulse_Checker_Prover_Base.g0
+                                                                    preamble_sub.Pulse_Checker_Prover_Base.g0
+                                                                    (Pulse_Checker_Prover_Base.op_Star
+                                                                    preamble_sub.Pulse_Checker_Prover_Base.ctxt
+                                                                    preamble_sub.Pulse_Checker_Prover_Base.frame)
+                                                                    (Pulse_Checker_Prover_Base.op_Star
+                                                                    preamble_sub.Pulse_Checker_Prover_Base.ctxt
+                                                                    preamble_sub.Pulse_Checker_Prover_Base.frame)
+                                                                    (Pulse_Checker_Prover_Base.op_Star
+                                                                    preamble_sub.Pulse_Checker_Prover_Base.ctxt
+                                                                    preamble_sub.Pulse_Checker_Prover_Base.frame)
+                                                                    (Pulse_Checker_Prover_Base.op_Star
+                                                                    (Pulse_Checker_Prover_Base.op_Star
+                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Typing_Combinators.vprop_as_list
+                                                                    preamble_sub.Pulse_Checker_Prover_Base.ctxt))
+                                                                    preamble_sub.Pulse_Checker_Prover_Base.frame)
+                                                                    (Pulse_Checker_Prover_Base.op_Array_Access
+                                                                    pst.Pulse_Checker_Prover_Base.ss
+                                                                    Pulse_Syntax_Pure.tm_emp))
+                                                                    (Pulse_Checker_Base.k_elab_unit
+                                                                    preamble_sub.Pulse_Checker_Prover_Base.g0
+                                                                    (Pulse_Checker_Prover_Base.op_Star
+                                                                    preamble_sub.Pulse_Checker_Prover_Base.ctxt
+                                                                    preamble_sub.Pulse_Checker_Prover_Base.frame))
+                                                                    () ()) ()))
+                                                                (fun uu___1
+                                                                   ->
+                                                                   (fun k_sub
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.IntroExists.fst"
+                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (132))
+                                                                    (Prims.of_int (20)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.IntroExists.fst"
+                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (350))
+                                                                    (Prims.of_int (6)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
                                                                     uu___1 ->
                                                                     {
                                                                     Pulse_Checker_Prover_Base.pg
@@ -556,8 +581,7 @@ let (intro_exists :
                                                                     =
                                                                     (Pulse_Typing_Env.push_binding
                                                                     pst.Pulse_Checker_Prover_Base.uvs
-                                                                    x
-                                                                    b.Pulse_Syntax_Base.binder_ppname
+                                                                    x ppname
                                                                     b.Pulse_Syntax_Base.binder_ty);
                                                                     Pulse_Checker_Prover_Base.ss
                                                                     =
@@ -582,9 +606,9 @@ let (intro_exists :
                                                                     Pulse_Checker_Prover_Base.solved_inv
                                                                     = ()
                                                                     }))
-                                                                (fun uu___1
-                                                                   ->
-                                                                   (fun
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun
                                                                     pst_sub
                                                                     ->
                                                                     Obj.magic
@@ -593,17 +617,17 @@ let (intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (33))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (6)))))
                                                                     (Obj.magic
                                                                     (prover
@@ -620,17 +644,17 @@ let (intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (138))
                                                                     (Prims.of_int (56))
-                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (138))
                                                                     (Prims.of_int (73)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (138))
                                                                     (Prims.of_int (76))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (6)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -647,17 +671,17 @@ let (intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (144))
+                                                                    (Prims.of_int (145))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (155))
                                                                     (Prims.of_int (20)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (138))
                                                                     (Prims.of_int (76))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (6)))))
                                                                     (match 
                                                                     pst_sub1.Pulse_Checker_Prover_Base.nts
@@ -681,17 +705,17 @@ let (intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (148))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (148))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (148))
+                                                                    (Prims.of_int (149))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (155))
                                                                     (Prims.of_int (20)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover_Substs.ss_to_nt_substs
@@ -742,17 +766,17 @@ let (intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (156))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (6)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (156))
                                                                     (Prims.of_int (75))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (6)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -768,17 +792,17 @@ let (intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (161))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (161))
                                                                     (Prims.of_int (94)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (163))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (6)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -795,17 +819,17 @@ let (intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (59))
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (89)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (92))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (6)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -822,17 +846,17 @@ let (intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (171))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (171))
                                                                     (Prims.of_int (96)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (171))
                                                                     (Prims.of_int (99))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (6)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -849,17 +873,17 @@ let (intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (13)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (6)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -875,17 +899,17 @@ let (intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (53))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (6)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -927,17 +951,17 @@ let (intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (189))
+                                                                    (Prims.of_int (190))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (189))
+                                                                    (Prims.of_int (190))
                                                                     (Prims.of_int (22)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (192))
                                                                     (Prims.of_int (84))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (6)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -954,17 +978,17 @@ let (intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (192))
+                                                                    (Prims.of_int (193))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (192))
+                                                                    (Prims.of_int (193))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (97))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (6)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -984,17 +1008,17 @@ let (intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (201))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (201))
                                                                     (Prims.of_int (22)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (201))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (6)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1011,17 +1035,17 @@ let (intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (210))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (210))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (210))
                                                                     (Prims.of_int (53))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (6)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1083,17 +1107,17 @@ let (intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (219))
+                                                                    (Prims.of_int (220))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (229))
                                                                     (Prims.of_int (19)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.IntroExists.fst"
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (346))
+                                                                    (Prims.of_int (347))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (k_intro_exists
@@ -1427,6 +1451,7 @@ let (intro_exists :
                                                                     uu___3)))
                                                                     uu___3)))
                                                                     uu___2)))
+                                                                    uu___1)))
                                                                     uu___1)))
                                                                     uu___1)))
                                                                     uu___1)))

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Base.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Base.ml
@@ -838,3 +838,51 @@ let (comp_inames : comp -> term) =
 type nvar = (ppname * var)
 let (v_as_nv : var -> nvar) = fun x -> (ppname_default, x)
 let (as_binder : term -> binder) = fun t -> null_binder t
+let (ppname_for_uvar :
+  ppname -> (ppname, unit) FStar_Tactics_Effect.tac_repr) =
+  fun p ->
+    FStar_Tactics_Effect.tac_bind
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "Pulse.Syntax.Base.fsti"
+               (Prims.of_int (395)) (Prims.of_int (18)) (Prims.of_int (395))
+               (Prims.of_int (48)))))
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "Pulse.Syntax.Base.fsti"
+               (Prims.of_int (395)) (Prims.of_int (4)) (Prims.of_int (395))
+               (Prims.of_int (49)))))
+      (Obj.magic
+         (FStar_Tactics_Effect.tac_bind
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "Pulse.Syntax.Base.fsti"
+                     (Prims.of_int (395)) (Prims.of_int (25))
+                     (Prims.of_int (395)) (Prims.of_int (48)))))
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "Pulse.Syntax.Base.fsti"
+                     (Prims.of_int (395)) (Prims.of_int (18))
+                     (Prims.of_int (395)) (Prims.of_int (48)))))
+            (Obj.magic
+               (FStar_Tactics_Effect.tac_bind
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range "Pulse.Syntax.Base.fsti"
+                           (Prims.of_int (395)) (Prims.of_int (32))
+                           (Prims.of_int (395)) (Prims.of_int (47)))))
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range "prims.fst"
+                           (Prims.of_int (590)) (Prims.of_int (19))
+                           (Prims.of_int (590)) (Prims.of_int (31)))))
+                  (Obj.magic (FStar_Tactics_Unseal.unseal p.name))
+                  (fun uu___ ->
+                     FStar_Tactics_Effect.lift_div_tac
+                       (fun uu___1 -> Prims.strcat "?" uu___))))
+            (fun uu___ ->
+               FStar_Tactics_Effect.lift_div_tac
+                 (fun uu___1 -> FStar_Sealed.seal uu___))))
+      (fun uu___ ->
+         FStar_Tactics_Effect.lift_div_tac
+           (fun uu___1 -> { name = uu___; range = (p.range) }))


### PR DESCRIPTION
Example:

    assume val f : int -> vprop

    ```pulse
    fn foo ()
      requires exists* x. f x
      ensures  emp
    {
      admit()
    }
    ```

    ```pulse
    fn test (x:int)
      requires emp
      ensures  emp
    {
      foo ()
    }
    ```


Before:
```
- Cannot prove:
    f x
- In the context:
    emp
```
After:
```
- Cannot prove:
    f ?x
- In the context:
    emp
```
I think this is clearer, since otherwise it looks like the `x` in scope.