### PR TITLE
Tame Pulse.Typing.FV

### DIFF
--- a/src/ocaml/plugin/FStar_Parser_Parse.mly
+++ b/src/ocaml/plugin/FStar_Parser_Parse.mly
@@ -640,7 +640,7 @@ atomicPattern:
       }
   | LBRACK pats=separated_list(SEMICOLON, tuplePattern) RBRACK
       { mk_pattern (PatList pats) (rr2 $loc($1) $loc($3)) }
-  | LBRACE record_pat=right_flexible_nonempty_list(SEMICOLON, fieldPattern) RBRACE
+  | LBRACE record_pat=right_flexible_list(SEMICOLON, fieldPattern) RBRACE
       { mk_pattern (PatRecord record_pat) (rr $loc) }
   | LENS_PAREN_LEFT pat0=constructorPattern COMMA pats=separated_nonempty_list(COMMA, constructorPattern) LENS_PAREN_RIGHT
       { mk_pattern (PatTuple(pat0::pats, true)) (rr $loc) }

--- a/src/ocaml/plugin/generated/Pulse_Typing_FV.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_FV.ml
@@ -18,3 +18,20 @@ let (contains_r :
       FStar_Pervasives_Native.uu___is_Some
         (FStar_Reflection_Typing.lookup_bvar g x)
 type ('a, 'du) src_typing_freevars_t = unit
+type ('g0, 't0, 'c0, 'd0) st_typing_freevars_cb_t = unit
+type 'pred st_typing_freevars_case = unit
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This proof was way too large and brittle for the SMT. Split it into cases, in separate functions, which makes it robust.