### PR TITLE
Printing improvements

### DIFF
--- a/src/checker/Pulse.Checker.Admit.fst
+++ b/src/checker/Pulse.Checker.Admit.fst
@@ -86,7 +86,7 @@ let check
     let msg = [
       text "Admitting continuation.";
       text "Current context:" ^^
-        indent (pp (VPropEquiv.canon_vprop pre))
+        indent (pp <| canon_vprop_print pre)
     ] in
     info_doc_env g (Some t0.range) msg
   end else ()) <: T.Tac unit;

--- a/src/checker/Pulse.Checker.AssertWithBinders.fst
+++ b/src/checker/Pulse.Checker.AssertWithBinders.fst
@@ -336,7 +336,7 @@ let check
     let open Pulse.PP in
     let msg = [
       text "Current context:" ^^
-            indent (pp (VPropEquiv.canon_vprop pre))
+            indent (pp <| canon_vprop_print pre)
     ] in
     fail_doc_env true g (Some r) msg
   | RENAME { pairs; goal } ->

--- a/src/checker/Pulse.Checker.AssertWithBinders.fst
+++ b/src/checker/Pulse.Checker.AssertWithBinders.fst
@@ -163,7 +163,7 @@ let visit_and_rewrite_conjuncts (p: (R.term & R.term)) (tms:list term) : T.Tac (
   T.map (visit_and_rewrite p) tms
 
 let visit_and_rewrite_conjuncts_all (p: list (R.term & R.term)) (goal:term) : T.Tac (term & term) =
-  let tms = Pulse.Typing.Combinators.vprop_as_list goal in
+  let tms = vprop_as_list goal in
   let tms' = T.fold_left (fun tms p -> visit_and_rewrite_conjuncts p tms) tms p in
   assume (L.length tms' == L.length tms);
   let lhs, rhs =
@@ -174,8 +174,7 @@ let visit_and_rewrite_conjuncts_all (p: list (R.term & R.term)) (goal:term) : T.
       ([], [])
       tms tms'
   in
-  Pulse.Typing.Combinators.list_as_vprop lhs,
-  Pulse.Typing.Combinators.list_as_vprop rhs
+  list_as_vprop lhs, list_as_vprop rhs
   
 
 let disjoint (dom:list var) (cod:Set.set var) =
@@ -270,7 +269,7 @@ let check_wild
     fail g (Some st.range) "A wildcard must have at least one binder"
 
   | _ ->
-    let vprops = Pulse.Typing.Combinators.vprop_as_list pre in
+    let vprops = vprop_as_list pre in
     let ex, rest = List.Tot.partition (fun (v:vprop) ->
                                        let vv = inspect_term v in
                                        Tm_ExistsSL? vv) vprops in

--- a/src/checker/Pulse.Checker.Prover.fst
+++ b/src/checker/Pulse.Checker.Prover.fst
@@ -169,14 +169,14 @@ let rec prover
               let open Pulse.PP in
               let msg = [
                 text "Cannot prove:" ^^
-                    indent (pp pst.ss.(q));
+                    indent (pp <| canon_vprop_print pst.ss.(q));
                 text "In the context:" ^^
-                    indent (pp (list_as_vprop pst.remaining_ctxt))
+                    indent (pp <| canon_vprop_list_print pst.remaining_ctxt)
               ] @ (if Pulse.Config.debug_flag "initial_solver_state" then [
                     text "The prover was started with goal:" ^^
-                        indent (pp preamble.goals);
+                        indent (pp <| canon_vprop_print preamble.goals);
                     text "and initial context:" ^^
-                        indent (pp preamble.ctxt);
+                        indent (pp <| canon_vprop_print preamble.ctxt);
                    ] else [])
               in
               // GM: I feel I should use (Some q.range) instead of None, but that makes

--- a/src/checker/Pulse.Checker.VPropEquiv.fsti
+++ b/src/checker/Pulse.Checker.VPropEquiv.fsti
@@ -21,13 +21,12 @@ open FStar.List.Tot
 open Pulse.Syntax
 open Pulse.Typing
 open Pulse.Typing.Combinators
-
 open Pulse.Checker.Base
+module T = FStar.Tactics.V2
 
 let canon_vprop (vp:term)
   : term
   = list_as_vprop (vprop_as_list vp)
-
 
 val ve_unit_r (g:env) (p:term) : vprop_equiv g (tm_star p tm_emp) p
 

--- a/src/checker/Pulse.Syntax.Naming.fst
+++ b/src/checker/Pulse.Syntax.Naming.fst
@@ -129,7 +129,7 @@ let close_open_inverse_ascription' (t:comp_ascription)
      | None -> ()
      | Some c -> close_open_inverse_comp' c x i)
 
-#push-options "--z3rlimit_factor 8 --fuel 2 --ifuel 2 --split_queries no"
+#push-options "--z3rlimit_factor 12 --fuel 2 --ifuel 2 --split_queries no"
 let rec close_open_inverse_st'  (t:st_term) 
                                 (x:var { ~(x `Set.mem` freevars_st t) } )
                                 (i:index)

--- a/src/checker/Pulse.Syntax.Pure.fst
+++ b/src/checker/Pulse.Syntax.Pure.fst
@@ -457,3 +457,18 @@ let rec inspect_term (t:R.term)
   | Tv_Unknown -> Tm_Unknown
 
   | Tv_Unsupp -> default_view
+
+let rec vprop_as_list (vp:term)
+  : list term
+  = match inspect_term vp with
+    | Tm_Emp -> []
+    | Tm_Star vp0 vp1 ->
+      vprop_as_list vp0 @ vprop_as_list vp1
+    | _ -> [vp]
+
+let rec list_as_vprop (vps:list term)
+  : term
+  = match vps with
+    | [] -> tm_emp
+    | [hd] -> hd
+    | hd::tl -> tm_star hd (list_as_vprop tl)

--- a/src/checker/Pulse.Syntax.Pure.fst
+++ b/src/checker/Pulse.Syntax.Pure.fst
@@ -472,3 +472,24 @@ let rec list_as_vprop (vps:list term)
     | [] -> tm_emp
     | [hd] -> hd
     | hd::tl -> tm_star hd (list_as_vprop tl)
+
+let rec insert1 (t:term) (ts : list term) : T.Tac (list term) =
+  match ts with
+  | [] -> [t]
+  | t'::ts' ->
+    if Order.le (T.compare_term t t')
+    then t::ts
+    else t'::insert1 t ts'
+
+let sort_terms (ts : list term) : T.Tac (list term) =
+  T.fold_right insert1 ts []
+
+(* This does not have any useful lemmas, but can put the terms
+in order. It's useful to pretty-print contexts. See #96. *)
+let canon_vprop_list_print (vs : list term)
+  : T.Tac term
+  = list_as_vprop <| sort_terms vs
+
+let canon_vprop_print (vp:term)
+  : T.Tac term
+  = canon_vprop_list_print <| vprop_as_list vp

--- a/src/checker/Pulse.Typing.Combinators.fsti
+++ b/src/checker/Pulse.Typing.Combinators.fsti
@@ -104,21 +104,6 @@ type st_typing_in_ctxt (g:env) (ctxt:vprop) (post_hint:post_hint_opt g) =
   c:comp_st { comp_pre c == ctxt /\ comp_post_matches_hint c post_hint } &
   st_typing g t c
 
-let rec vprop_as_list (vp:term)
-  : list term
-  = match inspect_term vp with
-    | Tm_Emp -> []
-    | Tm_Star vp0 vp1 ->
-      vprop_as_list vp0 @ vprop_as_list vp1
-    | _ -> [vp]
-
-let rec list_as_vprop (vps:list term)
-  : term
-  = match vps with
-    | [] -> tm_emp
-    | [hd] -> hd
-    | hd::tl -> tm_star hd (list_as_vprop tl)
-
 val comp_for_post_hint #g (#pre:vprop) (pre_typing:tot_typing g pre tm_vprop)
   (post:post_hint_t { g `env_extends` post.g })
   (x:var { lookup g x == None })

--- a/src/ocaml/plugin/generated/Pulse_Checker_Admit.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Admit.ml
@@ -729,7 +729,7 @@ let (check :
                                                                     (Prims.of_int (88))
                                                                     (Prims.of_int (6))
                                                                     (Prims.of_int (89))
-                                                                    (Prims.of_int (48)))))
+                                                                    (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -747,7 +747,7 @@ let (check :
                                                                     (Prims.of_int (89))
                                                                     (Prims.of_int (8))
                                                                     (Prims.of_int (89))
-                                                                    (Prims.of_int (48)))))
+                                                                    (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -755,7 +755,7 @@ let (check :
                                                                     (Prims.of_int (88))
                                                                     (Prims.of_int (6))
                                                                     (Prims.of_int (89))
-                                                                    (Prims.of_int (48)))))
+                                                                    (Prims.of_int (44)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
@@ -765,7 +765,7 @@ let (check :
                                                                     (Prims.of_int (89))
                                                                     (Prims.of_int (15))
                                                                     (Prims.of_int (89))
-                                                                    (Prims.of_int (48)))))
+                                                                    (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -773,12 +773,37 @@ let (check :
                                                                     (Prims.of_int (89))
                                                                     (Prims.of_int (8))
                                                                     (Prims.of_int (89))
-                                                                    (Prims.of_int (48)))))
+                                                                    (Prims.of_int (44)))))
                                                                     (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Admit.fst"
+                                                                    (Prims.of_int (89))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (89))
+                                                                    (Prims.of_int (43)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Admit.fst"
+                                                                    (Prims.of_int (89))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (89))
+                                                                    (Prims.of_int (44)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Syntax_Pure.canon_vprop_print
+                                                                    pre))
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    Obj.magic
                                                                     (Pulse_PP.pp
                                                                     Pulse_PP.printable_term
-                                                                    (Pulse_Checker_VPropEquiv.canon_vprop
-                                                                    pre)))
+                                                                    uu___5))
+                                                                    uu___5)))
                                                                     (fun
                                                                     uu___5 ->
                                                                     FStar_Tactics_Effect.lift_div_tac

--- a/src/ocaml/plugin/generated/Pulse_Checker_AssertWithBinders.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_AssertWithBinders.ml
@@ -1029,14 +1029,14 @@ let (visit_and_rewrite_conjuncts_all :
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
                  (Prims.of_int (166)) (Prims.of_int (12))
-                 (Prims.of_int (166)) (Prims.of_int (55)))))
+                 (Prims.of_int (166)) (Prims.of_int (30)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
-                 (Prims.of_int (166)) (Prims.of_int (58))
-                 (Prims.of_int (178)) (Prims.of_int (44)))))
+                 (Prims.of_int (166)) (Prims.of_int (33))
+                 (Prims.of_int (177)) (Prims.of_int (38)))))
         (FStar_Tactics_Effect.lift_div_tac
-           (fun uu___ -> Pulse_Typing_Combinators.vprop_as_list goal))
+           (fun uu___ -> Pulse_Syntax_Pure.vprop_as_list goal))
         (fun uu___ ->
            (fun tms ->
               Obj.magic
@@ -1052,7 +1052,7 @@ let (visit_and_rewrite_conjuncts_all :
                          (FStar_Range.mk_range
                             "Pulse.Checker.AssertWithBinders.fst"
                             (Prims.of_int (168)) (Prims.of_int (41))
-                            (Prims.of_int (178)) (Prims.of_int (44)))))
+                            (Prims.of_int (177)) (Prims.of_int (38)))))
                    (Obj.magic
                       (FStar_Tactics_Util.fold_left
                          (fun tms1 ->
@@ -1076,8 +1076,8 @@ let (visit_and_rewrite_conjuncts_all :
                                        "Pulse.Checker.AssertWithBinders.fst"
                                        (Prims.of_int (168))
                                        (Prims.of_int (41))
-                                       (Prims.of_int (178))
-                                       (Prims.of_int (44)))))
+                                       (Prims.of_int (177))
+                                       (Prims.of_int (38)))))
                               (Obj.magic
                                  (FStar_Tactics_Util.fold_left2
                                     (fun uu___2 ->
@@ -1106,9 +1106,9 @@ let (visit_and_rewrite_conjuncts_all :
                                    (fun uu___1 ->
                                       match uu___ with
                                       | (lhs, rhs) ->
-                                          ((Pulse_Typing_Combinators.list_as_vprop
+                                          ((Pulse_Syntax_Pure.list_as_vprop
                                               lhs),
-                                            (Pulse_Typing_Combinators.list_as_vprop
+                                            (Pulse_Syntax_Pure.list_as_vprop
                                                rhs)))))) uu___))) uu___)
 let (disjoint :
   Pulse_Syntax_Base.var Prims.list ->
@@ -1174,14 +1174,14 @@ let (rewrite_all :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.AssertWithBinders.fst"
-                                    (Prims.of_int (214)) (Prims.of_int (6))
-                                    (Prims.of_int (218)) (Prims.of_int (9)))))
+                                    (Prims.of_int (213)) (Prims.of_int (6))
+                                    (Prims.of_int (217)) (Prims.of_int (9)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.AssertWithBinders.fst"
-                                    (Prims.of_int (219)) (Prims.of_int (6))
-                                    (Prims.of_int (222)) (Prims.of_int (12)))))
+                                    (Prims.of_int (218)) (Prims.of_int (6))
+                                    (Prims.of_int (221)) (Prims.of_int (12)))))
                            (Obj.magic
                               (FStar_Tactics_Util.map
                                  (fun uu___1 ->
@@ -1192,17 +1192,17 @@ let (rewrite_all :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                   (Prims.of_int (216))
+                                                   (Prims.of_int (215))
                                                    (Prims.of_int (10))
-                                                   (Prims.of_int (216))
+                                                   (Prims.of_int (215))
                                                    (Prims.of_int (68)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                   (Prims.of_int (216))
+                                                   (Prims.of_int (215))
                                                    (Prims.of_int (10))
-                                                   (Prims.of_int (217))
+                                                   (Prims.of_int (216))
                                                    (Prims.of_int (68)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -1210,17 +1210,17 @@ let (rewrite_all :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (216))
+                                                         (Prims.of_int (215))
                                                          (Prims.of_int (15))
-                                                         (Prims.of_int (216))
+                                                         (Prims.of_int (215))
                                                          (Prims.of_int (67)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (216))
+                                                         (Prims.of_int (215))
                                                          (Prims.of_int (10))
-                                                         (Prims.of_int (216))
+                                                         (Prims.of_int (215))
                                                          (Prims.of_int (68)))))
                                                 (Obj.magic
                                                    (Pulse_Checker_Pure.instantiate_term_implicits
@@ -1238,17 +1238,17 @@ let (rewrite_all :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.AssertWithBinders.fst"
-                                                              (Prims.of_int (217))
+                                                              (Prims.of_int (216))
                                                               (Prims.of_int (10))
-                                                              (Prims.of_int (217))
+                                                              (Prims.of_int (216))
                                                               (Prims.of_int (68)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.AssertWithBinders.fst"
-                                                              (Prims.of_int (216))
+                                                              (Prims.of_int (215))
                                                               (Prims.of_int (10))
-                                                              (Prims.of_int (217))
+                                                              (Prims.of_int (216))
                                                               (Prims.of_int (68)))))
                                                      (Obj.magic
                                                         (FStar_Tactics_Effect.tac_bind
@@ -1256,17 +1256,17 @@ let (rewrite_all :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (217))
+                                                                    (Prims.of_int (216))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (217))
+                                                                    (Prims.of_int (216))
                                                                     (Prims.of_int (67)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (217))
+                                                                    (Prims.of_int (216))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (217))
+                                                                    (Prims.of_int (216))
                                                                     (Prims.of_int (68)))))
                                                            (Obj.magic
                                                               (Pulse_Checker_Pure.instantiate_term_implicits
@@ -1290,17 +1290,17 @@ let (rewrite_all :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.AssertWithBinders.fst"
-                                               (Prims.of_int (220))
+                                               (Prims.of_int (219))
                                                (Prims.of_int (19))
-                                               (Prims.of_int (220))
+                                               (Prims.of_int (219))
                                                (Prims.of_int (54)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.AssertWithBinders.fst"
-                                               (Prims.of_int (219))
+                                               (Prims.of_int (218))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (222))
+                                               (Prims.of_int (221))
                                                (Prims.of_int (12)))))
                                       (Obj.magic
                                          (visit_and_rewrite_conjuncts_all p1
@@ -1315,17 +1315,17 @@ let (rewrite_all :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.AssertWithBinders.fst"
-                                                              (Prims.of_int (221))
+                                                              (Prims.of_int (220))
                                                               (Prims.of_int (4))
-                                                              (Prims.of_int (221))
+                                                              (Prims.of_int (220))
                                                               (Prims.of_int (106)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.AssertWithBinders.fst"
-                                                              (Prims.of_int (222))
+                                                              (Prims.of_int (221))
                                                               (Prims.of_int (4))
-                                                              (Prims.of_int (222))
+                                                              (Prims.of_int (221))
                                                               (Prims.of_int (12)))))
                                                      (Obj.magic
                                                         (debug_log g
@@ -1335,17 +1335,17 @@ let (rewrite_all :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (220))
                                                                     (Prims.of_int (83))
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (220))
                                                                     (Prims.of_int (105)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (220))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (220))
                                                                     (Prims.of_int (105)))))
                                                                 (Obj.magic
                                                                    (Pulse_Syntax_Printer.term_to_string
@@ -1360,17 +1360,17 @@ let (rewrite_all :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (220))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (220))
                                                                     (Prims.of_int (105)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (220))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (220))
                                                                     (Prims.of_int (105)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1378,9 +1378,9 @@ let (rewrite_all :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (220))
                                                                     (Prims.of_int (60))
-                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (220))
                                                                     (Prims.of_int (82)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1434,12 +1434,12 @@ let (check_renaming :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
-                   (Prims.of_int (233)) (Prims.of_int (35))
-                   (Prims.of_int (233)) (Prims.of_int (42)))))
+                   (Prims.of_int (232)) (Prims.of_int (35))
+                   (Prims.of_int (232)) (Prims.of_int (42)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
-                   (Prims.of_int (233)) Prims.int_one (Prims.of_int (259))
+                   (Prims.of_int (232)) Prims.int_one (Prims.of_int (258))
                    (Prims.of_int (3)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ -> st.Pulse_Syntax_Base.term1))
@@ -1453,14 +1453,14 @@ let (check_renaming :
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Checker.AssertWithBinders.fst"
-                                  (Prims.of_int (234)) (Prims.of_int (65))
-                                  (Prims.of_int (234)) (Prims.of_int (67)))))
+                                  (Prims.of_int (233)) (Prims.of_int (65))
+                                  (Prims.of_int (233)) (Prims.of_int (67)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Checker.AssertWithBinders.fst"
-                                  (Prims.of_int (233)) (Prims.of_int (45))
-                                  (Prims.of_int (259)) (Prims.of_int (3)))))
+                                  (Prims.of_int (232)) (Prims.of_int (45))
+                                  (Prims.of_int (258)) (Prims.of_int (3)))))
                          (FStar_Tactics_Effect.lift_div_tac
                             (fun uu___1 -> ht))
                          (fun uu___1 ->
@@ -1541,17 +1541,17 @@ let (check_renaming :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (250))
+                                                         (Prims.of_int (249))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (250))
+                                                         (Prims.of_int (249))
                                                          (Prims.of_int (42)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (248))
+                                                         (Prims.of_int (247))
                                                          (Prims.of_int (15))
-                                                         (Prims.of_int (252))
+                                                         (Prims.of_int (251))
                                                          (Prims.of_int (77)))))
                                                 (Obj.magic
                                                    (rewrite_all g pairs pre))
@@ -1607,17 +1607,17 @@ let (check_renaming :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (255))
+                                                         (Prims.of_int (254))
                                                          (Prims.of_int (20))
-                                                         (Prims.of_int (255))
+                                                         (Prims.of_int (254))
                                                          (Prims.of_int (56)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.AssertWithBinders.fst"
-                                                         (Prims.of_int (254))
+                                                         (Prims.of_int (253))
                                                          (Prims.of_int (21))
-                                                         (Prims.of_int (259))
+                                                         (Prims.of_int (258))
                                                          (Prims.of_int (3)))))
                                                 (Obj.magic
                                                    (Pulse_Checker_Pure.instantiate_term_implicits
@@ -1632,17 +1632,17 @@ let (check_renaming :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (256))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (256))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (45)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (59))
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (79)))))
                                                                (Obj.magic
                                                                   (rewrite_all
@@ -1711,12 +1711,12 @@ let (check_wild :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
-                   (Prims.of_int (266)) (Prims.of_int (35))
-                   (Prims.of_int (266)) (Prims.of_int (42)))))
+                   (Prims.of_int (265)) (Prims.of_int (35))
+                   (Prims.of_int (265)) (Prims.of_int (42)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.AssertWithBinders.fst"
-                   (Prims.of_int (266)) Prims.int_one (Prims.of_int (298))
+                   (Prims.of_int (265)) Prims.int_one (Prims.of_int (297))
                    (Prims.of_int (23)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ -> st.Pulse_Syntax_Base.term1))
@@ -1730,14 +1730,14 @@ let (check_wild :
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Checker.AssertWithBinders.fst"
-                                  (Prims.of_int (267)) (Prims.of_int (31))
-                                  (Prims.of_int (267)) (Prims.of_int (33)))))
+                                  (Prims.of_int (266)) (Prims.of_int (31))
+                                  (Prims.of_int (266)) (Prims.of_int (33)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Checker.AssertWithBinders.fst"
-                                  (Prims.of_int (266)) (Prims.of_int (45))
-                                  (Prims.of_int (298)) (Prims.of_int (23)))))
+                                  (Prims.of_int (265)) (Prims.of_int (45))
+                                  (Prims.of_int (297)) (Prims.of_int (23)))))
                          (FStar_Tactics_Effect.lift_div_tac
                             (fun uu___1 -> ht))
                          (fun uu___1 ->
@@ -1760,21 +1760,21 @@ let (check_wild :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.AssertWithBinders.fst"
-                                                      (Prims.of_int (273))
+                                                      (Prims.of_int (272))
                                                       (Prims.of_int (17))
-                                                      (Prims.of_int (273))
-                                                      (Prims.of_int (59)))))
+                                                      (Prims.of_int (272))
+                                                      (Prims.of_int (34)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.AssertWithBinders.fst"
-                                                      (Prims.of_int (273))
-                                                      (Prims.of_int (62))
-                                                      (Prims.of_int (298))
+                                                      (Prims.of_int (272))
+                                                      (Prims.of_int (37))
+                                                      (Prims.of_int (297))
                                                       (Prims.of_int (23)))))
                                              (FStar_Tactics_Effect.lift_div_tac
                                                 (fun uu___4 ->
-                                                   Pulse_Typing_Combinators.vprop_as_list
+                                                   Pulse_Syntax_Pure.vprop_as_list
                                                      pre))
                                              (fun uu___4 ->
                                                 (fun vprops ->
@@ -1784,17 +1784,17 @@ let (check_wild :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.AssertWithBinders.fst"
-                                                                 (Prims.of_int (274))
+                                                                 (Prims.of_int (273))
                                                                  (Prims.of_int (19))
-                                                                 (Prims.of_int (276))
+                                                                 (Prims.of_int (275))
                                                                  (Prims.of_int (62)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.AssertWithBinders.fst"
-                                                                 (Prims.of_int (273))
-                                                                 (Prims.of_int (62))
-                                                                 (Prims.of_int (298))
+                                                                 (Prims.of_int (272))
+                                                                 (Prims.of_int (37))
+                                                                 (Prims.of_int (297))
                                                                  (Prims.of_int (23)))))
                                                         (FStar_Tactics_Effect.lift_div_tac
                                                            (fun uu___4 ->
@@ -1836,17 +1836,17 @@ let (check_wild :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (281))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (281))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (281))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (297))
                                                                     (Prims.of_int (23)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1918,17 +1918,35 @@ let (check_wild :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (38)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (38)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
                                                                     (Prims.of_int (293))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1937,26 +1955,8 @@ let (check_wild :
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
                                                                     (Prims.of_int (294))
-                                                                    (Prims.of_int (15))
-                                                                    (Prims.of_int (295))
-                                                                    (Prims.of_int (38)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (294))
-                                                                    (Prims.of_int (15))
-                                                                    (Prims.of_int (295))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2047,17 +2047,17 @@ let rec (add_rem_uvs :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.AssertWithBinders.fst"
-                                        (Prims.of_int (309))
+                                        (Prims.of_int (308))
                                         (Prims.of_int (12))
-                                        (Prims.of_int (309))
+                                        (Prims.of_int (308))
                                         (Prims.of_int (34)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.AssertWithBinders.fst"
-                                        (Prims.of_int (309))
+                                        (Prims.of_int (308))
                                         (Prims.of_int (37))
-                                        (Prims.of_int (313))
+                                        (Prims.of_int (312))
                                         (Prims.of_int (37)))))
                                (FStar_Tactics_Effect.lift_div_tac
                                   (fun uu___ ->
@@ -2071,17 +2071,17 @@ let rec (add_rem_uvs :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                   (Prims.of_int (310))
+                                                   (Prims.of_int (309))
                                                    (Prims.of_int (13))
-                                                   (Prims.of_int (310))
+                                                   (Prims.of_int (309))
                                                    (Prims.of_int (48)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.AssertWithBinders.fst"
-                                                   (Prims.of_int (310))
+                                                   (Prims.of_int (309))
                                                    (Prims.of_int (51))
-                                                   (Prims.of_int (313))
+                                                   (Prims.of_int (312))
                                                    (Prims.of_int (37)))))
                                           (FStar_Tactics_Effect.lift_div_tac
                                              (fun uu___ ->
@@ -2097,17 +2097,17 @@ let rec (add_rem_uvs :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.AssertWithBinders.fst"
-                                                              (Prims.of_int (311))
+                                                              (Prims.of_int (310))
                                                               (Prims.of_int (14))
-                                                              (Prims.of_int (311))
+                                                              (Prims.of_int (310))
                                                               (Prims.of_int (64)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.AssertWithBinders.fst"
-                                                              (Prims.of_int (311))
+                                                              (Prims.of_int (310))
                                                               (Prims.of_int (67))
-                                                              (Prims.of_int (313))
+                                                              (Prims.of_int (312))
                                                               (Prims.of_int (37)))))
                                                      (FStar_Tactics_Effect.lift_div_tac
                                                         (fun uu___ ->
@@ -2123,17 +2123,17 @@ let rec (add_rem_uvs :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (312))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (312))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (82)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (313))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (313))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (37)))))
                                                                 (FStar_Tactics_Effect.lift_div_tac
                                                                    (fun uu___
@@ -2182,14 +2182,14 @@ let (check :
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.AssertWithBinders.fst"
-                           (Prims.of_int (326)) (Prims.of_int (10))
-                           (Prims.of_int (326)) (Prims.of_int (48)))))
+                           (Prims.of_int (325)) (Prims.of_int (10))
+                           (Prims.of_int (325)) (Prims.of_int (48)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range
                            "Pulse.Checker.AssertWithBinders.fst"
-                           (Prims.of_int (326)) (Prims.of_int (51))
-                           (Prims.of_int (429)) (Prims.of_int (50)))))
+                           (Prims.of_int (325)) (Prims.of_int (51))
+                           (Prims.of_int (428)) (Prims.of_int (50)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
                         Pulse_Typing_Env.push_context g "check_assert"
@@ -2202,17 +2202,17 @@ let (check :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.AssertWithBinders.fst"
-                                      (Prims.of_int (328))
+                                      (Prims.of_int (327))
                                       (Prims.of_int (66))
-                                      (Prims.of_int (328))
+                                      (Prims.of_int (327))
                                       (Prims.of_int (73)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.AssertWithBinders.fst"
-                                      (Prims.of_int (326))
+                                      (Prims.of_int (325))
                                       (Prims.of_int (51))
-                                      (Prims.of_int (429))
+                                      (Prims.of_int (428))
                                       (Prims.of_int (50)))))
                              (FStar_Tactics_Effect.lift_div_tac
                                 (fun uu___ -> st.Pulse_Syntax_Base.term1))
@@ -2234,17 +2234,17 @@ let (check :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (332))
+                                                          (Prims.of_int (331))
                                                           (Prims.of_int (13))
-                                                          (Prims.of_int (332))
+                                                          (Prims.of_int (331))
                                                           (Prims.of_int (32)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (333))
+                                                          (Prims.of_int (332))
                                                           (Prims.of_int (4))
-                                                          (Prims.of_int (333))
+                                                          (Prims.of_int (332))
                                                           (Prims.of_int (50)))))
                                                  (Obj.magic
                                                     (check_wild g1 pre st))
@@ -2263,17 +2263,17 @@ let (check :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (338))
+                                                          (Prims.of_int (337))
                                                           (Prims.of_int (14))
-                                                          (Prims.of_int (341))
+                                                          (Prims.of_int (340))
                                                           (Prims.of_int (5)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (342))
+                                                          (Prims.of_int (341))
                                                           (Prims.of_int (4))
-                                                          (Prims.of_int (342))
+                                                          (Prims.of_int (341))
                                                           (Prims.of_int (36)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_Effect.tac_bind
@@ -2281,17 +2281,17 @@ let (check :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.AssertWithBinders.fst"
-                                                                (Prims.of_int (339))
+                                                                (Prims.of_int (338))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (340))
-                                                                (Prims.of_int (52)))))
+                                                                (Prims.of_int (339))
+                                                                (Prims.of_int (48)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.AssertWithBinders.fst"
-                                                                (Prims.of_int (338))
+                                                                (Prims.of_int (337))
                                                                 (Prims.of_int (14))
-                                                                (Prims.of_int (341))
+                                                                (Prims.of_int (340))
                                                                 (Prims.of_int (5)))))
                                                        (Obj.magic
                                                           (FStar_Tactics_Effect.tac_bind
@@ -2299,41 +2299,66 @@ let (check :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (340))
-                                                                    (Prims.of_int (52)))))
+                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (48)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (340))
-                                                                    (Prims.of_int (52)))))
+                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (48)))))
                                                              (Obj.magic
                                                                 (FStar_Tactics_Effect.tac_bind
                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (340))
-                                                                    (Prims.of_int (52)))))
+                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (48)))))
                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (340))
-                                                                    (Prims.of_int (52)))))
+                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (48)))))
                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (47)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.AssertWithBinders.fst"
+                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (48)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Syntax_Pure.canon_vprop_print
+                                                                    pre))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    Obj.magic
                                                                     (Pulse_PP.pp
                                                                     Pulse_PP.printable_term
-                                                                    (Pulse_Checker_VPropEquiv.canon_vprop
-                                                                    pre)))
+                                                                    uu___1))
+                                                                    uu___1)))
                                                                    (fun
                                                                     uu___1 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
@@ -2372,17 +2397,17 @@ let (check :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (344))
+                                                          (Prims.of_int (343))
                                                           (Prims.of_int (13))
-                                                          (Prims.of_int (344))
+                                                          (Prims.of_int (343))
                                                           (Prims.of_int (36)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (345))
+                                                          (Prims.of_int (344))
                                                           (Prims.of_int (4))
-                                                          (Prims.of_int (345))
+                                                          (Prims.of_int (344))
                                                           (Prims.of_int (50)))))
                                                  (Obj.magic
                                                     (check_renaming g1 pre st))
@@ -2405,17 +2430,17 @@ let (check :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.AssertWithBinders.fst"
-                                                               (Prims.of_int (350))
+                                                               (Prims.of_int (349))
                                                                (Prims.of_int (16))
-                                                               (Prims.of_int (350))
+                                                               (Prims.of_int (349))
                                                                (Prims.of_int (52)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.AssertWithBinders.fst"
-                                                               (Prims.of_int (351))
+                                                               (Prims.of_int (350))
                                                                (Prims.of_int (6))
-                                                               (Prims.of_int (352))
+                                                               (Prims.of_int (351))
                                                                (Prims.of_int (83)))))
                                                       (FStar_Tactics_Effect.lift_div_tac
                                                          (fun uu___1 ->
@@ -2470,17 +2495,17 @@ let (check :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.AssertWithBinders.fst"
-                                                               (Prims.of_int (354))
+                                                               (Prims.of_int (353))
                                                                (Prims.of_int (16))
-                                                               (Prims.of_int (354))
+                                                               (Prims.of_int (353))
                                                                (Prims.of_int (52)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.AssertWithBinders.fst"
-                                                               (Prims.of_int (354))
+                                                               (Prims.of_int (353))
                                                                (Prims.of_int (57))
-                                                               (Prims.of_int (357))
+                                                               (Prims.of_int (356))
                                                                (Prims.of_int (52)))))
                                                       (FStar_Tactics_Effect.lift_div_tac
                                                          (fun uu___2 ->
@@ -2510,18 +2535,18 @@ let (check :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (355))
+                                                                    (Prims.of_int (354))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (355))
+                                                                    (Prims.of_int (354))
                                                                     (Prims.of_int (88)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (355))
+                                                                    (Prims.of_int (354))
                                                                     (Prims.of_int (93))
-                                                                    (Prims.of_int (357))
+                                                                    (Prims.of_int (356))
                                                                     (Prims.of_int (52)))))
                                                                  (FStar_Tactics_Effect.lift_div_tac
                                                                     (
@@ -2558,17 +2583,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (356))
+                                                                    (Prims.of_int (355))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (356))
+                                                                    (Prims.of_int (355))
                                                                     (Prims.of_int (113)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (357))
+                                                                    (Prims.of_int (356))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (357))
+                                                                    (Prims.of_int (356))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2618,17 +2643,17 @@ let (check :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (361))
+                                                          (Prims.of_int (360))
                                                           (Prims.of_int (4))
-                                                          (Prims.of_int (361))
+                                                          (Prims.of_int (360))
                                                           (Prims.of_int (36)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (361))
+                                                          (Prims.of_int (360))
                                                           (Prims.of_int (37))
-                                                          (Prims.of_int (377))
+                                                          (Prims.of_int (376))
                                                           (Prims.of_int (52)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_BreakVC.break_vc
@@ -2641,17 +2666,17 @@ let (check :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (362))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (362))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (38)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (362))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (377))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (52)))))
                                                             (Obj.magic
                                                                (infer_binder_types
@@ -2665,17 +2690,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (43))
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (90)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (362))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (377))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (open_binders
@@ -2702,17 +2727,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (364))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (364))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (93))
-                                                                    (Prims.of_int (377))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2734,17 +2759,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (365))
+                                                                    (Prims.of_int (364))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (365))
+                                                                    (Prims.of_int (364))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (364))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (42))
-                                                                    (Prims.of_int (377))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_vprop
@@ -2767,17 +2792,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (42))
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (71)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (365))
+                                                                    (Prims.of_int (364))
                                                                     (Prims.of_int (57))
-                                                                    (Prims.of_int (377))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover.prove
@@ -2803,17 +2828,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (374))
+                                                                    (Prims.of_int (373))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (376))
+                                                                    (Prims.of_int (375))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (74))
-                                                                    (Prims.of_int (377))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (check1
@@ -2870,17 +2895,17 @@ let (check :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (383))
+                                                          (Prims.of_int (382))
                                                           (Prims.of_int (42))
-                                                          (Prims.of_int (385))
+                                                          (Prims.of_int (384))
                                                           (Prims.of_int (53)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (381))
+                                                          (Prims.of_int (380))
                                                           (Prims.of_int (26))
-                                                          (Prims.of_int (429))
+                                                          (Prims.of_int (428))
                                                           (Prims.of_int (50)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_Effect.tac_bind
@@ -2888,17 +2913,17 @@ let (check :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.AssertWithBinders.fst"
-                                                                (Prims.of_int (384))
+                                                                (Prims.of_int (383))
                                                                 (Prims.of_int (15))
-                                                                (Prims.of_int (384))
+                                                                (Prims.of_int (383))
                                                                 (Prims.of_int (40)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.AssertWithBinders.fst"
-                                                                (Prims.of_int (385))
+                                                                (Prims.of_int (384))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (385))
+                                                                (Prims.of_int (384))
                                                                 (Prims.of_int (53)))))
                                                        (Obj.magic
                                                           (infer_binder_types
@@ -2926,17 +2951,17 @@ let (check :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (386))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (386))
                                                                     (Prims.of_int (24)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (386))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                 (Obj.magic
                                                                    (check_unfoldable
@@ -2951,17 +2976,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (81)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (386))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.instantiate_term_implicits
@@ -2983,17 +3008,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (391))
+                                                                    (Prims.of_int (390))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (394))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (84))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3001,17 +3026,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (393))
+                                                                    (Prims.of_int (392))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (393))
+                                                                    (Prims.of_int (392))
                                                                     (Prims.of_int (74)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (391))
+                                                                    (Prims.of_int (390))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (394))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (36)))))
                                                                     (Obj.magic
                                                                     (add_rem_uvs
@@ -3054,17 +3079,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (396))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (403))
+                                                                    (Prims.of_int (402))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (394))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (39))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (match hint_type
                                                                     with
@@ -3077,17 +3102,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -3116,17 +3141,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (402))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (402))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (402))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (403))
+                                                                    (Prims.of_int (402))
                                                                     (Prims.of_int (16)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -3156,17 +3181,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (53)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (56))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3174,17 +3199,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (53)))))
                                                                     (Obj.magic
                                                                     (Pulse_Typing_Env.bindings_with_ppname
@@ -3206,17 +3231,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (406))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (406))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (406))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (42))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3234,17 +3259,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (407))
+                                                                    (Prims.of_int (406))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (407))
+                                                                    (Prims.of_int (406))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (407))
+                                                                    (Prims.of_int (406))
                                                                     (Prims.of_int (43))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3262,17 +3287,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (408))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (408))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (408))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (43))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3290,17 +3315,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (409))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (409))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (409))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (55))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3318,17 +3343,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (33)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3345,17 +3370,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (414))
+                                                                    (Prims.of_int (413))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (414))
+                                                                    (Prims.of_int (413))
                                                                     (Prims.of_int (57))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3388,17 +3413,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (414))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3440,17 +3465,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (421))
+                                                                    (Prims.of_int (420))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (428))
+                                                                    (Prims.of_int (427))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3520,17 +3545,17 @@ let (check :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (383))
+                                                          (Prims.of_int (382))
                                                           (Prims.of_int (42))
-                                                          (Prims.of_int (385))
+                                                          (Prims.of_int (384))
                                                           (Prims.of_int (53)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.AssertWithBinders.fst"
-                                                          (Prims.of_int (381))
+                                                          (Prims.of_int (380))
                                                           (Prims.of_int (26))
-                                                          (Prims.of_int (429))
+                                                          (Prims.of_int (428))
                                                           (Prims.of_int (50)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_Effect.tac_bind
@@ -3538,17 +3563,17 @@ let (check :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.AssertWithBinders.fst"
-                                                                (Prims.of_int (384))
+                                                                (Prims.of_int (383))
                                                                 (Prims.of_int (15))
-                                                                (Prims.of_int (384))
+                                                                (Prims.of_int (383))
                                                                 (Prims.of_int (40)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.AssertWithBinders.fst"
-                                                                (Prims.of_int (385))
+                                                                (Prims.of_int (384))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (385))
+                                                                (Prims.of_int (384))
                                                                 (Prims.of_int (53)))))
                                                        (Obj.magic
                                                           (infer_binder_types
@@ -3576,17 +3601,17 @@ let (check :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (386))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (386))
                                                                     (Prims.of_int (24)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (386))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                 (Obj.magic
                                                                    (check_unfoldable
@@ -3601,17 +3626,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (81)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (386))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.instantiate_term_implicits
@@ -3633,17 +3658,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (391))
+                                                                    (Prims.of_int (390))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (394))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (84))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3651,17 +3676,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (393))
+                                                                    (Prims.of_int (392))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (393))
+                                                                    (Prims.of_int (392))
                                                                     (Prims.of_int (74)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (391))
+                                                                    (Prims.of_int (390))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (394))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (36)))))
                                                                     (Obj.magic
                                                                     (add_rem_uvs
@@ -3704,17 +3729,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (396))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (403))
+                                                                    (Prims.of_int (402))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (394))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (39))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (match hint_type
                                                                     with
@@ -3727,17 +3752,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -3766,17 +3791,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (402))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (402))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (402))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (403))
+                                                                    (Prims.of_int (402))
                                                                     (Prims.of_int (16)))))
                                                                     (Obj.magic
                                                                     (unfold_defs
@@ -3806,17 +3831,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (53)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (56))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3824,17 +3849,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (53)))))
                                                                     (Obj.magic
                                                                     (Pulse_Typing_Env.bindings_with_ppname
@@ -3856,17 +3881,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (406))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (406))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (406))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (42))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3884,17 +3909,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (407))
+                                                                    (Prims.of_int (406))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (407))
+                                                                    (Prims.of_int (406))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (407))
+                                                                    (Prims.of_int (406))
                                                                     (Prims.of_int (43))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3912,17 +3937,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (408))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (408))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (408))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (43))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3940,17 +3965,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (409))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (409))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (409))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (55))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3968,17 +3993,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (33)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3995,17 +4020,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (414))
+                                                                    (Prims.of_int (413))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (414))
+                                                                    (Prims.of_int (413))
                                                                     (Prims.of_int (57))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4038,17 +4063,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (414))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4090,17 +4115,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (421))
+                                                                    (Prims.of_int (420))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (428))
+                                                                    (Prims.of_int (427))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.AssertWithBinders.fst"
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun

--- a/src/ocaml/plugin/generated/Pulse_Checker_Exists.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Exists.ml
@@ -143,7 +143,7 @@ let (check_elim_exists :
                                                                (FStar_Tactics_Effect.lift_div_tac
                                                                   (fun uu___1
                                                                     ->
-                                                                    Pulse_Typing_Combinators.vprop_as_list
+                                                                    Pulse_Syntax_Pure.vprop_as_list
                                                                     pre))
                                                                (fun uu___1 ->
                                                                   (fun ts ->

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover.ml
@@ -347,7 +347,7 @@ let rec (prover :
                             (Prims.of_int (123)) (Prims.of_int (54)))))
                    (Obj.magic
                       (Pulse_Syntax_Printer.term_to_string
-                         (Pulse_Typing_Combinators.list_as_vprop
+                         (Pulse_Syntax_Pure.list_as_vprop
                             pst0.Pulse_Checker_Prover_Base.unsolved)))
                    (fun uu___1 ->
                       (fun uu___1 ->
@@ -389,7 +389,7 @@ let rec (prover :
                                              (Prims.of_int (44)))))
                                     (Obj.magic
                                        (Pulse_Syntax_Printer.term_to_string
-                                          (Pulse_Typing_Combinators.list_as_vprop
+                                          (Pulse_Syntax_Pure.list_as_vprop
                                              pst0.Pulse_Checker_Prover_Base.remaining_ctxt)))
                                     (fun uu___2 ->
                                        FStar_Tactics_Effect.lift_div_tac
@@ -474,7 +474,7 @@ let rec (prover :
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (Pulse_Syntax_Printer.term_to_string
-                                                      (Pulse_Typing_Combinators.list_as_vprop
+                                                      (Pulse_Syntax_Pure.list_as_vprop
                                                          pst.Pulse_Checker_Prover_Base.remaining_ctxt)))
                                                 (fun uu___3 ->
                                                    FStar_Tactics_Effect.lift_div_tac
@@ -550,7 +550,7 @@ let rec (prover :
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst1.Pulse_Checker_Prover_Base.remaining_ctxt)))
                                                                     (fun
                                                                     uu___4 ->
@@ -643,7 +643,7 @@ let rec (prover :
                                                                     (Prims.of_int (86)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     rest)))
                                                                     (fun
                                                                     uu___6 ->
@@ -687,7 +687,7 @@ let rec (prover :
                                                                     (Prims.of_int (44)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     exs)))
                                                                     (fun
                                                                     uu___7 ->
@@ -788,7 +788,7 @@ let rec (prover :
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst2.Pulse_Checker_Prover_Base.unsolved)))
                                                                     (fun
                                                                     uu___7 ->
@@ -992,7 +992,7 @@ let rec (prover :
                                                                     (Prims.of_int (171))
                                                                     (Prims.of_int (16))
                                                                     (Prims.of_int (172))
-                                                                    (Prims.of_int (42)))))
+                                                                    (Prims.of_int (63)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1010,7 +1010,7 @@ let rec (prover :
                                                                     (Prims.of_int (172))
                                                                     (Prims.of_int (20))
                                                                     (Prims.of_int (172))
-                                                                    (Prims.of_int (42)))))
+                                                                    (Prims.of_int (63)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1018,7 +1018,7 @@ let rec (prover :
                                                                     (Prims.of_int (171))
                                                                     (Prims.of_int (16))
                                                                     (Prims.of_int (172))
-                                                                    (Prims.of_int (42)))))
+                                                                    (Prims.of_int (63)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
@@ -1028,7 +1028,7 @@ let rec (prover :
                                                                     (Prims.of_int (172))
                                                                     (Prims.of_int (27))
                                                                     (Prims.of_int (172))
-                                                                    (Prims.of_int (42)))))
+                                                                    (Prims.of_int (63)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1036,13 +1036,41 @@ let rec (prover :
                                                                     (Prims.of_int (172))
                                                                     (Prims.of_int (20))
                                                                     (Prims.of_int (172))
-                                                                    (Prims.of_int (42)))))
+                                                                    (Prims.of_int (63)))))
                                                                     (Obj.magic
-                                                                    (Pulse_PP.pp
-                                                                    Pulse_PP.printable_term
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (34))
+                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (62)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (27))
+                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (63)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Syntax_Pure.canon_vprop_print
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst3.Pulse_Checker_Prover_Base.ss
                                                                     q)))
+                                                                    (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.printable_term
+                                                                    uu___10))
+                                                                    uu___10)))
                                                                     (fun
                                                                     uu___10
                                                                     ->
@@ -1096,7 +1124,7 @@ let rec (prover :
                                                                     (Prims.of_int (173))
                                                                     (Prims.of_int (16))
                                                                     (Prims.of_int (174))
-                                                                    (Prims.of_int (66)))))
+                                                                    (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1114,7 +1142,7 @@ let rec (prover :
                                                                     (Prims.of_int (174))
                                                                     (Prims.of_int (20))
                                                                     (Prims.of_int (174))
-                                                                    (Prims.of_int (66)))))
+                                                                    (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1122,7 +1150,7 @@ let rec (prover :
                                                                     (Prims.of_int (173))
                                                                     (Prims.of_int (16))
                                                                     (Prims.of_int (174))
-                                                                    (Prims.of_int (66)))))
+                                                                    (Prims.of_int (76)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
@@ -1132,7 +1160,7 @@ let rec (prover :
                                                                     (Prims.of_int (174))
                                                                     (Prims.of_int (27))
                                                                     (Prims.of_int (174))
-                                                                    (Prims.of_int (66)))))
+                                                                    (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1140,12 +1168,39 @@ let rec (prover :
                                                                     (Prims.of_int (174))
                                                                     (Prims.of_int (20))
                                                                     (Prims.of_int (174))
-                                                                    (Prims.of_int (66)))))
+                                                                    (Prims.of_int (76)))))
                                                                     (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (34))
+                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (75)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (27))
+                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (76)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Syntax_Pure.canon_vprop_list_print
+                                                                    pst3.Pulse_Checker_Prover_Base.remaining_ctxt))
+                                                                    (fun
+                                                                    uu___11
+                                                                    ->
+                                                                    (fun
+                                                                    uu___11
+                                                                    ->
+                                                                    Obj.magic
                                                                     (Pulse_PP.pp
                                                                     Pulse_PP.printable_term
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
-                                                                    pst3.Pulse_Checker_Prover_Base.remaining_ctxt)))
+                                                                    uu___11))
+                                                                    uu___11)))
                                                                     (fun
                                                                     uu___11
                                                                     ->
@@ -1249,7 +1304,7 @@ let rec (prover :
                                                                     (Prims.of_int (176))
                                                                     (Prims.of_int (20))
                                                                     (Prims.of_int (177))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (71)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1267,7 +1322,7 @@ let rec (prover :
                                                                     (Prims.of_int (177))
                                                                     (Prims.of_int (24))
                                                                     (Prims.of_int (177))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (71)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1275,7 +1330,7 @@ let rec (prover :
                                                                     (Prims.of_int (176))
                                                                     (Prims.of_int (20))
                                                                     (Prims.of_int (177))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (71)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
@@ -1285,7 +1340,7 @@ let rec (prover :
                                                                     (Prims.of_int (177))
                                                                     (Prims.of_int (31))
                                                                     (Prims.of_int (177))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (71)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1293,11 +1348,39 @@ let rec (prover :
                                                                     (Prims.of_int (177))
                                                                     (Prims.of_int (24))
                                                                     (Prims.of_int (177))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (71)))))
                                                                     (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (38))
+                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (70)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (31))
+                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (71)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Syntax_Pure.canon_vprop_print
+                                                                    preamble.Pulse_Checker_Prover_Base.goals))
+                                                                    (fun
+                                                                    uu___12
+                                                                    ->
+                                                                    (fun
+                                                                    uu___12
+                                                                    ->
+                                                                    Obj.magic
                                                                     (Pulse_PP.pp
                                                                     Pulse_PP.printable_term
-                                                                    preamble.Pulse_Checker_Prover_Base.goals))
+                                                                    uu___12))
+                                                                    uu___12)))
                                                                     (fun
                                                                     uu___12
                                                                     ->
@@ -1351,7 +1434,7 @@ let rec (prover :
                                                                     (Prims.of_int (178))
                                                                     (Prims.of_int (20))
                                                                     (Prims.of_int (179))
-                                                                    (Prims.of_int (49)))))
+                                                                    (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1369,7 +1452,7 @@ let rec (prover :
                                                                     (Prims.of_int (179))
                                                                     (Prims.of_int (24))
                                                                     (Prims.of_int (179))
-                                                                    (Prims.of_int (49)))))
+                                                                    (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1377,7 +1460,7 @@ let rec (prover :
                                                                     (Prims.of_int (178))
                                                                     (Prims.of_int (20))
                                                                     (Prims.of_int (179))
-                                                                    (Prims.of_int (49)))))
+                                                                    (Prims.of_int (70)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
@@ -1387,7 +1470,7 @@ let rec (prover :
                                                                     (Prims.of_int (179))
                                                                     (Prims.of_int (31))
                                                                     (Prims.of_int (179))
-                                                                    (Prims.of_int (49)))))
+                                                                    (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
@@ -1395,11 +1478,39 @@ let rec (prover :
                                                                     (Prims.of_int (179))
                                                                     (Prims.of_int (24))
                                                                     (Prims.of_int (179))
-                                                                    (Prims.of_int (49)))))
+                                                                    (Prims.of_int (70)))))
                                                                     (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (38))
+                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (69)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (31))
+                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (70)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Syntax_Pure.canon_vprop_print
+                                                                    preamble.Pulse_Checker_Prover_Base.ctxt))
+                                                                    (fun
+                                                                    uu___13
+                                                                    ->
+                                                                    (fun
+                                                                    uu___13
+                                                                    ->
+                                                                    Obj.magic
                                                                     (Pulse_PP.pp
                                                                     Pulse_PP.printable_term
-                                                                    preamble.Pulse_Checker_Prover_Base.ctxt))
+                                                                    uu___13))
+                                                                    uu___13)))
                                                                     (fun
                                                                     uu___13
                                                                     ->
@@ -1628,7 +1739,7 @@ let (prove :
                                     (Prims.of_int (288)) (Prims.of_int (126)))))
                            (FStar_Tactics_Effect.lift_div_tac
                               (fun uu___1 ->
-                                 Pulse_Typing_Combinators.vprop_as_list ctxt))
+                                 Pulse_Syntax_Pure.vprop_as_list ctxt))
                            (fun uu___1 ->
                               (fun ctxt_l ->
                                  Obj.magic
@@ -1690,7 +1801,7 @@ let (prove :
                                                            = g;
                                                          Pulse_Checker_Prover_Base.remaining_ctxt
                                                            =
-                                                           (Pulse_Typing_Combinators.vprop_as_list
+                                                           (Pulse_Syntax_Pure.vprop_as_list
                                                               ctxt);
                                                          Pulse_Checker_Prover_Base.remaining_ctxt_frame_typing
                                                            = ();
@@ -1707,7 +1818,7 @@ let (prove :
                                                            Pulse_Syntax_Pure.tm_emp;
                                                          Pulse_Checker_Prover_Base.unsolved
                                                            =
-                                                           (Pulse_Typing_Combinators.vprop_as_list
+                                                           (Pulse_Syntax_Pure.vprop_as_list
                                                               goals);
                                                          Pulse_Checker_Prover_Base.k
                                                            =
@@ -1720,8 +1831,8 @@ let (prove :
                                                               (Pulse_Checker_Prover_Base.op_Star
                                                                  (Pulse_Checker_Prover_Base.op_Star
                                                                     (
-                                                                    Pulse_Typing_Combinators.list_as_vprop
-                                                                    (Pulse_Typing_Combinators.vprop_as_list
+                                                                    Pulse_Syntax_Pure.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.vprop_as_list
                                                                     ctxt))
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                  (Pulse_Checker_Prover_Base.op_Array_Access
@@ -1874,7 +1985,7 @@ let (prove :
                                                                     ((pst.Pulse_Checker_Prover_Base.pg),
                                                                     nts_uvs,
                                                                     nts_uvs_effect_labels,
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt),
                                                                     (Pulse_Checker_Base.k_elab_equiv
                                                                     g
@@ -1885,7 +1996,7 @@ let (prove :
                                                                     ctxt
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     Pulse_Syntax_Pure.tm_emp)
                                                                     (Pulse_Checker_Prover_Substs.nt_subst_term
@@ -1895,7 +2006,7 @@ let (prove :
                                                                     (Pulse_Checker_Prover_Substs.nt_subst_term
                                                                     goals
                                                                     nts_uvs)
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt))
                                                                     pst.Pulse_Checker_Prover_Base.k
                                                                     () ())))))))

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_Base.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_Base.ml
@@ -150,8 +150,7 @@ let (canon_right :
                        (Prims.of_int (75)) (Prims.of_int (3))
                        (Prims.of_int (80)) (Prims.of_int (110)))))
               (Obj.magic
-                 (canon_right_aux g
-                    (Pulse_Typing_Combinators.vprop_as_list ctxt) f))
+                 (canon_right_aux g (Pulse_Syntax_Pure.vprop_as_list ctxt) f))
               (fun uu___ ->
                  FStar_Tactics_Effect.lift_div_tac
                    (fun uu___1 ->
@@ -159,16 +158,16 @@ let (canon_right :
                       | FStar_Pervasives.Mkdtuple3 (vps', pures, veq) ->
                           FStar_Pervasives.Mkdtuple3
                             ((list_as_vprop'
-                                (Pulse_Typing_Combinators.list_as_vprop vps')
-                                pures), (),
+                                (Pulse_Syntax_Pure.list_as_vprop vps') pures),
+                              (),
                               (Pulse_Checker_Base.k_elab_equiv g g
                                  (Pulse_Syntax_Pure.tm_star ctxt frame)
                                  (Pulse_Syntax_Pure.tm_star ctxt frame)
                                  (Pulse_Syntax_Pure.tm_star ctxt frame)
                                  (Pulse_Syntax_Pure.tm_star
                                     (list_as_vprop'
-                                       (Pulse_Typing_Combinators.list_as_vprop
-                                          vps') pures) frame)
+                                       (Pulse_Syntax_Pure.list_as_vprop vps')
+                                       pures) frame)
                                  (Pulse_Checker_Base.k_elab_unit g
                                     (Pulse_Syntax_Pure.tm_star ctxt frame))
                                  () ()))))

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_ElimExists.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_ElimExists.ml
@@ -148,7 +148,7 @@ let (elim_exists_pst :
                  (Prims.of_int (3)))))
         (Obj.magic
            (elim_exists_frame pst.Pulse_Checker_Prover_Base.pg
-              (Pulse_Typing_Combinators.list_as_vprop
+              (Pulse_Syntax_Pure.list_as_vprop
                  pst.Pulse_Checker_Prover_Base.remaining_ctxt)
               (Pulse_Checker_Prover_Base.op_Star
                  preamble.Pulse_Checker_Prover_Base.frame
@@ -164,8 +164,7 @@ let (elim_exists_pst :
                     {
                       Pulse_Checker_Prover_Base.pg = g';
                       Pulse_Checker_Prover_Base.remaining_ctxt =
-                        (Pulse_Typing_Combinators.vprop_as_list
-                           remaining_ctxt');
+                        (Pulse_Syntax_Pure.vprop_as_list remaining_ctxt');
                       Pulse_Checker_Prover_Base.remaining_ctxt_frame_typing =
                         ();
                       Pulse_Checker_Prover_Base.uvs =
@@ -188,7 +187,7 @@ let (elim_exists_pst :
                               preamble.Pulse_Checker_Prover_Base.frame)
                            (Pulse_Checker_Prover_Base.op_Star
                               (Pulse_Checker_Prover_Base.op_Star
-                                 (Pulse_Typing_Combinators.list_as_vprop
+                                 (Pulse_Syntax_Pure.list_as_vprop
                                     (Pulse_Checker_Prover_Base.__proj__Mkprover_state__item__remaining_ctxt
                                        preamble pst))
                                  preamble.Pulse_Checker_Prover_Base.frame)
@@ -208,7 +207,7 @@ let (elim_exists_pst :
                            (Pulse_Checker_Base.k_elab_equiv
                               pst.Pulse_Checker_Prover_Base.pg g'
                               (Pulse_Checker_Prover_Base.op_Star
-                                 (Pulse_Typing_Combinators.list_as_vprop
+                                 (Pulse_Syntax_Pure.list_as_vprop
                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                  (Pulse_Checker_Prover_Base.op_Star
                                     preamble.Pulse_Checker_Prover_Base.frame
@@ -217,7 +216,7 @@ let (elim_exists_pst :
                                        pst.Pulse_Checker_Prover_Base.solved)))
                               (Pulse_Checker_Prover_Base.op_Star
                                  (Pulse_Checker_Prover_Base.op_Star
-                                    (Pulse_Typing_Combinators.list_as_vprop
+                                    (Pulse_Syntax_Pure.list_as_vprop
                                        pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                     preamble.Pulse_Checker_Prover_Base.frame)
                                  (Pulse_Checker_Prover_Base.op_Array_Access

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_ElimPure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_ElimPure.ml
@@ -180,7 +180,7 @@ let (elim_pure_pst :
                  (Prims.of_int (171)) (Prims.of_int (3)))))
         (Obj.magic
            (elim_pure_frame pst.Pulse_Checker_Prover_Base.pg
-              (Pulse_Typing_Combinators.list_as_vprop
+              (Pulse_Syntax_Pure.list_as_vprop
                  pst.Pulse_Checker_Prover_Base.remaining_ctxt)
               (Pulse_Checker_Prover_Base.op_Star
                  preamble.Pulse_Checker_Prover_Base.frame
@@ -196,8 +196,7 @@ let (elim_pure_pst :
                     {
                       Pulse_Checker_Prover_Base.pg = g';
                       Pulse_Checker_Prover_Base.remaining_ctxt =
-                        (Pulse_Typing_Combinators.vprop_as_list
-                           remaining_ctxt');
+                        (Pulse_Syntax_Pure.vprop_as_list remaining_ctxt');
                       Pulse_Checker_Prover_Base.remaining_ctxt_frame_typing =
                         ();
                       Pulse_Checker_Prover_Base.uvs =
@@ -220,7 +219,7 @@ let (elim_pure_pst :
                               preamble.Pulse_Checker_Prover_Base.frame)
                            (Pulse_Checker_Prover_Base.op_Star
                               (Pulse_Checker_Prover_Base.op_Star
-                                 (Pulse_Typing_Combinators.list_as_vprop
+                                 (Pulse_Syntax_Pure.list_as_vprop
                                     (Pulse_Checker_Prover_Base.__proj__Mkprover_state__item__remaining_ctxt
                                        preamble pst))
                                  preamble.Pulse_Checker_Prover_Base.frame)
@@ -240,7 +239,7 @@ let (elim_pure_pst :
                            (Pulse_Checker_Base.k_elab_equiv
                               pst.Pulse_Checker_Prover_Base.pg g'
                               (Pulse_Checker_Prover_Base.op_Star
-                                 (Pulse_Typing_Combinators.list_as_vprop
+                                 (Pulse_Syntax_Pure.list_as_vprop
                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                  (Pulse_Checker_Prover_Base.op_Star
                                     preamble.Pulse_Checker_Prover_Base.frame
@@ -249,7 +248,7 @@ let (elim_pure_pst :
                                        pst.Pulse_Checker_Prover_Base.solved)))
                               (Pulse_Checker_Prover_Base.op_Star
                                  (Pulse_Checker_Prover_Base.op_Star
-                                    (Pulse_Typing_Combinators.list_as_vprop
+                                    (Pulse_Syntax_Pure.list_as_vprop
                                        pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                     preamble.Pulse_Checker_Prover_Base.frame)
                                  (Pulse_Checker_Prover_Base.op_Array_Access

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_IntroExists.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_IntroExists.ml
@@ -472,7 +472,7 @@ let (intro_exists :
                                                                (pst.Pulse_Checker_Prover_Base.pg);
                                                              Pulse_Checker_Prover_Base.ctxt
                                                                =
-                                                               (Pulse_Typing_Combinators.list_as_vprop
+                                                               (Pulse_Syntax_Pure.list_as_vprop
                                                                   pst.Pulse_Checker_Prover_Base.remaining_ctxt);
                                                              Pulse_Checker_Prover_Base.frame
                                                                =
@@ -488,7 +488,7 @@ let (intro_exists :
                                                                (Pulse_Checker_Prover_Base.op_Star
                                                                   (Pulse_Syntax_Naming.open_term_nv
                                                                     body px)
-                                                                  (Pulse_Typing_Combinators.list_as_vprop
+                                                                  (Pulse_Syntax_Pure.list_as_vprop
                                                                     unsolved'))
                                                            }))
                                                      (fun uu___1 ->
@@ -529,8 +529,8 @@ let (intro_exists :
                                                                     preamble_sub.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
-                                                                    (Pulse_Typing_Combinators.vprop_as_list
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.vprop_as_list
                                                                     preamble_sub.Pulse_Checker_Prover_Base.ctxt))
                                                                     preamble_sub.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -573,7 +573,7 @@ let (intro_exists :
                                                                     (pst.Pulse_Checker_Prover_Base.pg);
                                                                     Pulse_Checker_Prover_Base.remaining_ctxt
                                                                     =
-                                                                    (Pulse_Typing_Combinators.vprop_as_list
+                                                                    (Pulse_Syntax_Pure.vprop_as_list
                                                                     preamble_sub.Pulse_Checker_Prover_Base.ctxt);
                                                                     Pulse_Checker_Prover_Base.remaining_ctxt_frame_typing
                                                                     = ();
@@ -595,7 +595,7 @@ let (intro_exists :
                                                                     Pulse_Checker_Prover_Base.unsolved
                                                                     =
                                                                     (FStar_List_Tot_Base.append
-                                                                    (Pulse_Typing_Combinators.vprop_as_list
+                                                                    (Pulse_Syntax_Pure.vprop_as_list
                                                                     (Pulse_Syntax_Naming.open_term_nv
                                                                     body px))
                                                                     unsolved');
@@ -925,7 +925,7 @@ let (intro_exists :
                                                                     preamble_sub.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble_sub.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -933,7 +933,7 @@ let (intro_exists :
                                                                     pst_sub1.Pulse_Checker_Prover_Base.solved))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble_sub.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -1061,7 +1061,7 @@ let (intro_exists :
                                                                     preamble_sub.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble_sub.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Star
@@ -1075,17 +1075,17 @@ let (intro_exists :
                                                                     witness)])
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst_sub1.Pulse_Checker_Prover_Base.ss
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     unsolved'))))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble_sub.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst_sub1.Pulse_Checker_Prover_Base.ss
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     unsolved')))
                                                                     (Pulse_Syntax_Naming.subst_term
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -1132,12 +1132,12 @@ let (intro_exists :
                                                                     ()
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble_sub.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst_sub1.Pulse_Checker_Prover_Base.ss
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     unsolved')))
                                                                     ()))
                                                                     (fun
@@ -1185,18 +1185,18 @@ let (intro_exists :
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst_sub1.Pulse_Checker_Prover_Base.ss
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     pst.Pulse_Checker_Prover_Base.solved
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.unsolved))))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -1213,7 +1213,7 @@ let (intro_exists :
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     (Pulse_Checker_Prover_Base.__proj__Mkprover_state__item__remaining_ctxt
                                                                     preamble
                                                                     pst))
@@ -1227,21 +1227,21 @@ let (intro_exists :
                                                                     pst)))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst_sub1.Pulse_Checker_Prover_Base.ss
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     pst.Pulse_Checker_Prover_Base.solved
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.unsolved))))
                                                                     pst.Pulse_Checker_Prover_Base.k
                                                                     (Pulse_Checker_Base.k_elab_equiv
                                                                     pst.Pulse_Checker_Prover_Base.pg
                                                                     pst_sub1.Pulse_Checker_Prover_Base.pg
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     preamble.Pulse_Checker_Prover_Base.frame
@@ -1250,7 +1250,7 @@ let (intro_exists :
                                                                     pst.Pulse_Checker_Prover_Base.solved)))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -1258,25 +1258,25 @@ let (intro_exists :
                                                                     pst.Pulse_Checker_Prover_Base.solved))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst_sub1.Pulse_Checker_Prover_Base.ss
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     pst.Pulse_Checker_Prover_Base.solved
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.unsolved))))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst_sub1.Pulse_Checker_Prover_Base.ss
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     pst.Pulse_Checker_Prover_Base.solved
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.unsolved))))
                                                                     (coerce_eq
                                                                     (Pulse_Checker_Base.k_elab_equiv
@@ -1290,7 +1290,7 @@ let (intro_exists :
                                                                     preamble_sub.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -1300,18 +1300,18 @@ let (intro_exists :
                                                                     pst.Pulse_Checker_Prover_Base.solved
                                                                     (Pulse_Syntax_Pure.tm_exists_sl
                                                                     u b body))
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     unsolved'))))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst_sub1.Pulse_Checker_Prover_Base.ss
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     pst.Pulse_Checker_Prover_Base.solved
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.unsolved))))
                                                                     (Pulse_Checker_Base.k_elab_trans
                                                                     preamble_sub.Pulse_Checker_Prover_Base.g0
@@ -1323,12 +1323,12 @@ let (intro_exists :
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble_sub.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst_sub1.Pulse_Checker_Prover_Base.ss
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     unsolved')))
                                                                     (Pulse_Syntax_Naming.subst_term
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -1340,7 +1340,7 @@ let (intro_exists :
                                                                     witness)]))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -1350,7 +1350,7 @@ let (intro_exists :
                                                                     pst.Pulse_Checker_Prover_Base.solved
                                                                     (Pulse_Syntax_Pure.tm_exists_sl
                                                                     u b body))
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     unsolved'))))
                                                                     k_sub5
                                                                     (coerce_eq
@@ -1360,12 +1360,12 @@ let (intro_exists :
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble_sub.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst_sub1.Pulse_Checker_Prover_Base.ss
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     unsolved')))
                                                                     (Pulse_Syntax_Naming.subst_term
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -1378,12 +1378,12 @@ let (intro_exists :
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble_sub.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst_sub1.Pulse_Checker_Prover_Base.ss
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     unsolved')))
                                                                     (Pulse_Syntax_Naming.subst_term
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -1396,7 +1396,7 @@ let (intro_exists :
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     preamble.Pulse_Checker_Prover_Base.frame
@@ -1405,7 +1405,7 @@ let (intro_exists :
                                                                     pst.Pulse_Checker_Prover_Base.solved)))
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst_sub1.Pulse_Checker_Prover_Base.ss
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     unsolved')))
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst_sub1.Pulse_Checker_Prover_Base.ss
@@ -1413,7 +1413,7 @@ let (intro_exists :
                                                                     u b body)))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Star
@@ -1427,7 +1427,7 @@ let (intro_exists :
                                                                     u b body)))
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst_sub1.Pulse_Checker_Prover_Base.ss
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     unsolved'))))
                                                                     (coerce_eq
                                                                     k_intro_exists1

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_IntroPure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_IntroPure.ml
@@ -1463,7 +1463,7 @@ let (intro_pure :
                                                                     uu___3 ->
                                                                     Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -1510,7 +1510,7 @@ let (intro_pure :
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -1518,7 +1518,7 @@ let (intro_pure :
                                                                     pst.Pulse_Checker_Prover_Base.solved))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -1538,7 +1538,7 @@ let (intro_pure :
                                                                     t_ss1))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Star

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_Match.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_Match.ml
@@ -1248,7 +1248,7 @@ let (match_step :
                                                                     (
                                                                     Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     (p ::
                                                                     remaining_ctxt'))
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
@@ -1260,7 +1260,7 @@ let (match_step :
                                                                     (
                                                                     Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     remaining_ctxt')
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Star
@@ -1320,7 +1320,7 @@ let (remaining_ctxt_equiv_pst :
                     preamble.Pulse_Checker_Prover_Base.frame)
                  (Pulse_Checker_Prover_Base.op_Star
                     (Pulse_Checker_Prover_Base.op_Star
-                       (Pulse_Typing_Combinators.list_as_vprop
+                       (Pulse_Syntax_Pure.list_as_vprop
                           (Pulse_Checker_Prover_Base.__proj__Mkprover_state__item__remaining_ctxt
                              preamble pst))
                        preamble.Pulse_Checker_Prover_Base.frame)
@@ -1331,8 +1331,7 @@ let (remaining_ctxt_equiv_pst :
                           preamble pst)))
                  (Pulse_Checker_Prover_Base.op_Star
                     (Pulse_Checker_Prover_Base.op_Star
-                       (Pulse_Typing_Combinators.list_as_vprop
-                          remaining_ctxt')
+                       (Pulse_Syntax_Pure.list_as_vprop remaining_ctxt')
                        preamble.Pulse_Checker_Prover_Base.frame)
                     (Pulse_Checker_Prover_Base.op_Array_Access
                        pst.Pulse_Checker_Prover_Base.ss
@@ -1563,7 +1562,7 @@ let (match_q :
                                      Pulse_Checker_Prover_Base.g0 =
                                        (pst.Pulse_Checker_Prover_Base.pg);
                                      Pulse_Checker_Prover_Base.ctxt =
-                                       (Pulse_Typing_Combinators.list_as_vprop
+                                       (Pulse_Syntax_Pure.list_as_vprop
                                           pst.Pulse_Checker_Prover_Base.remaining_ctxt);
                                      Pulse_Checker_Prover_Base.frame =
                                        (Pulse_Checker_Prover_Base.op_Star
@@ -1576,7 +1575,7 @@ let (match_q :
                                      Pulse_Checker_Prover_Base.goals =
                                        (Pulse_Checker_Prover_Base.op_Star
                                           q_ss
-                                          (Pulse_Typing_Combinators.list_as_vprop
+                                          (Pulse_Syntax_Pure.list_as_vprop
                                              unsolved'))
                                    }))
                              (fun uu___1 ->
@@ -1616,8 +1615,8 @@ let (match_q :
                                                       preamble_sub.Pulse_Checker_Prover_Base.frame)
                                                    (Pulse_Checker_Prover_Base.op_Star
                                                       (Pulse_Checker_Prover_Base.op_Star
-                                                         (Pulse_Typing_Combinators.list_as_vprop
-                                                            (Pulse_Typing_Combinators.vprop_as_list
+                                                         (Pulse_Syntax_Pure.list_as_vprop
+                                                            (Pulse_Syntax_Pure.vprop_as_list
                                                                preamble_sub.Pulse_Checker_Prover_Base.ctxt))
                                                          preamble_sub.Pulse_Checker_Prover_Base.frame)
                                                       (Pulse_Checker_Prover_Base.op_Array_Access
@@ -1657,7 +1656,7 @@ let (match_q :
                                                              (pst.Pulse_Checker_Prover_Base.pg);
                                                            Pulse_Checker_Prover_Base.remaining_ctxt
                                                              =
-                                                             (Pulse_Typing_Combinators.vprop_as_list
+                                                             (Pulse_Syntax_Pure.vprop_as_list
                                                                 preamble_sub.Pulse_Checker_Prover_Base.ctxt);
                                                            Pulse_Checker_Prover_Base.remaining_ctxt_frame_typing
                                                              = ();
@@ -1676,7 +1675,7 @@ let (match_q :
                                                            Pulse_Checker_Prover_Base.unsolved
                                                              =
                                                              (FStar_List_Tot_Base.append
-                                                                (Pulse_Typing_Combinators.vprop_as_list
+                                                                (Pulse_Syntax_Pure.vprop_as_list
                                                                    q_ss)
                                                                 unsolved');
                                                            Pulse_Checker_Prover_Base.k
@@ -1767,7 +1766,7 @@ let (match_q :
                                                                     pst.Pulse_Checker_Prover_Base.pg
                                                                     pst_sub1.Pulse_Checker_Prover_Base.pg
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     preamble.Pulse_Checker_Prover_Base.frame
@@ -1776,7 +1775,7 @@ let (match_q :
                                                                     pst.Pulse_Checker_Prover_Base.solved)))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -1784,7 +1783,7 @@ let (match_q :
                                                                     pst.Pulse_Checker_Prover_Base.solved))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     preamble.Pulse_Checker_Prover_Base.frame
@@ -1796,7 +1795,7 @@ let (match_q :
                                                                     pst_sub1.Pulse_Checker_Prover_Base.solved))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Star
@@ -1975,7 +1974,7 @@ let (match_q :
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     (Pulse_Checker_Prover_Base.__proj__Mkprover_state__item__remaining_ctxt
                                                                     preamble
                                                                     pst))
@@ -1989,7 +1988,7 @@ let (match_q :
                                                                     pst)))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -2001,7 +2000,7 @@ let (match_q :
                                                                     pst_sub1.Pulse_Checker_Prover_Base.pg
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -2009,7 +2008,7 @@ let (match_q :
                                                                     pst.Pulse_Checker_Prover_Base.solved))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -2017,18 +2016,18 @@ let (match_q :
                                                                     pst.Pulse_Checker_Prover_Base.solved))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst_sub1.Pulse_Checker_Prover_Base.ss
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.unsolved)
                                                                     pst.Pulse_Checker_Prover_Base.solved)))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -2040,7 +2039,7 @@ let (match_q :
                                                                     pst_sub1.Pulse_Checker_Prover_Base.pg
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -2048,7 +2047,7 @@ let (match_q :
                                                                     pst.Pulse_Checker_Prover_Base.solved))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
@@ -2056,7 +2055,7 @@ let (match_q :
                                                                     pst.Pulse_Checker_Prover_Base.solved))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Star
@@ -2068,13 +2067,13 @@ let (match_q :
                                                                     pst.Pulse_Checker_Prover_Base.solved)))
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst_sub1.Pulse_Checker_Prover_Base.remaining_ctxt)
                                                                     preamble.Pulse_Checker_Prover_Base.frame)
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst_sub1.Pulse_Checker_Prover_Base.ss
-                                                                    (Pulse_Typing_Combinators.list_as_vprop
+                                                                    (Pulse_Syntax_Pure.list_as_vprop
                                                                     pst.Pulse_Checker_Prover_Base.unsolved))
                                                                     (Pulse_Checker_Prover_Base.op_Array_Access
                                                                     pst.Pulse_Checker_Prover_Base.ss

--- a/src/ocaml/plugin/generated/Pulse_Checker_VPropEquiv.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_VPropEquiv.ml
@@ -1,6 +1,5 @@
 open Prims
 let (canon_vprop : Pulse_Syntax_Base.term -> Pulse_Syntax_Base.term) =
   fun vp ->
-    Pulse_Typing_Combinators.list_as_vprop
-      (Pulse_Typing_Combinators.vprop_as_list vp)
+    Pulse_Syntax_Pure.list_as_vprop (Pulse_Syntax_Pure.vprop_as_list vp)
 

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Printer.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Printer.ml
@@ -787,6 +787,43 @@ let (term_to_string :
   Pulse_Syntax_Base.term ->
     (Prims.string, unit) FStar_Tactics_Effect.tac_repr)
   = fun t -> term_to_string' "" t
+let (star_doc : FStar_Pprint.document) = FStar_Pprint.doc_of_string "**"
+let rec fold_right1 :
+  'a .
+    ('a -> 'a -> ('a, unit) FStar_Tactics_Effect.tac_repr) ->
+      'a Prims.list -> ('a, unit) FStar_Tactics_Effect.tac_repr
+  =
+  fun uu___1 ->
+    fun uu___ ->
+      (fun f ->
+         fun l ->
+           match l with
+           | [] ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_V2_Derived.fail "fold_right1: empty list"))
+           | x::[] ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> x)))
+           | hd::tl ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (130)) (Prims.of_int (19))
+                                (Prims.of_int (130)) (Prims.of_int (37)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                                (Prims.of_int (130)) (Prims.of_int (14))
+                                (Prims.of_int (130)) (Prims.of_int (37)))))
+                       (Obj.magic (fold_right1 f tl))
+                       (fun uu___ ->
+                          (fun uu___ -> Obj.magic (f hd uu___)) uu___))))
+        uu___1 uu___
 let rec (binder_to_doc :
   Pulse_Syntax_Base.binder ->
     (FStar_Pprint.document, unit) FStar_Tactics_Effect.tac_repr)
@@ -796,37 +833,37 @@ let rec (binder_to_doc :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (125)) (Prims.of_int (9)) (Prims.of_int (127))
+               (Prims.of_int (133)) (Prims.of_int (9)) (Prims.of_int (135))
                (Prims.of_int (37)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (125)) (Prims.of_int (2)) (Prims.of_int (127))
+               (Prims.of_int (133)) (Prims.of_int (2)) (Prims.of_int (135))
                (Prims.of_int (37)))))
       (Obj.magic
          (FStar_Tactics_Effect.tac_bind
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (125)) (Prims.of_int (10))
-                     (Prims.of_int (125)) (Prims.of_int (55)))))
+                     (Prims.of_int (133)) (Prims.of_int (10))
+                     (Prims.of_int (133)) (Prims.of_int (55)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (125)) (Prims.of_int (9))
-                     (Prims.of_int (127)) (Prims.of_int (37)))))
+                     (Prims.of_int (133)) (Prims.of_int (9))
+                     (Prims.of_int (135)) (Prims.of_int (37)))))
             (Obj.magic
                (FStar_Tactics_Effect.tac_bind
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                           (Prims.of_int (125)) (Prims.of_int (24))
-                           (Prims.of_int (125)) (Prims.of_int (55)))))
+                           (Prims.of_int (133)) (Prims.of_int (24))
+                           (Prims.of_int (133)) (Prims.of_int (55)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                           (Prims.of_int (125)) (Prims.of_int (10))
-                           (Prims.of_int (125)) (Prims.of_int (55)))))
+                           (Prims.of_int (133)) (Prims.of_int (10))
+                           (Prims.of_int (133)) (Prims.of_int (55)))))
                   (Obj.magic
                      (FStar_Tactics_Unseal.unseal
                         (b.Pulse_Syntax_Base.binder_ppname).Pulse_Syntax_Base.name))
@@ -840,30 +877,30 @@ let rec (binder_to_doc :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (126)) (Prims.of_int (13))
-                                (Prims.of_int (127)) (Prims.of_int (36)))))
+                                (Prims.of_int (134)) (Prims.of_int (13))
+                                (Prims.of_int (135)) (Prims.of_int (36)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (125)) (Prims.of_int (9))
-                                (Prims.of_int (127)) (Prims.of_int (37)))))
+                                (Prims.of_int (133)) (Prims.of_int (9))
+                                (Prims.of_int (135)) (Prims.of_int (37)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (127))
+                                      (Prims.of_int (135))
                                       (Prims.of_int (13))
-                                      (Prims.of_int (127))
+                                      (Prims.of_int (135))
                                       (Prims.of_int (36)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (126))
+                                      (Prims.of_int (134))
                                       (Prims.of_int (13))
-                                      (Prims.of_int (127))
+                                      (Prims.of_int (135))
                                       (Prims.of_int (36)))))
                              (Obj.magic
                                 (term_to_doc b.Pulse_Syntax_Base.binder_ty))
@@ -899,27 +936,27 @@ and (term_to_doc :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (133)) (Prims.of_int (44))
-                            (Prims.of_int (133)) (Prims.of_int (66)))))
+                            (Prims.of_int (141)) (Prims.of_int (44))
+                            (Prims.of_int (141)) (Prims.of_int (66)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (133)) (Prims.of_int (19))
-                            (Prims.of_int (133)) (Prims.of_int (66)))))
+                            (Prims.of_int (141)) (Prims.of_int (19))
+                            (Prims.of_int (141)) (Prims.of_int (66)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Syntax.Printer.fst"
-                                  (Prims.of_int (133)) (Prims.of_int (51))
-                                  (Prims.of_int (133)) (Prims.of_int (66)))))
+                                  (Prims.of_int (141)) (Prims.of_int (51))
+                                  (Prims.of_int (141)) (Prims.of_int (66)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Syntax.Printer.fst"
-                                  (Prims.of_int (133)) (Prims.of_int (44))
-                                  (Prims.of_int (133)) (Prims.of_int (66)))))
+                                  (Prims.of_int (141)) (Prims.of_int (44))
+                                  (Prims.of_int (141)) (Prims.of_int (66)))))
                          (Obj.magic (term_to_doc p))
                          (fun uu___ ->
                             FStar_Tactics_Effect.lift_div_tac
@@ -929,49 +966,88 @@ and (term_to_doc :
                         (fun uu___1 ->
                            FStar_Pprint.op_Hat_Hat
                              (FStar_Pprint.doc_of_string "pure ") uu___))))
-       | Pulse_Syntax_Pure.Tm_Star (p1, p2) ->
+       | Pulse_Syntax_Pure.Tm_Star (uu___, uu___1) ->
            Obj.magic
              (Obj.repr
                 (FStar_Tactics_Effect.tac_bind
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (140)) (Prims.of_int (16))
-                            (Prims.of_int (140)) (Prims.of_int (32)))))
+                            (Prims.of_int (152)) (Prims.of_int (23))
+                            (Prims.of_int (152)) (Prims.of_int (38)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (139)) (Prims.of_int (6))
-                            (Prims.of_int (141)) (Prims.of_int (32)))))
-                   (Obj.magic (term_to_doc p1))
-                   (fun uu___ ->
-                      (fun uu___ ->
+                            (Prims.of_int (152)) (Prims.of_int (41))
+                            (Prims.of_int (158)) (Prims.of_int (80)))))
+                   (FStar_Tactics_Effect.lift_div_tac
+                      (fun uu___2 -> Pulse_Syntax_Pure.vprop_as_list t))
+                   (fun uu___2 ->
+                      (fun components ->
                          Obj.magic
                            (FStar_Tactics_Effect.tac_bind
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Syntax.Printer.fst"
-                                       (Prims.of_int (141))
-                                       (Prims.of_int (16))
-                                       (Prims.of_int (141))
-                                       (Prims.of_int (32)))))
+                                       (Prims.of_int (153))
+                                       (Prims.of_int (17))
+                                       (Prims.of_int (153))
+                                       (Prims.of_int (45)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Syntax.Printer.fst"
-                                       (Prims.of_int (139))
+                                       (Prims.of_int (157))
                                        (Prims.of_int (6))
-                                       (Prims.of_int (141))
-                                       (Prims.of_int (32)))))
-                              (Obj.magic (term_to_doc p2))
-                              (fun uu___1 ->
-                                 FStar_Tactics_Effect.lift_div_tac
-                                   (fun uu___2 ->
-                                      FStar_Pprint.infix Prims.int_zero
-                                        Prims.int_one
-                                        (FStar_Pprint.doc_of_string "**")
-                                        uu___ uu___1)))) uu___)))
+                                       (Prims.of_int (158))
+                                       (Prims.of_int (80)))))
+                              (Obj.magic
+                                 (FStar_Tactics_Util.map term_to_doc
+                                    components))
+                              (fun uu___2 ->
+                                 (fun docs ->
+                                    Obj.magic
+                                      (FStar_Tactics_Effect.tac_bind
+                                         (FStar_Sealed.seal
+                                            (Obj.magic
+                                               (FStar_Range.mk_range
+                                                  "Pulse.Syntax.Printer.fst"
+                                                  (Prims.of_int (158))
+                                                  (Prims.of_int (8))
+                                                  (Prims.of_int (158))
+                                                  (Prims.of_int (80)))))
+                                         (FStar_Sealed.seal
+                                            (Obj.magic
+                                               (FStar_Range.mk_range
+                                                  "Pulse.Syntax.Printer.fst"
+                                                  (Prims.of_int (157))
+                                                  (Prims.of_int (6))
+                                                  (Prims.of_int (158))
+                                                  (Prims.of_int (80)))))
+                                         (Obj.magic
+                                            (fold_right1
+                                               (fun uu___3 ->
+                                                  fun uu___2 ->
+                                                    (fun p ->
+                                                       fun q ->
+                                                         Obj.magic
+                                                           (FStar_Tactics_Effect.lift_div_tac
+                                                              (fun uu___2 ->
+                                                                 FStar_Pprint.op_Hat_Slash_Hat
+                                                                   (FStar_Pprint.op_Hat_Hat
+                                                                    p
+                                                                    (FStar_Pprint.op_Hat_Hat
+                                                                    (FStar_Pprint.doc_of_string
+                                                                    " ")
+                                                                    star_doc))
+                                                                   q)))
+                                                      uu___3 uu___2) docs))
+                                         (fun uu___2 ->
+                                            FStar_Tactics_Effect.lift_div_tac
+                                              (fun uu___3 ->
+                                                 FStar_Pprint.group uu___2))))
+                                   uu___2))) uu___2)))
        | Pulse_Syntax_Pure.Tm_ExistsSL (uu___, uu___1, uu___2) ->
            Obj.magic
              (Obj.repr
@@ -979,13 +1055,13 @@ and (term_to_doc :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (144)) (Prims.of_int (21))
-                            (Prims.of_int (144)) (Prims.of_int (51)))))
+                            (Prims.of_int (161)) (Prims.of_int (21))
+                            (Prims.of_int (161)) (Prims.of_int (51)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (143)) (Prims.of_int (26))
-                            (Prims.of_int (148)) (Prims.of_int (37)))))
+                            (Prims.of_int (160)) (Prims.of_int (26))
+                            (Prims.of_int (165)) (Prims.of_int (37)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___3 ->
                          collect_binders
@@ -1000,17 +1076,17 @@ and (term_to_doc :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (145))
+                                           (Prims.of_int (162))
                                            (Prims.of_int (19))
-                                           (Prims.of_int (145))
+                                           (Prims.of_int (162))
                                            (Prims.of_int (88)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (146))
+                                           (Prims.of_int (163))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (148))
+                                           (Prims.of_int (165))
                                            (Prims.of_int (37)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -1018,17 +1094,17 @@ and (term_to_doc :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (145))
+                                                 (Prims.of_int (162))
                                                  (Prims.of_int (25))
-                                                 (Prims.of_int (145))
+                                                 (Prims.of_int (162))
                                                  (Prims.of_int (88)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (145))
+                                                 (Prims.of_int (162))
                                                  (Prims.of_int (19))
-                                                 (Prims.of_int (145))
+                                                 (Prims.of_int (162))
                                                  (Prims.of_int (88)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -1036,17 +1112,17 @@ and (term_to_doc :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (145))
+                                                       (Prims.of_int (162))
                                                        (Prims.of_int (32))
-                                                       (Prims.of_int (145))
+                                                       (Prims.of_int (162))
                                                        (Prims.of_int (87)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (145))
+                                                       (Prims.of_int (162))
                                                        (Prims.of_int (25))
-                                                       (Prims.of_int (145))
+                                                       (Prims.of_int (162))
                                                        (Prims.of_int (88)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -1054,17 +1130,17 @@ and (term_to_doc :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (145))
+                                                             (Prims.of_int (162))
                                                              (Prims.of_int (62))
-                                                             (Prims.of_int (145))
+                                                             (Prims.of_int (162))
                                                              (Prims.of_int (86)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (145))
+                                                             (Prims.of_int (162))
                                                              (Prims.of_int (32))
-                                                             (Prims.of_int (145))
+                                                             (Prims.of_int (162))
                                                              (Prims.of_int (87)))))
                                                     (Obj.magic
                                                        (FStar_Tactics_Util.map
@@ -1092,17 +1168,17 @@ and (term_to_doc :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Syntax.Printer.fst"
-                                                      (Prims.of_int (147))
+                                                      (Prims.of_int (164))
                                                       (Prims.of_int (8))
-                                                      (Prims.of_int (148))
+                                                      (Prims.of_int (165))
                                                       (Prims.of_int (37)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Syntax.Printer.fst"
-                                                      (Prims.of_int (146))
+                                                      (Prims.of_int (163))
                                                       (Prims.of_int (6))
-                                                      (Prims.of_int (148))
+                                                      (Prims.of_int (165))
                                                       (Prims.of_int (37)))))
                                              (Obj.magic
                                                 (FStar_Tactics_Effect.tac_bind
@@ -1110,17 +1186,17 @@ and (term_to_doc :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (148))
+                                                            (Prims.of_int (165))
                                                             (Prims.of_int (19))
-                                                            (Prims.of_int (148))
+                                                            (Prims.of_int (165))
                                                             (Prims.of_int (37)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (147))
+                                                            (Prims.of_int (164))
                                                             (Prims.of_int (8))
-                                                            (Prims.of_int (148))
+                                                            (Prims.of_int (165))
                                                             (Prims.of_int (37)))))
                                                    (Obj.magic
                                                       (term_to_doc body))
@@ -1152,13 +1228,13 @@ and (term_to_doc :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (154)) (Prims.of_int (21))
-                            (Prims.of_int (154)) (Prims.of_int (51)))))
+                            (Prims.of_int (171)) (Prims.of_int (21))
+                            (Prims.of_int (171)) (Prims.of_int (51)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (153)) (Prims.of_int (26))
-                            (Prims.of_int (158)) (Prims.of_int (37)))))
+                            (Prims.of_int (170)) (Prims.of_int (26))
+                            (Prims.of_int (175)) (Prims.of_int (37)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___3 ->
                          collect_binders
@@ -1173,17 +1249,17 @@ and (term_to_doc :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (155))
+                                           (Prims.of_int (172))
                                            (Prims.of_int (19))
-                                           (Prims.of_int (155))
+                                           (Prims.of_int (172))
                                            (Prims.of_int (88)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (156))
+                                           (Prims.of_int (173))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (158))
+                                           (Prims.of_int (175))
                                            (Prims.of_int (37)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -1191,17 +1267,17 @@ and (term_to_doc :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (155))
+                                                 (Prims.of_int (172))
                                                  (Prims.of_int (25))
-                                                 (Prims.of_int (155))
+                                                 (Prims.of_int (172))
                                                  (Prims.of_int (88)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (155))
+                                                 (Prims.of_int (172))
                                                  (Prims.of_int (19))
-                                                 (Prims.of_int (155))
+                                                 (Prims.of_int (172))
                                                  (Prims.of_int (88)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -1209,17 +1285,17 @@ and (term_to_doc :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (155))
+                                                       (Prims.of_int (172))
                                                        (Prims.of_int (32))
-                                                       (Prims.of_int (155))
+                                                       (Prims.of_int (172))
                                                        (Prims.of_int (87)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (155))
+                                                       (Prims.of_int (172))
                                                        (Prims.of_int (25))
-                                                       (Prims.of_int (155))
+                                                       (Prims.of_int (172))
                                                        (Prims.of_int (88)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -1227,17 +1303,17 @@ and (term_to_doc :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (155))
+                                                             (Prims.of_int (172))
                                                              (Prims.of_int (62))
-                                                             (Prims.of_int (155))
+                                                             (Prims.of_int (172))
                                                              (Prims.of_int (86)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (155))
+                                                             (Prims.of_int (172))
                                                              (Prims.of_int (32))
-                                                             (Prims.of_int (155))
+                                                             (Prims.of_int (172))
                                                              (Prims.of_int (87)))))
                                                     (Obj.magic
                                                        (FStar_Tactics_Util.map
@@ -1265,17 +1341,17 @@ and (term_to_doc :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Syntax.Printer.fst"
-                                                      (Prims.of_int (157))
+                                                      (Prims.of_int (174))
                                                       (Prims.of_int (8))
-                                                      (Prims.of_int (158))
+                                                      (Prims.of_int (175))
                                                       (Prims.of_int (37)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Syntax.Printer.fst"
-                                                      (Prims.of_int (156))
+                                                      (Prims.of_int (173))
                                                       (Prims.of_int (6))
-                                                      (Prims.of_int (158))
+                                                      (Prims.of_int (175))
                                                       (Prims.of_int (37)))))
                                              (Obj.magic
                                                 (FStar_Tactics_Effect.tac_bind
@@ -1283,17 +1359,17 @@ and (term_to_doc :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (158))
+                                                            (Prims.of_int (175))
                                                             (Prims.of_int (19))
-                                                            (Prims.of_int (158))
+                                                            (Prims.of_int (175))
                                                             (Prims.of_int (37)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (157))
+                                                            (Prims.of_int (174))
                                                             (Prims.of_int (8))
-                                                            (Prims.of_int (158))
+                                                            (Prims.of_int (175))
                                                             (Prims.of_int (37)))))
                                                    (Obj.magic
                                                       (term_to_doc body))
@@ -1340,13 +1416,13 @@ and (term_to_doc :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (165)) (Prims.of_int (16))
-                            (Prims.of_int (165)) (Prims.of_int (31)))))
+                            (Prims.of_int (182)) (Prims.of_int (16))
+                            (Prims.of_int (182)) (Prims.of_int (31)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (164)) (Prims.of_int (6))
-                            (Prims.of_int (166)) (Prims.of_int (31)))))
+                            (Prims.of_int (181)) (Prims.of_int (6))
+                            (Prims.of_int (183)) (Prims.of_int (31)))))
                    (Obj.magic (term_to_doc i))
                    (fun uu___ ->
                       (fun uu___ ->
@@ -1356,17 +1432,17 @@ and (term_to_doc :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Syntax.Printer.fst"
-                                       (Prims.of_int (166))
+                                       (Prims.of_int (183))
                                        (Prims.of_int (16))
-                                       (Prims.of_int (166))
+                                       (Prims.of_int (183))
                                        (Prims.of_int (31)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Syntax.Printer.fst"
-                                       (Prims.of_int (164))
+                                       (Prims.of_int (181))
                                        (Prims.of_int (6))
-                                       (Prims.of_int (166))
+                                       (Prims.of_int (183))
                                        (Prims.of_int (31)))))
                               (Obj.magic (term_to_doc p))
                               (fun uu___1 ->
@@ -1393,12 +1469,12 @@ let (binder_to_string :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (178)) (Prims.of_int (12)) (Prims.of_int (178))
+               (Prims.of_int (195)) (Prims.of_int (12)) (Prims.of_int (195))
                (Prims.of_int (40)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (173)) (Prims.of_int (4)) (Prims.of_int (178))
+               (Prims.of_int (190)) (Prims.of_int (4)) (Prims.of_int (195))
                (Prims.of_int (40)))))
       (Obj.magic (term_to_string b.Pulse_Syntax_Base.binder_ty))
       (fun uu___ ->
@@ -1408,25 +1484,25 @@ let (binder_to_string :
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                          (Prims.of_int (173)) (Prims.of_int (4))
-                          (Prims.of_int (178)) (Prims.of_int (40)))))
+                          (Prims.of_int (190)) (Prims.of_int (4))
+                          (Prims.of_int (195)) (Prims.of_int (40)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                          (Prims.of_int (173)) (Prims.of_int (4))
-                          (Prims.of_int (178)) (Prims.of_int (40)))))
+                          (Prims.of_int (190)) (Prims.of_int (4))
+                          (Prims.of_int (195)) (Prims.of_int (40)))))
                  (Obj.magic
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (177)) (Prims.of_int (12))
-                                (Prims.of_int (177)) (Prims.of_int (43)))))
+                                (Prims.of_int (194)) (Prims.of_int (12))
+                                (Prims.of_int (194)) (Prims.of_int (43)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (173)) (Prims.of_int (4))
-                                (Prims.of_int (178)) (Prims.of_int (40)))))
+                                (Prims.of_int (190)) (Prims.of_int (4))
+                                (Prims.of_int (195)) (Prims.of_int (40)))))
                        (Obj.magic
                           (FStar_Tactics_Unseal.unseal
                              (b.Pulse_Syntax_Base.binder_ppname).Pulse_Syntax_Base.name))
@@ -1438,17 +1514,17 @@ let (binder_to_string :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (173))
+                                           (Prims.of_int (190))
                                            (Prims.of_int (4))
-                                           (Prims.of_int (178))
+                                           (Prims.of_int (195))
                                            (Prims.of_int (40)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (173))
+                                           (Prims.of_int (190))
                                            (Prims.of_int (4))
-                                           (Prims.of_int (178))
+                                           (Prims.of_int (195))
                                            (Prims.of_int (40)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -1456,9 +1532,9 @@ let (binder_to_string :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (174))
+                                                 (Prims.of_int (191))
                                                  (Prims.of_int (12))
-                                                 (Prims.of_int (176))
+                                                 (Prims.of_int (193))
                                                  (Prims.of_int (91)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
@@ -1474,17 +1550,17 @@ let (binder_to_string :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (174))
+                                                       (Prims.of_int (191))
                                                        (Prims.of_int (19))
-                                                       (Prims.of_int (174))
+                                                       (Prims.of_int (191))
                                                        (Prims.of_int (42)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (174))
+                                                       (Prims.of_int (191))
                                                        (Prims.of_int (12))
-                                                       (Prims.of_int (176))
+                                                       (Prims.of_int (193))
                                                        (Prims.of_int (91)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Unseal.unseal
@@ -1506,9 +1582,9 @@ let (binder_to_string :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (193))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (193))
                                                                     (Prims.of_int (90)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
@@ -1524,17 +1600,17 @@ let (binder_to_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (193))
                                                                     (Prims.of_int (59))
-                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (193))
                                                                     (Prims.of_int (89)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (193))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (193))
                                                                     (Prims.of_int (90)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Util.map
@@ -1609,8 +1685,8 @@ let (effect_annot_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (192)) (Prims.of_int (57))
-                            (Prims.of_int (192)) (Prims.of_int (79)))))
+                            (Prims.of_int (209)) (Prims.of_int (57))
+                            (Prims.of_int (209)) (Prims.of_int (79)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -1629,8 +1705,8 @@ let (effect_annot_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (193)) (Prims.of_int (59))
-                            (Prims.of_int (193)) (Prims.of_int (81)))))
+                            (Prims.of_int (210)) (Prims.of_int (59))
+                            (Prims.of_int (210)) (Prims.of_int (81)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -1650,8 +1726,8 @@ let (effect_annot_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (194)) (Prims.of_int (75))
-                            (Prims.of_int (194)) (Prims.of_int (97)))))
+                            (Prims.of_int (211)) (Prims.of_int (75))
+                            (Prims.of_int (211)) (Prims.of_int (97)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -1674,8 +1750,8 @@ let (comp_to_string :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (200)) (Prims.of_int (23))
-                   (Prims.of_int (200)) (Prims.of_int (41)))))
+                   (Prims.of_int (217)) (Prims.of_int (23))
+                   (Prims.of_int (217)) (Prims.of_int (41)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -1689,13 +1765,13 @@ let (comp_to_string :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (206)) (Prims.of_int (14))
-                   (Prims.of_int (206)) (Prims.of_int (37)))))
+                   (Prims.of_int (223)) (Prims.of_int (14))
+                   (Prims.of_int (223)) (Prims.of_int (37)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (203)) (Prims.of_int (6))
-                   (Prims.of_int (206)) (Prims.of_int (37)))))
+                   (Prims.of_int (220)) (Prims.of_int (6))
+                   (Prims.of_int (223)) (Prims.of_int (37)))))
           (Obj.magic (term_to_string s.Pulse_Syntax_Base.post))
           (fun uu___ ->
              (fun uu___ ->
@@ -1704,27 +1780,27 @@ let (comp_to_string :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (203)) (Prims.of_int (6))
-                              (Prims.of_int (206)) (Prims.of_int (37)))))
+                              (Prims.of_int (220)) (Prims.of_int (6))
+                              (Prims.of_int (223)) (Prims.of_int (37)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (203)) (Prims.of_int (6))
-                              (Prims.of_int (206)) (Prims.of_int (37)))))
+                              (Prims.of_int (220)) (Prims.of_int (6))
+                              (Prims.of_int (223)) (Prims.of_int (37)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (205)) (Prims.of_int (14))
-                                    (Prims.of_int (205)) (Prims.of_int (36)))))
+                                    (Prims.of_int (222)) (Prims.of_int (14))
+                                    (Prims.of_int (222)) (Prims.of_int (36)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (203)) (Prims.of_int (6))
-                                    (Prims.of_int (206)) (Prims.of_int (37)))))
+                                    (Prims.of_int (220)) (Prims.of_int (6))
+                                    (Prims.of_int (223)) (Prims.of_int (37)))))
                            (Obj.magic
                               (term_to_string s.Pulse_Syntax_Base.pre))
                            (fun uu___1 ->
@@ -1735,17 +1811,17 @@ let (comp_to_string :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (203))
+                                               (Prims.of_int (220))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (206))
+                                               (Prims.of_int (223))
                                                (Prims.of_int (37)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (203))
+                                               (Prims.of_int (220))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (206))
+                                               (Prims.of_int (223))
                                                (Prims.of_int (37)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -1753,9 +1829,9 @@ let (comp_to_string :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (204))
+                                                     (Prims.of_int (221))
                                                      (Prims.of_int (14))
-                                                     (Prims.of_int (204))
+                                                     (Prims.of_int (221))
                                                      (Prims.of_int (36)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
@@ -1796,13 +1872,13 @@ let (comp_to_string :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (214)) (Prims.of_int (14))
-                   (Prims.of_int (214)) (Prims.of_int (37)))))
+                   (Prims.of_int (231)) (Prims.of_int (14))
+                   (Prims.of_int (231)) (Prims.of_int (37)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (209)) (Prims.of_int (6))
-                   (Prims.of_int (214)) (Prims.of_int (37)))))
+                   (Prims.of_int (226)) (Prims.of_int (6))
+                   (Prims.of_int (231)) (Prims.of_int (37)))))
           (Obj.magic (term_to_string s.Pulse_Syntax_Base.post))
           (fun uu___ ->
              (fun uu___ ->
@@ -1811,27 +1887,27 @@ let (comp_to_string :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (209)) (Prims.of_int (6))
-                              (Prims.of_int (214)) (Prims.of_int (37)))))
+                              (Prims.of_int (226)) (Prims.of_int (6))
+                              (Prims.of_int (231)) (Prims.of_int (37)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (209)) (Prims.of_int (6))
-                              (Prims.of_int (214)) (Prims.of_int (37)))))
+                              (Prims.of_int (226)) (Prims.of_int (6))
+                              (Prims.of_int (231)) (Prims.of_int (37)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (213)) (Prims.of_int (14))
-                                    (Prims.of_int (213)) (Prims.of_int (36)))))
+                                    (Prims.of_int (230)) (Prims.of_int (14))
+                                    (Prims.of_int (230)) (Prims.of_int (36)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (209)) (Prims.of_int (6))
-                                    (Prims.of_int (214)) (Prims.of_int (37)))))
+                                    (Prims.of_int (226)) (Prims.of_int (6))
+                                    (Prims.of_int (231)) (Prims.of_int (37)))))
                            (Obj.magic
                               (term_to_string s.Pulse_Syntax_Base.pre))
                            (fun uu___1 ->
@@ -1842,17 +1918,17 @@ let (comp_to_string :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (209))
+                                               (Prims.of_int (226))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (214))
+                                               (Prims.of_int (231))
                                                (Prims.of_int (37)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (209))
+                                               (Prims.of_int (226))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (214))
+                                               (Prims.of_int (231))
                                                (Prims.of_int (37)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -1860,17 +1936,17 @@ let (comp_to_string :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (212))
+                                                     (Prims.of_int (229))
                                                      (Prims.of_int (14))
-                                                     (Prims.of_int (212))
+                                                     (Prims.of_int (229))
                                                      (Prims.of_int (37)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (209))
+                                                     (Prims.of_int (226))
                                                      (Prims.of_int (6))
-                                                     (Prims.of_int (214))
+                                                     (Prims.of_int (231))
                                                      (Prims.of_int (37)))))
                                             (Obj.magic
                                                (term_to_string inames))
@@ -1882,17 +1958,17 @@ let (comp_to_string :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (209))
+                                                                (Prims.of_int (226))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (214))
+                                                                (Prims.of_int (231))
                                                                 (Prims.of_int (37)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (209))
+                                                                (Prims.of_int (226))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (214))
+                                                                (Prims.of_int (231))
                                                                 (Prims.of_int (37)))))
                                                        (Obj.magic
                                                           (FStar_Tactics_Effect.tac_bind
@@ -1900,17 +1976,17 @@ let (comp_to_string :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (226))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (214))
+                                                                    (Prims.of_int (231))
                                                                     (Prims.of_int (37)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (226))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (214))
+                                                                    (Prims.of_int (231))
                                                                     (Prims.of_int (37)))))
                                                              (Obj.magic
                                                                 (FStar_Tactics_Effect.tac_bind
@@ -1918,9 +1994,9 @@ let (comp_to_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (36)))))
                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1985,13 +2061,13 @@ let (comp_to_string :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (221)) (Prims.of_int (14))
-                   (Prims.of_int (221)) (Prims.of_int (37)))))
+                   (Prims.of_int (238)) (Prims.of_int (14))
+                   (Prims.of_int (238)) (Prims.of_int (37)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (217)) (Prims.of_int (6))
-                   (Prims.of_int (221)) (Prims.of_int (37)))))
+                   (Prims.of_int (234)) (Prims.of_int (6))
+                   (Prims.of_int (238)) (Prims.of_int (37)))))
           (Obj.magic (term_to_string s.Pulse_Syntax_Base.post))
           (fun uu___ ->
              (fun uu___ ->
@@ -2000,27 +2076,27 @@ let (comp_to_string :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (217)) (Prims.of_int (6))
-                              (Prims.of_int (221)) (Prims.of_int (37)))))
+                              (Prims.of_int (234)) (Prims.of_int (6))
+                              (Prims.of_int (238)) (Prims.of_int (37)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (217)) (Prims.of_int (6))
-                              (Prims.of_int (221)) (Prims.of_int (37)))))
+                              (Prims.of_int (234)) (Prims.of_int (6))
+                              (Prims.of_int (238)) (Prims.of_int (37)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (220)) (Prims.of_int (14))
-                                    (Prims.of_int (220)) (Prims.of_int (36)))))
+                                    (Prims.of_int (237)) (Prims.of_int (14))
+                                    (Prims.of_int (237)) (Prims.of_int (36)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (217)) (Prims.of_int (6))
-                                    (Prims.of_int (221)) (Prims.of_int (37)))))
+                                    (Prims.of_int (234)) (Prims.of_int (6))
+                                    (Prims.of_int (238)) (Prims.of_int (37)))))
                            (Obj.magic
                               (term_to_string s.Pulse_Syntax_Base.pre))
                            (fun uu___1 ->
@@ -2031,17 +2107,17 @@ let (comp_to_string :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (217))
+                                               (Prims.of_int (234))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (221))
+                                               (Prims.of_int (238))
                                                (Prims.of_int (37)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (217))
+                                               (Prims.of_int (234))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (221))
+                                               (Prims.of_int (238))
                                                (Prims.of_int (37)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -2049,17 +2125,17 @@ let (comp_to_string :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (219))
+                                                     (Prims.of_int (236))
                                                      (Prims.of_int (14))
-                                                     (Prims.of_int (219))
+                                                     (Prims.of_int (236))
                                                      (Prims.of_int (37)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (217))
+                                                     (Prims.of_int (234))
                                                      (Prims.of_int (6))
-                                                     (Prims.of_int (221))
+                                                     (Prims.of_int (238))
                                                      (Prims.of_int (37)))))
                                             (Obj.magic
                                                (term_to_string inames))
@@ -2071,17 +2147,17 @@ let (comp_to_string :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (217))
+                                                                (Prims.of_int (234))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (221))
+                                                                (Prims.of_int (238))
                                                                 (Prims.of_int (37)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (217))
+                                                                (Prims.of_int (234))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (221))
+                                                                (Prims.of_int (238))
                                                                 (Prims.of_int (37)))))
                                                        (Obj.magic
                                                           (FStar_Tactics_Effect.tac_bind
@@ -2089,9 +2165,9 @@ let (comp_to_string :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (218))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (218))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (36)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
@@ -2162,12 +2238,12 @@ let (term_list_to_string :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                 (Prims.of_int (231)) (Prims.of_int (22))
-                 (Prims.of_int (231)) (Prims.of_int (46)))))
+                 (Prims.of_int (248)) (Prims.of_int (22))
+                 (Prims.of_int (248)) (Prims.of_int (46)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                 (Prims.of_int (231)) (Prims.of_int (4)) (Prims.of_int (231))
+                 (Prims.of_int (248)) (Prims.of_int (4)) (Prims.of_int (248))
                  (Prims.of_int (46)))))
         (Obj.magic (FStar_Tactics_Util.map term_to_string t))
         (fun uu___ ->
@@ -2194,8 +2270,8 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (239)) (Prims.of_int (8))
-                                (Prims.of_int (239)) (Prims.of_int (29)))))
+                                (Prims.of_int (256)) (Prims.of_int (8))
+                                (Prims.of_int (256)) (Prims.of_int (29)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
@@ -2221,13 +2297,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (246)) (Prims.of_int (8))
-                                (Prims.of_int (246)) (Prims.of_int (28)))))
+                                (Prims.of_int (263)) (Prims.of_int (8))
+                                (Prims.of_int (263)) (Prims.of_int (28)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (242)) (Prims.of_int (6))
-                                (Prims.of_int (246)) (Prims.of_int (28)))))
+                                (Prims.of_int (259)) (Prims.of_int (6))
+                                (Prims.of_int (263)) (Prims.of_int (28)))))
                        (Obj.magic (term_to_string arg))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -2237,17 +2313,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (242))
+                                           (Prims.of_int (259))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (246))
+                                           (Prims.of_int (263))
                                            (Prims.of_int (28)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (242))
+                                           (Prims.of_int (259))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (246))
+                                           (Prims.of_int (263))
                                            (Prims.of_int (28)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -2255,17 +2331,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (242))
+                                                 (Prims.of_int (259))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (246))
+                                                 (Prims.of_int (263))
                                                  (Prims.of_int (28)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (242))
+                                                 (Prims.of_int (259))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (246))
+                                                 (Prims.of_int (263))
                                                  (Prims.of_int (28)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -2273,9 +2349,9 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (244))
+                                                       (Prims.of_int (261))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (244))
+                                                       (Prims.of_int (261))
                                                        (Prims.of_int (29)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
@@ -2330,13 +2406,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (259)) (Prims.of_int (10))
-                                (Prims.of_int (259)) (Prims.of_int (41)))))
+                                (Prims.of_int (276)) (Prims.of_int (10))
+                                (Prims.of_int (276)) (Prims.of_int (41)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (255)) (Prims.of_int (8))
-                                (Prims.of_int (259)) (Prims.of_int (41)))))
+                                (Prims.of_int (272)) (Prims.of_int (8))
+                                (Prims.of_int (276)) (Prims.of_int (41)))))
                        (Obj.magic (st_term_to_string' level body))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -2346,17 +2422,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (255))
+                                           (Prims.of_int (272))
                                            (Prims.of_int (8))
-                                           (Prims.of_int (259))
+                                           (Prims.of_int (276))
                                            (Prims.of_int (41)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (255))
+                                           (Prims.of_int (272))
                                            (Prims.of_int (8))
-                                           (Prims.of_int (259))
+                                           (Prims.of_int (276))
                                            (Prims.of_int (41)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -2364,17 +2440,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (255))
+                                                 (Prims.of_int (272))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (259))
+                                                 (Prims.of_int (276))
                                                  (Prims.of_int (41)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (255))
+                                                 (Prims.of_int (272))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (259))
+                                                 (Prims.of_int (276))
                                                  (Prims.of_int (41)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -2382,17 +2458,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (257))
+                                                       (Prims.of_int (274))
                                                        (Prims.of_int (10))
-                                                       (Prims.of_int (257))
+                                                       (Prims.of_int (274))
                                                        (Prims.of_int (41)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (255))
+                                                       (Prims.of_int (272))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (259))
+                                                       (Prims.of_int (276))
                                                        (Prims.of_int (41)))))
                                               (Obj.magic
                                                  (st_term_to_string' level
@@ -2405,17 +2481,17 @@ let rec (st_term_to_string' :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (255))
+                                                                  (Prims.of_int (272))
                                                                   (Prims.of_int (8))
-                                                                  (Prims.of_int (259))
+                                                                  (Prims.of_int (276))
                                                                   (Prims.of_int (41)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (255))
+                                                                  (Prims.of_int (272))
                                                                   (Prims.of_int (8))
-                                                                  (Prims.of_int (259))
+                                                                  (Prims.of_int (276))
                                                                   (Prims.of_int (41)))))
                                                          (Obj.magic
                                                             (FStar_Tactics_Effect.tac_bind
@@ -2423,9 +2499,9 @@ let rec (st_term_to_string' :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (256))
+                                                                    (Prims.of_int (273))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (256))
+                                                                    (Prims.of_int (273))
                                                                     (Prims.of_int (35)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
@@ -2483,13 +2559,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (267)) (Prims.of_int (8))
-                                (Prims.of_int (267)) (Prims.of_int (39)))))
+                                (Prims.of_int (284)) (Prims.of_int (8))
+                                (Prims.of_int (284)) (Prims.of_int (39)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (263)) (Prims.of_int (6))
-                                (Prims.of_int (267)) (Prims.of_int (39)))))
+                                (Prims.of_int (280)) (Prims.of_int (6))
+                                (Prims.of_int (284)) (Prims.of_int (39)))))
                        (Obj.magic (st_term_to_string' level body))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -2499,17 +2575,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (263))
+                                           (Prims.of_int (280))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (267))
+                                           (Prims.of_int (284))
                                            (Prims.of_int (39)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (263))
+                                           (Prims.of_int (280))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (267))
+                                           (Prims.of_int (284))
                                            (Prims.of_int (39)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -2517,17 +2593,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (263))
+                                                 (Prims.of_int (280))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (267))
+                                                 (Prims.of_int (284))
                                                  (Prims.of_int (39)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (263))
+                                                 (Prims.of_int (280))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (267))
+                                                 (Prims.of_int (284))
                                                  (Prims.of_int (39)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -2535,17 +2611,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (265))
+                                                       (Prims.of_int (282))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (265))
+                                                       (Prims.of_int (282))
                                                        (Prims.of_int (29)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (263))
+                                                       (Prims.of_int (280))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (267))
+                                                       (Prims.of_int (284))
                                                        (Prims.of_int (39)))))
                                               (Obj.magic
                                                  (term_to_string head))
@@ -2557,17 +2633,17 @@ let rec (st_term_to_string' :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (263))
+                                                                  (Prims.of_int (280))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (267))
+                                                                  (Prims.of_int (284))
                                                                   (Prims.of_int (39)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (263))
+                                                                  (Prims.of_int (280))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (267))
+                                                                  (Prims.of_int (284))
                                                                   (Prims.of_int (39)))))
                                                          (Obj.magic
                                                             (FStar_Tactics_Effect.tac_bind
@@ -2575,9 +2651,9 @@ let rec (st_term_to_string' :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (281))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (281))
                                                                     (Prims.of_int (33)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
@@ -2635,13 +2711,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (276)) (Prims.of_int (14))
-                                (Prims.of_int (276)) (Prims.of_int (90)))))
+                                (Prims.of_int (293)) (Prims.of_int (14))
+                                (Prims.of_int (293)) (Prims.of_int (90)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (270)) (Prims.of_int (6))
-                                (Prims.of_int (276)) (Prims.of_int (90)))))
+                                (Prims.of_int (287)) (Prims.of_int (6))
+                                (Prims.of_int (293)) (Prims.of_int (90)))))
                        (match c.Pulse_Syntax_Base.elaborated with
                         | FStar_Pervasives_Native.None ->
                             Obj.magic
@@ -2656,9 +2732,9 @@ let rec (st_term_to_string' :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Syntax.Printer.fst"
-                                             (Prims.of_int (276))
+                                             (Prims.of_int (293))
                                              (Prims.of_int (73))
-                                             (Prims.of_int (276))
+                                             (Prims.of_int (293))
                                              (Prims.of_int (89)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
@@ -2680,17 +2756,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (270))
+                                           (Prims.of_int (287))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (276))
+                                           (Prims.of_int (293))
                                            (Prims.of_int (90)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (270))
+                                           (Prims.of_int (287))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (276))
+                                           (Prims.of_int (293))
                                            (Prims.of_int (90)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -2698,17 +2774,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (275))
+                                                 (Prims.of_int (292))
                                                  (Prims.of_int (14))
-                                                 (Prims.of_int (275))
+                                                 (Prims.of_int (292))
                                                  (Prims.of_int (54)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (270))
+                                                 (Prims.of_int (287))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (276))
+                                                 (Prims.of_int (293))
                                                  (Prims.of_int (90)))))
                                         (Obj.magic
                                            (st_term_to_string' (indent level)
@@ -2721,17 +2797,17 @@ let rec (st_term_to_string' :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (270))
+                                                            (Prims.of_int (287))
                                                             (Prims.of_int (6))
-                                                            (Prims.of_int (276))
+                                                            (Prims.of_int (293))
                                                             (Prims.of_int (90)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (270))
+                                                            (Prims.of_int (287))
                                                             (Prims.of_int (6))
-                                                            (Prims.of_int (276))
+                                                            (Prims.of_int (293))
                                                             (Prims.of_int (90)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_Effect.tac_bind
@@ -2739,17 +2815,17 @@ let rec (st_term_to_string' :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (270))
+                                                                  (Prims.of_int (287))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (276))
+                                                                  (Prims.of_int (293))
                                                                   (Prims.of_int (90)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (270))
+                                                                  (Prims.of_int (287))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (276))
+                                                                  (Prims.of_int (293))
                                                                   (Prims.of_int (90)))))
                                                          (Obj.magic
                                                             (FStar_Tactics_Effect.tac_bind
@@ -2757,17 +2833,17 @@ let rec (st_term_to_string' :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (80)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (270))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (90)))))
                                                                (match 
                                                                   c.Pulse_Syntax_Base.annotated
@@ -2795,17 +2871,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (270))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (90)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (270))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (90)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2813,9 +2889,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2892,28 +2968,28 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (279)) (Prims.of_int (6))
-                                (Prims.of_int (289)) (Prims.of_int (13)))))
+                                (Prims.of_int (296)) (Prims.of_int (6))
+                                (Prims.of_int (306)) (Prims.of_int (13)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (279)) (Prims.of_int (6))
-                                (Prims.of_int (289)) (Prims.of_int (13)))))
+                                (Prims.of_int (296)) (Prims.of_int (6))
+                                (Prims.of_int (306)) (Prims.of_int (13)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (288)) (Prims.of_int (8))
-                                      (Prims.of_int (288))
+                                      (Prims.of_int (305)) (Prims.of_int (8))
+                                      (Prims.of_int (305))
                                       (Prims.of_int (49)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (279)) (Prims.of_int (6))
-                                      (Prims.of_int (289))
+                                      (Prims.of_int (296)) (Prims.of_int (6))
+                                      (Prims.of_int (306))
                                       (Prims.of_int (13)))))
                              (Obj.magic
                                 (st_term_to_string' (indent level) else_))
@@ -2925,17 +3001,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (279))
+                                                 (Prims.of_int (296))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (289))
+                                                 (Prims.of_int (306))
                                                  (Prims.of_int (13)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (279))
+                                                 (Prims.of_int (296))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (289))
+                                                 (Prims.of_int (306))
                                                  (Prims.of_int (13)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -2943,17 +3019,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (279))
+                                                       (Prims.of_int (296))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (289))
+                                                       (Prims.of_int (306))
                                                        (Prims.of_int (13)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (279))
+                                                       (Prims.of_int (296))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (289))
+                                                       (Prims.of_int (306))
                                                        (Prims.of_int (13)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -2961,17 +3037,17 @@ let rec (st_term_to_string' :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (279))
+                                                             (Prims.of_int (296))
                                                              (Prims.of_int (6))
-                                                             (Prims.of_int (289))
+                                                             (Prims.of_int (306))
                                                              (Prims.of_int (13)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (279))
+                                                             (Prims.of_int (296))
                                                              (Prims.of_int (6))
-                                                             (Prims.of_int (289))
+                                                             (Prims.of_int (306))
                                                              (Prims.of_int (13)))))
                                                     (Obj.magic
                                                        (FStar_Tactics_Effect.tac_bind
@@ -2979,17 +3055,17 @@ let rec (st_term_to_string' :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (279))
+                                                                   (Prims.of_int (296))
                                                                    (Prims.of_int (6))
-                                                                   (Prims.of_int (289))
+                                                                   (Prims.of_int (306))
                                                                    (Prims.of_int (13)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (279))
+                                                                   (Prims.of_int (296))
                                                                    (Prims.of_int (6))
-                                                                   (Prims.of_int (289))
+                                                                   (Prims.of_int (306))
                                                                    (Prims.of_int (13)))))
                                                           (Obj.magic
                                                              (FStar_Tactics_Effect.tac_bind
@@ -2997,17 +3073,17 @@ let rec (st_term_to_string' :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (279))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (13)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (279))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (13)))))
                                                                 (Obj.magic
                                                                    (FStar_Tactics_Effect.tac_bind
@@ -3015,17 +3091,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (279))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (13)))))
                                                                     (Obj.magic
                                                                     (st_term_to_string'
@@ -3042,35 +3118,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (279))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (13)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (279))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (289))
-                                                                    (Prims.of_int (13)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (279))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (289))
-                                                                    (Prims.of_int (13)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (279))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (13)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3078,17 +3136,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (279))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (13)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (279))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (13)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3096,9 +3154,27 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (280))
+                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (306))
+                                                                    (Prims.of_int (13)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (306))
+                                                                    (Prims.of_int (13)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (297))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (280))
+                                                                    (Prims.of_int (297))
                                                                     (Prims.of_int (26)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -3219,13 +3295,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (294)) (Prims.of_int (8))
-                                (Prims.of_int (294)) (Prims.of_int (32)))))
+                                (Prims.of_int (311)) (Prims.of_int (8))
+                                (Prims.of_int (311)) (Prims.of_int (32)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (292)) (Prims.of_int (6))
-                                (Prims.of_int (294)) (Prims.of_int (32)))))
+                                (Prims.of_int (309)) (Prims.of_int (6))
+                                (Prims.of_int (311)) (Prims.of_int (32)))))
                        (Obj.magic (branches_to_string brs))
                        (fun uu___1 ->
                           (fun uu___1 ->
@@ -3235,17 +3311,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (292))
+                                           (Prims.of_int (309))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (294))
+                                           (Prims.of_int (311))
                                            (Prims.of_int (32)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (292))
+                                           (Prims.of_int (309))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (294))
+                                           (Prims.of_int (311))
                                            (Prims.of_int (32)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -3253,9 +3329,9 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (293))
+                                                 (Prims.of_int (310))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (293))
+                                                 (Prims.of_int (310))
                                                  (Prims.of_int (27)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
@@ -3286,8 +3362,8 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (299)) (Prims.of_int (8))
-                                (Prims.of_int (299)) (Prims.of_int (42)))))
+                                (Prims.of_int (316)) (Prims.of_int (8))
+                                (Prims.of_int (316)) (Prims.of_int (42)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
@@ -3308,8 +3384,8 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (303)) (Prims.of_int (8))
-                                (Prims.of_int (303)) (Prims.of_int (26)))))
+                                (Prims.of_int (320)) (Prims.of_int (8))
+                                (Prims.of_int (320)) (Prims.of_int (26)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
@@ -3331,13 +3407,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (310)) (Prims.of_int (8))
-                                (Prims.of_int (310)) (Prims.of_int (43)))))
+                                (Prims.of_int (327)) (Prims.of_int (8))
+                                (Prims.of_int (327)) (Prims.of_int (43)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (306)) (Prims.of_int (6))
-                                (Prims.of_int (310)) (Prims.of_int (43)))))
+                                (Prims.of_int (323)) (Prims.of_int (6))
+                                (Prims.of_int (327)) (Prims.of_int (43)))))
                        (Obj.magic (term_list_to_string " " witnesses))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -3347,17 +3423,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (306))
+                                           (Prims.of_int (323))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (310))
+                                           (Prims.of_int (327))
                                            (Prims.of_int (43)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (306))
+                                           (Prims.of_int (323))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (310))
+                                           (Prims.of_int (327))
                                            (Prims.of_int (43)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -3365,17 +3441,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (306))
+                                                 (Prims.of_int (323))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (310))
+                                                 (Prims.of_int (327))
                                                  (Prims.of_int (43)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (306))
+                                                 (Prims.of_int (323))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (310))
+                                                 (Prims.of_int (327))
                                                  (Prims.of_int (43)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -3383,9 +3459,9 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (308))
+                                                       (Prims.of_int (325))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (308))
+                                                       (Prims.of_int (325))
                                                        (Prims.of_int (42)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
@@ -3436,28 +3512,28 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (313)) (Prims.of_int (6))
-                                (Prims.of_int (320)) (Prims.of_int (13)))))
+                                (Prims.of_int (330)) (Prims.of_int (6))
+                                (Prims.of_int (337)) (Prims.of_int (13)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (313)) (Prims.of_int (6))
-                                (Prims.of_int (320)) (Prims.of_int (13)))))
+                                (Prims.of_int (330)) (Prims.of_int (6))
+                                (Prims.of_int (337)) (Prims.of_int (13)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (319)) (Prims.of_int (8))
-                                      (Prims.of_int (319))
+                                      (Prims.of_int (336)) (Prims.of_int (8))
+                                      (Prims.of_int (336))
                                       (Prims.of_int (48)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (313)) (Prims.of_int (6))
-                                      (Prims.of_int (320))
+                                      (Prims.of_int (330)) (Prims.of_int (6))
+                                      (Prims.of_int (337))
                                       (Prims.of_int (13)))))
                              (Obj.magic
                                 (st_term_to_string' (indent level) body))
@@ -3469,17 +3545,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (313))
+                                                 (Prims.of_int (330))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (320))
+                                                 (Prims.of_int (337))
                                                  (Prims.of_int (13)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (313))
+                                                 (Prims.of_int (330))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (320))
+                                                 (Prims.of_int (337))
                                                  (Prims.of_int (13)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -3487,17 +3563,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (313))
+                                                       (Prims.of_int (330))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (320))
+                                                       (Prims.of_int (337))
                                                        (Prims.of_int (13)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (313))
+                                                       (Prims.of_int (330))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (320))
+                                                       (Prims.of_int (337))
                                                        (Prims.of_int (13)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -3505,17 +3581,17 @@ let rec (st_term_to_string' :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (313))
+                                                             (Prims.of_int (330))
                                                              (Prims.of_int (6))
-                                                             (Prims.of_int (320))
+                                                             (Prims.of_int (337))
                                                              (Prims.of_int (13)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (313))
+                                                             (Prims.of_int (330))
                                                              (Prims.of_int (6))
-                                                             (Prims.of_int (320))
+                                                             (Prims.of_int (337))
                                                              (Prims.of_int (13)))))
                                                     (Obj.magic
                                                        (FStar_Tactics_Effect.tac_bind
@@ -3523,17 +3599,17 @@ let rec (st_term_to_string' :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (316))
+                                                                   (Prims.of_int (333))
                                                                    (Prims.of_int (8))
-                                                                   (Prims.of_int (316))
+                                                                   (Prims.of_int (333))
                                                                    (Prims.of_int (34)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (313))
+                                                                   (Prims.of_int (330))
                                                                    (Prims.of_int (6))
-                                                                   (Prims.of_int (320))
+                                                                   (Prims.of_int (337))
                                                                    (Prims.of_int (13)))))
                                                           (Obj.magic
                                                              (term_to_string
@@ -3546,35 +3622,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (313))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (320))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (13)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (313))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (320))
-                                                                    (Prims.of_int (13)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (313))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (320))
-                                                                    (Prims.of_int (13)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (313))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (320))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (13)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3582,9 +3640,27 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (314))
+                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (13)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (13)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (314))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -3677,13 +3753,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (329)) (Prims.of_int (8))
-                                (Prims.of_int (329)) (Prims.of_int (30)))))
+                                (Prims.of_int (346)) (Prims.of_int (8))
+                                (Prims.of_int (346)) (Prims.of_int (30)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (323)) (Prims.of_int (6))
-                                (Prims.of_int (329)) (Prims.of_int (30)))))
+                                (Prims.of_int (340)) (Prims.of_int (6))
+                                (Prims.of_int (346)) (Prims.of_int (30)))))
                        (Obj.magic (term_to_string post2))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -3693,17 +3769,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (323))
+                                           (Prims.of_int (340))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (329))
+                                           (Prims.of_int (346))
                                            (Prims.of_int (30)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (323))
+                                           (Prims.of_int (340))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (329))
+                                           (Prims.of_int (346))
                                            (Prims.of_int (30)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -3711,17 +3787,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (328))
+                                                 (Prims.of_int (345))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (328))
+                                                 (Prims.of_int (345))
                                                  (Prims.of_int (40)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (323))
+                                                 (Prims.of_int (340))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (329))
+                                                 (Prims.of_int (346))
                                                  (Prims.of_int (30)))))
                                         (Obj.magic
                                            (st_term_to_string' level body2))
@@ -3733,17 +3809,17 @@ let rec (st_term_to_string' :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (323))
+                                                            (Prims.of_int (340))
                                                             (Prims.of_int (6))
-                                                            (Prims.of_int (329))
+                                                            (Prims.of_int (346))
                                                             (Prims.of_int (30)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (323))
+                                                            (Prims.of_int (340))
                                                             (Prims.of_int (6))
-                                                            (Prims.of_int (329))
+                                                            (Prims.of_int (346))
                                                             (Prims.of_int (30)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_Effect.tac_bind
@@ -3751,17 +3827,17 @@ let rec (st_term_to_string' :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (327))
+                                                                  (Prims.of_int (344))
                                                                   (Prims.of_int (8))
-                                                                  (Prims.of_int (327))
+                                                                  (Prims.of_int (344))
                                                                   (Prims.of_int (29)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (323))
+                                                                  (Prims.of_int (340))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (329))
+                                                                  (Prims.of_int (346))
                                                                   (Prims.of_int (30)))))
                                                          (Obj.magic
                                                             (term_to_string
@@ -3775,18 +3851,18 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (340))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (30)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (340))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (30)))))
                                                                     (
                                                                     Obj.magic
@@ -3795,17 +3871,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (326))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (326))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (340))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (30)))))
                                                                     (Obj.magic
                                                                     (term_to_string
@@ -3820,17 +3896,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (340))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (340))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (30)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3838,17 +3914,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (325))
+                                                                    (Prims.of_int (342))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (325))
+                                                                    (Prims.of_int (342))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (340))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (30)))))
                                                                     (Obj.magic
                                                                     (st_term_to_string'
@@ -3864,17 +3940,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (340))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (340))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (30)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3882,9 +3958,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (324))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (324))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -3968,13 +4044,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (334)) (Prims.of_int (8))
-                                (Prims.of_int (334)) (Prims.of_int (27)))))
+                                (Prims.of_int (351)) (Prims.of_int (8))
+                                (Prims.of_int (351)) (Prims.of_int (27)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (332)) (Prims.of_int (7))
-                                (Prims.of_int (334)) (Prims.of_int (27)))))
+                                (Prims.of_int (349)) (Prims.of_int (7))
+                                (Prims.of_int (351)) (Prims.of_int (27)))))
                        (Obj.magic (term_to_string t2))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -3984,17 +4060,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (332))
+                                           (Prims.of_int (349))
                                            (Prims.of_int (7))
-                                           (Prims.of_int (334))
+                                           (Prims.of_int (351))
                                            (Prims.of_int (27)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (332))
+                                           (Prims.of_int (349))
                                            (Prims.of_int (7))
-                                           (Prims.of_int (334))
+                                           (Prims.of_int (351))
                                            (Prims.of_int (27)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -4002,9 +4078,9 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (333))
+                                                 (Prims.of_int (350))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (333))
+                                                 (Prims.of_int (350))
                                                  (Prims.of_int (27)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
@@ -4038,13 +4114,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (341)) (Prims.of_int (8))
-                                (Prims.of_int (341)) (Prims.of_int (39)))))
+                                (Prims.of_int (358)) (Prims.of_int (8))
+                                (Prims.of_int (358)) (Prims.of_int (39)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (337)) (Prims.of_int (6))
-                                (Prims.of_int (341)) (Prims.of_int (39)))))
+                                (Prims.of_int (354)) (Prims.of_int (6))
+                                (Prims.of_int (358)) (Prims.of_int (39)))))
                        (Obj.magic (st_term_to_string' level body))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -4054,17 +4130,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (337))
+                                           (Prims.of_int (354))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (341))
+                                           (Prims.of_int (358))
                                            (Prims.of_int (39)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (337))
+                                           (Prims.of_int (354))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (341))
+                                           (Prims.of_int (358))
                                            (Prims.of_int (39)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -4072,17 +4148,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (337))
+                                                 (Prims.of_int (354))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (341))
+                                                 (Prims.of_int (358))
                                                  (Prims.of_int (39)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (337))
+                                                 (Prims.of_int (354))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (341))
+                                                 (Prims.of_int (358))
                                                  (Prims.of_int (39)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -4090,17 +4166,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (339))
+                                                       (Prims.of_int (356))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (339))
+                                                       (Prims.of_int (356))
                                                        (Prims.of_int (36)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (337))
+                                                       (Prims.of_int (354))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (341))
+                                                       (Prims.of_int (358))
                                                        (Prims.of_int (39)))))
                                               (Obj.magic
                                                  (term_to_string initializer1))
@@ -4112,17 +4188,17 @@ let rec (st_term_to_string' :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (337))
+                                                                  (Prims.of_int (354))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (341))
+                                                                  (Prims.of_int (358))
                                                                   (Prims.of_int (39)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (337))
+                                                                  (Prims.of_int (354))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (341))
+                                                                  (Prims.of_int (358))
                                                                   (Prims.of_int (39)))))
                                                          (Obj.magic
                                                             (FStar_Tactics_Effect.tac_bind
@@ -4130,9 +4206,9 @@ let rec (st_term_to_string' :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (355))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (355))
                                                                     (Prims.of_int (33)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
@@ -4191,13 +4267,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (349)) (Prims.of_int (8))
-                                (Prims.of_int (349)) (Prims.of_int (39)))))
+                                (Prims.of_int (366)) (Prims.of_int (8))
+                                (Prims.of_int (366)) (Prims.of_int (39)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (344)) (Prims.of_int (6))
-                                (Prims.of_int (349)) (Prims.of_int (39)))))
+                                (Prims.of_int (361)) (Prims.of_int (6))
+                                (Prims.of_int (366)) (Prims.of_int (39)))))
                        (Obj.magic (st_term_to_string' level body))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -4207,17 +4283,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (344))
+                                           (Prims.of_int (361))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (349))
+                                           (Prims.of_int (366))
                                            (Prims.of_int (39)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (344))
+                                           (Prims.of_int (361))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (349))
+                                           (Prims.of_int (366))
                                            (Prims.of_int (39)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -4225,17 +4301,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (344))
+                                                 (Prims.of_int (361))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (349))
+                                                 (Prims.of_int (366))
                                                  (Prims.of_int (39)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (344))
+                                                 (Prims.of_int (361))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (349))
+                                                 (Prims.of_int (366))
                                                  (Prims.of_int (39)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -4243,17 +4319,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (347))
+                                                       (Prims.of_int (364))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (347))
+                                                       (Prims.of_int (364))
                                                        (Prims.of_int (31)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (344))
+                                                       (Prims.of_int (361))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (349))
+                                                       (Prims.of_int (366))
                                                        (Prims.of_int (39)))))
                                               (Obj.magic
                                                  (term_to_string length))
@@ -4265,17 +4341,17 @@ let rec (st_term_to_string' :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (344))
+                                                                  (Prims.of_int (361))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (349))
+                                                                  (Prims.of_int (366))
                                                                   (Prims.of_int (39)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (344))
+                                                                  (Prims.of_int (361))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (349))
+                                                                  (Prims.of_int (366))
                                                                   (Prims.of_int (39)))))
                                                          (Obj.magic
                                                             (FStar_Tactics_Effect.tac_bind
@@ -4283,17 +4359,17 @@ let rec (st_term_to_string' :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (346))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (346))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (36)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (39)))))
                                                                (Obj.magic
                                                                   (term_to_string
@@ -4307,17 +4383,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4325,9 +4401,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (33)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -4398,13 +4474,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (359)) (Prims.of_int (8))
-                                (Prims.of_int (361)) (Prims.of_int (60)))))
+                                (Prims.of_int (376)) (Prims.of_int (8))
+                                (Prims.of_int (378)) (Prims.of_int (60)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (352)) (Prims.of_int (6))
-                                (Prims.of_int (361)) (Prims.of_int (60)))))
+                                (Prims.of_int (369)) (Prims.of_int (6))
+                                (Prims.of_int (378)) (Prims.of_int (60)))))
                        (match post with
                         | FStar_Pervasives_Native.None ->
                             Obj.magic
@@ -4419,9 +4495,9 @@ let rec (st_term_to_string' :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Syntax.Printer.fst"
-                                             (Prims.of_int (361))
+                                             (Prims.of_int (378))
                                              (Prims.of_int (38))
-                                             (Prims.of_int (361))
+                                             (Prims.of_int (378))
                                              (Prims.of_int (59)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
@@ -4444,17 +4520,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (352))
+                                           (Prims.of_int (369))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (361))
+                                           (Prims.of_int (378))
                                            (Prims.of_int (60)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (352))
+                                           (Prims.of_int (369))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (361))
+                                           (Prims.of_int (378))
                                            (Prims.of_int (60)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -4462,9 +4538,9 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (358))
+                                                 (Prims.of_int (375))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (358))
+                                                 (Prims.of_int (375))
                                                  (Prims.of_int (28)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
@@ -4522,13 +4598,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (367)) (Prims.of_int (8))
-                                (Prims.of_int (369)) (Prims.of_int (86)))))
+                                (Prims.of_int (384)) (Prims.of_int (8))
+                                (Prims.of_int (386)) (Prims.of_int (86)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (370)) (Prims.of_int (8))
-                                (Prims.of_int (395)) (Prims.of_int (36)))))
+                                (Prims.of_int (387)) (Prims.of_int (8))
+                                (Prims.of_int (412)) (Prims.of_int (36)))))
                        (match binders with
                         | [] ->
                             Obj.magic
@@ -4543,9 +4619,9 @@ let rec (st_term_to_string' :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Syntax.Printer.fst"
-                                             (Prims.of_int (369))
+                                             (Prims.of_int (386))
                                              (Prims.of_int (34))
-                                             (Prims.of_int (369))
+                                             (Prims.of_int (386))
                                              (Prims.of_int (86)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
@@ -4560,17 +4636,17 @@ let rec (st_term_to_string' :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Syntax.Printer.fst"
-                                                   (Prims.of_int (369))
+                                                   (Prims.of_int (386))
                                                    (Prims.of_int (53))
-                                                   (Prims.of_int (369))
+                                                   (Prims.of_int (386))
                                                    (Prims.of_int (85)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Syntax.Printer.fst"
-                                                   (Prims.of_int (369))
+                                                   (Prims.of_int (386))
                                                    (Prims.of_int (34))
-                                                   (Prims.of_int (369))
+                                                   (Prims.of_int (386))
                                                    (Prims.of_int (86)))))
                                           (Obj.magic
                                              (FStar_Tactics_Util.map
@@ -4593,17 +4669,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (371))
+                                           (Prims.of_int (388))
                                            (Prims.of_int (28))
-                                           (Prims.of_int (373))
+                                           (Prims.of_int (390))
                                            (Prims.of_int (58)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (374))
+                                           (Prims.of_int (391))
                                            (Prims.of_int (8))
-                                           (Prims.of_int (395))
+                                           (Prims.of_int (412))
                                            (Prims.of_int (36)))))
                                   (FStar_Tactics_Effect.lift_div_tac
                                      (fun uu___ ->
@@ -4624,17 +4700,17 @@ let rec (st_term_to_string' :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Syntax.Printer.fst"
-                                                      (Prims.of_int (376))
+                                                      (Prims.of_int (393))
                                                       (Prims.of_int (8))
-                                                      (Prims.of_int (392))
+                                                      (Prims.of_int (409))
                                                       (Prims.of_int (54)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Syntax.Printer.fst"
-                                                      (Prims.of_int (374))
+                                                      (Prims.of_int (391))
                                                       (Prims.of_int (8))
-                                                      (Prims.of_int (395))
+                                                      (Prims.of_int (412))
                                                       (Prims.of_int (36)))))
                                              (match hint_type with
                                               | Pulse_Syntax_Base.ASSERT
@@ -4648,17 +4724,17 @@ let rec (st_term_to_string' :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (377))
+                                                                   (Prims.of_int (394))
                                                                    (Prims.of_int (36))
-                                                                   (Prims.of_int (377))
+                                                                   (Prims.of_int (394))
                                                                    (Prims.of_int (52)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (377))
+                                                                   (Prims.of_int (394))
                                                                    (Prims.of_int (26))
-                                                                   (Prims.of_int (377))
+                                                                   (Prims.of_int (394))
                                                                    (Prims.of_int (52)))))
                                                           (Obj.magic
                                                              (term_to_string
@@ -4681,17 +4757,17 @@ let rec (st_term_to_string' :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (378))
+                                                                   (Prims.of_int (395))
                                                                    (Prims.of_int (77))
-                                                                   (Prims.of_int (378))
+                                                                   (Prims.of_int (395))
                                                                    (Prims.of_int (93)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (378))
+                                                                   (Prims.of_int (395))
                                                                    (Prims.of_int (33))
-                                                                   (Prims.of_int (378))
+                                                                   (Prims.of_int (395))
                                                                    (Prims.of_int (93)))))
                                                           (Obj.magic
                                                              (term_to_string
@@ -4718,17 +4794,17 @@ let rec (st_term_to_string' :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (379))
+                                                                   (Prims.of_int (396))
                                                                    (Prims.of_int (73))
-                                                                   (Prims.of_int (379))
+                                                                   (Prims.of_int (396))
                                                                    (Prims.of_int (89)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (379))
+                                                                   (Prims.of_int (396))
                                                                    (Prims.of_int (31))
-                                                                   (Prims.of_int (379))
+                                                                   (Prims.of_int (396))
                                                                    (Prims.of_int (89)))))
                                                           (Obj.magic
                                                              (term_to_string
@@ -4756,17 +4832,17 @@ let rec (st_term_to_string' :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (381))
+                                                                   (Prims.of_int (398))
                                                                    (Prims.of_int (10))
-                                                                   (Prims.of_int (385))
+                                                                   (Prims.of_int (402))
                                                                    (Prims.of_int (21)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (381))
+                                                                   (Prims.of_int (398))
                                                                    (Prims.of_int (10))
-                                                                   (Prims.of_int (388))
+                                                                   (Prims.of_int (405))
                                                                    (Prims.of_int (60)))))
                                                           (Obj.magic
                                                              (FStar_Tactics_Effect.tac_bind
@@ -4774,9 +4850,9 @@ let rec (st_term_to_string' :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (385))
+                                                                    (Prims.of_int (402))
                                                                     (Prims.of_int (21)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
@@ -4792,17 +4868,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (400))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (385))
+                                                                    (Prims.of_int (402))
                                                                     (Prims.of_int (20)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (385))
+                                                                    (Prims.of_int (402))
                                                                     (Prims.of_int (21)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Util.map
@@ -4817,17 +4893,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (87)))))
                                                                     (Obj.magic
                                                                     (term_to_string
@@ -4842,17 +4918,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (87)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4860,9 +4936,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (68)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -4922,17 +4998,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (386))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (60)))))
                                                                     (match goal
                                                                     with
@@ -4955,9 +5031,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -5000,17 +5076,17 @@ let rec (st_term_to_string' :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (390))
+                                                                   (Prims.of_int (407))
                                                                    (Prims.of_int (10))
-                                                                   (Prims.of_int (390))
+                                                                   (Prims.of_int (407))
                                                                    (Prims.of_int (76)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (390))
+                                                                   (Prims.of_int (407))
                                                                    (Prims.of_int (10))
-                                                                   (Prims.of_int (390))
+                                                                   (Prims.of_int (407))
                                                                    (Prims.of_int (80)))))
                                                           (Obj.magic
                                                              (FStar_Tactics_Effect.tac_bind
@@ -5018,17 +5094,17 @@ let rec (st_term_to_string' :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (57))
-                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (76)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (76)))))
                                                                 (Obj.magic
                                                                    (term_to_string
@@ -5042,17 +5118,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (76)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -5060,9 +5136,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (37))
-                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -5125,9 +5201,9 @@ let rec (st_term_to_string' :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (395))
+                                                                    (Prims.of_int (412))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (395))
+                                                                    (Prims.of_int (412))
                                                                     (Prims.of_int (36)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
@@ -5170,13 +5246,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (401)) (Prims.of_int (8))
-                                (Prims.of_int (407)) (Prims.of_int (32)))))
+                                (Prims.of_int (418)) (Prims.of_int (8))
+                                (Prims.of_int (424)) (Prims.of_int (32)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (398)) (Prims.of_int (6))
-                                (Prims.of_int (407)) (Prims.of_int (32)))))
+                                (Prims.of_int (415)) (Prims.of_int (6))
+                                (Prims.of_int (424)) (Prims.of_int (32)))))
                        (match returns_inv with
                         | FStar_Pervasives_Native.None ->
                             Obj.magic
@@ -5191,17 +5267,17 @@ let rec (st_term_to_string' :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Syntax.Printer.fst"
-                                             (Prims.of_int (407))
+                                             (Prims.of_int (424))
                                              (Prims.of_int (12))
-                                             (Prims.of_int (407))
+                                             (Prims.of_int (424))
                                              (Prims.of_int (31)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Syntax.Printer.fst"
-                                             (Prims.of_int (404))
+                                             (Prims.of_int (421))
                                              (Prims.of_int (10))
-                                             (Prims.of_int (407))
+                                             (Prims.of_int (424))
                                              (Prims.of_int (31)))))
                                     (Obj.magic (term_to_string is))
                                     (fun uu___ ->
@@ -5212,17 +5288,17 @@ let rec (st_term_to_string' :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Syntax.Printer.fst"
-                                                        (Prims.of_int (404))
+                                                        (Prims.of_int (421))
                                                         (Prims.of_int (10))
-                                                        (Prims.of_int (407))
+                                                        (Prims.of_int (424))
                                                         (Prims.of_int (31)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Syntax.Printer.fst"
-                                                        (Prims.of_int (404))
+                                                        (Prims.of_int (421))
                                                         (Prims.of_int (10))
-                                                        (Prims.of_int (407))
+                                                        (Prims.of_int (424))
                                                         (Prims.of_int (31)))))
                                                (Obj.magic
                                                   (FStar_Tactics_Effect.tac_bind
@@ -5230,17 +5306,17 @@ let rec (st_term_to_string' :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Syntax.Printer.fst"
-                                                              (Prims.of_int (406))
+                                                              (Prims.of_int (423))
                                                               (Prims.of_int (12))
-                                                              (Prims.of_int (406))
+                                                              (Prims.of_int (423))
                                                               (Prims.of_int (30)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Syntax.Printer.fst"
-                                                              (Prims.of_int (404))
+                                                              (Prims.of_int (421))
                                                               (Prims.of_int (10))
-                                                              (Prims.of_int (407))
+                                                              (Prims.of_int (424))
                                                               (Prims.of_int (31)))))
                                                      (Obj.magic
                                                         (term_to_string t1))
@@ -5252,17 +5328,17 @@ let rec (st_term_to_string' :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (404))
+                                                                    (Prims.of_int (421))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (407))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (31)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (404))
+                                                                    (Prims.of_int (421))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (407))
+                                                                    (Prims.of_int (424))
                                                                     (Prims.of_int (31)))))
                                                                 (Obj.magic
                                                                    (FStar_Tactics_Effect.tac_bind
@@ -5270,9 +5346,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (422))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (405))
+                                                                    (Prims.of_int (422))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -5324,17 +5400,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (398))
+                                           (Prims.of_int (415))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (407))
+                                           (Prims.of_int (424))
                                            (Prims.of_int (32)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (398))
+                                           (Prims.of_int (415))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (407))
+                                           (Prims.of_int (424))
                                            (Prims.of_int (32)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -5342,17 +5418,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (400))
+                                                 (Prims.of_int (417))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (400))
+                                                 (Prims.of_int (417))
                                                  (Prims.of_int (39)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (398))
+                                                 (Prims.of_int (415))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (407))
+                                                 (Prims.of_int (424))
                                                  (Prims.of_int (32)))))
                                         (Obj.magic
                                            (st_term_to_string' level body))
@@ -5364,17 +5440,17 @@ let rec (st_term_to_string' :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (398))
+                                                            (Prims.of_int (415))
                                                             (Prims.of_int (6))
-                                                            (Prims.of_int (407))
+                                                            (Prims.of_int (424))
                                                             (Prims.of_int (32)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (398))
+                                                            (Prims.of_int (415))
                                                             (Prims.of_int (6))
-                                                            (Prims.of_int (407))
+                                                            (Prims.of_int (424))
                                                             (Prims.of_int (32)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_Effect.tac_bind
@@ -5382,9 +5458,9 @@ let rec (st_term_to_string' :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (399))
+                                                                  (Prims.of_int (416))
                                                                   (Prims.of_int (8))
-                                                                  (Prims.of_int (399))
+                                                                  (Prims.of_int (416))
                                                                   (Prims.of_int (29)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
@@ -5439,13 +5515,13 @@ and (branches_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (412)) (Prims.of_int (13))
-                            (Prims.of_int (412)) (Prims.of_int (31)))))
+                            (Prims.of_int (429)) (Prims.of_int (13))
+                            (Prims.of_int (429)) (Prims.of_int (31)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (412)) (Prims.of_int (13))
-                            (Prims.of_int (412)) (Prims.of_int (55)))))
+                            (Prims.of_int (429)) (Prims.of_int (13))
+                            (Prims.of_int (429)) (Prims.of_int (55)))))
                    (Obj.magic (branch_to_string b))
                    (fun uu___ ->
                       (fun uu___ ->
@@ -5455,9 +5531,9 @@ and (branches_to_string :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Syntax.Printer.fst"
-                                       (Prims.of_int (412))
+                                       (Prims.of_int (429))
                                        (Prims.of_int (34))
-                                       (Prims.of_int (412))
+                                       (Prims.of_int (429))
                                        (Prims.of_int (55)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
@@ -5480,12 +5556,12 @@ and (branch_to_string :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (415)) (Prims.of_int (17)) (Prims.of_int (415))
+               (Prims.of_int (432)) (Prims.of_int (17)) (Prims.of_int (432))
                (Prims.of_int (19)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (414)) (Prims.of_int (35)) (Prims.of_int (418))
+               (Prims.of_int (431)) (Prims.of_int (35)) (Prims.of_int (435))
                (Prims.of_int (29)))))
       (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> br))
       (fun uu___ ->
@@ -5497,13 +5573,13 @@ and (branch_to_string :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (418)) (Prims.of_int (4))
-                              (Prims.of_int (418)) (Prims.of_int (29)))))
+                              (Prims.of_int (435)) (Prims.of_int (4))
+                              (Prims.of_int (435)) (Prims.of_int (29)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (416)) (Prims.of_int (2))
-                              (Prims.of_int (418)) (Prims.of_int (29)))))
+                              (Prims.of_int (433)) (Prims.of_int (2))
+                              (Prims.of_int (435)) (Prims.of_int (29)))))
                      (Obj.magic (st_term_to_string' "" e))
                      (fun uu___1 ->
                         (fun uu___1 ->
@@ -5513,17 +5589,17 @@ and (branch_to_string :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Syntax.Printer.fst"
-                                         (Prims.of_int (416))
+                                         (Prims.of_int (433))
                                          (Prims.of_int (2))
-                                         (Prims.of_int (418))
+                                         (Prims.of_int (435))
                                          (Prims.of_int (29)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Syntax.Printer.fst"
-                                         (Prims.of_int (416))
+                                         (Prims.of_int (433))
                                          (Prims.of_int (2))
-                                         (Prims.of_int (418))
+                                         (Prims.of_int (435))
                                          (Prims.of_int (29)))))
                                 (Obj.magic
                                    (FStar_Tactics_Effect.tac_bind
@@ -5531,9 +5607,9 @@ and (branch_to_string :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (417))
+                                               (Prims.of_int (434))
                                                (Prims.of_int (4))
-                                               (Prims.of_int (417))
+                                               (Prims.of_int (434))
                                                (Prims.of_int (27)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
@@ -5571,8 +5647,8 @@ and (pattern_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (425)) (Prims.of_int (6))
-                            (Prims.of_int (425)) (Prims.of_int (74)))))
+                            (Prims.of_int (442)) (Prims.of_int (6))
+                            (Prims.of_int (442)) (Prims.of_int (74)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -5584,14 +5660,14 @@ and (pattern_to_string :
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Syntax.Printer.fst"
-                                  (Prims.of_int (425)) (Prims.of_int (25))
-                                  (Prims.of_int (425)) (Prims.of_int (73)))))
+                                  (Prims.of_int (442)) (Prims.of_int (25))
+                                  (Prims.of_int (442)) (Prims.of_int (73)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Syntax.Printer.fst"
-                                  (Prims.of_int (425)) (Prims.of_int (6))
-                                  (Prims.of_int (425)) (Prims.of_int (74)))))
+                                  (Prims.of_int (442)) (Prims.of_int (6))
+                                  (Prims.of_int (442)) (Prims.of_int (74)))))
                          (Obj.magic
                             (FStar_Tactics_Util.map
                                (fun uu___ ->
@@ -5688,8 +5764,8 @@ let (tag_of_comp :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (480)) (Prims.of_int (57))
-                            (Prims.of_int (480)) (Prims.of_int (75)))))
+                            (Prims.of_int (497)) (Prims.of_int (57))
+                            (Prims.of_int (497)) (Prims.of_int (75)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -5791,8 +5867,8 @@ let (decl_to_string :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (539)) (Prims.of_int (12))
-                   (Prims.of_int (542)) (Prims.of_int (42)))))
+                   (Prims.of_int (556)) (Prims.of_int (12))
+                   (Prims.of_int (559)) (Prims.of_int (42)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -5803,8 +5879,8 @@ let (decl_to_string :
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                         (Prims.of_int (540)) (Prims.of_int (5))
-                         (Prims.of_int (542)) (Prims.of_int (42)))))
+                         (Prims.of_int (557)) (Prims.of_int (5))
+                         (Prims.of_int (559)) (Prims.of_int (42)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -5815,8 +5891,8 @@ let (decl_to_string :
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                               (Prims.of_int (540)) (Prims.of_int (32))
-                               (Prims.of_int (542)) (Prims.of_int (42)))))
+                               (Prims.of_int (557)) (Prims.of_int (32))
+                               (Prims.of_int (559)) (Prims.of_int (42)))))
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "prims.fst"
@@ -5828,8 +5904,8 @@ let (decl_to_string :
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "Pulse.Syntax.Printer.fst"
-                                     (Prims.of_int (541)) (Prims.of_int (5))
-                                     (Prims.of_int (542)) (Prims.of_int (42)))))
+                                     (Prims.of_int (558)) (Prims.of_int (5))
+                                     (Prims.of_int (559)) (Prims.of_int (42)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range "prims.fst"
@@ -5841,17 +5917,17 @@ let (decl_to_string :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (541))
+                                           (Prims.of_int (558))
                                            (Prims.of_int (5))
-                                           (Prims.of_int (541))
+                                           (Prims.of_int (558))
                                            (Prims.of_int (71)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (541))
+                                           (Prims.of_int (558))
                                            (Prims.of_int (5))
-                                           (Prims.of_int (542))
+                                           (Prims.of_int (559))
                                            (Prims.of_int (42)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -5859,17 +5935,17 @@ let (decl_to_string :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (541))
+                                                 (Prims.of_int (558))
                                                  (Prims.of_int (23))
-                                                 (Prims.of_int (541))
+                                                 (Prims.of_int (558))
                                                  (Prims.of_int (71)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (541))
+                                                 (Prims.of_int (558))
                                                  (Prims.of_int (5))
-                                                 (Prims.of_int (541))
+                                                 (Prims.of_int (558))
                                                  (Prims.of_int (71)))))
                                         (Obj.magic
                                            (FStar_Tactics_Util.map
@@ -5890,9 +5966,9 @@ let (decl_to_string :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Syntax.Printer.fst"
-                                                      (Prims.of_int (542))
+                                                      (Prims.of_int (559))
                                                       (Prims.of_int (6))
-                                                      (Prims.of_int (542))
+                                                      (Prims.of_int (559))
                                                       (Prims.of_int (42)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
@@ -5908,9 +5984,9 @@ let (decl_to_string :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (542))
+                                                            (Prims.of_int (559))
                                                             (Prims.of_int (14))
-                                                            (Prims.of_int (542))
+                                                            (Prims.of_int (559))
                                                             (Prims.of_int (42)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
@@ -5926,9 +6002,9 @@ let (decl_to_string :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (542))
+                                                                  (Prims.of_int (559))
                                                                   (Prims.of_int (14))
-                                                                  (Prims.of_int (542))
+                                                                  (Prims.of_int (559))
                                                                   (Prims.of_int (36)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Pure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Pure.ml
@@ -675,3 +675,89 @@ let rec (inspect_term : FStar_Reflection_Types.term -> term_view) =
     | FStar_Reflection_V2_Data.Tv_Uvar (uu___, uu___1) -> default_view
     | FStar_Reflection_V2_Data.Tv_Unknown -> Tm_Unknown
     | FStar_Reflection_V2_Data.Tv_Unsupp -> default_view
+let rec (vprop_as_list :
+  Pulse_Syntax_Base.term -> Pulse_Syntax_Base.term Prims.list) =
+  fun vp ->
+    match inspect_term vp with
+    | Tm_Emp -> []
+    | Tm_Star (vp0, vp1) ->
+        FStar_List_Tot_Base.append (vprop_as_list vp0) (vprop_as_list vp1)
+    | uu___ -> [vp]
+let rec (list_as_vprop :
+  Pulse_Syntax_Base.term Prims.list -> Pulse_Syntax_Base.term) =
+  fun vps ->
+    match vps with
+    | [] -> tm_emp
+    | hd::[] -> hd
+    | hd::tl -> tm_star hd (list_as_vprop tl)
+let rec (insert1 :
+  Pulse_Syntax_Base.term ->
+    Pulse_Syntax_Base.term Prims.list ->
+      (Pulse_Syntax_Base.term Prims.list, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun uu___1 ->
+    fun uu___ ->
+      (fun t ->
+         fun ts ->
+           match ts with
+           | [] ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> [t])))
+           | t'::ts' ->
+               Obj.magic
+                 (Obj.repr
+                    (if
+                       FStar_Order.le
+                         (FStar_Reflection_V2_Compare.compare_term t t')
+                     then
+                       Obj.repr
+                         (FStar_Tactics_Effect.lift_div_tac
+                            (fun uu___ -> t :: ts))
+                     else
+                       Obj.repr
+                         (FStar_Tactics_Effect.tac_bind
+                            (FStar_Sealed.seal
+                               (Obj.magic
+                                  (FStar_Range.mk_range
+                                     "Pulse.Syntax.Pure.fst"
+                                     (Prims.of_int (482)) (Prims.of_int (13))
+                                     (Prims.of_int (482)) (Prims.of_int (26)))))
+                            (FStar_Sealed.seal
+                               (Obj.magic
+                                  (FStar_Range.mk_range
+                                     "Pulse.Syntax.Pure.fst"
+                                     (Prims.of_int (482)) (Prims.of_int (9))
+                                     (Prims.of_int (482)) (Prims.of_int (26)))))
+                            (Obj.magic (insert1 t ts'))
+                            (fun uu___1 ->
+                               FStar_Tactics_Effect.lift_div_tac
+                                 (fun uu___2 -> t' :: uu___1)))))) uu___1
+        uu___
+let (sort_terms :
+  Pulse_Syntax_Base.term Prims.list ->
+    (Pulse_Syntax_Base.term Prims.list, unit) FStar_Tactics_Effect.tac_repr)
+  = fun ts -> FStar_Tactics_Util.fold_right insert1 ts []
+let (canon_vprop_list_print :
+  Pulse_Syntax_Base.term Prims.list ->
+    (Pulse_Syntax_Base.term, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun vs ->
+    FStar_Tactics_Effect.tac_bind
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "Pulse.Syntax.Pure.fst"
+               (Prims.of_int (491)) (Prims.of_int (21)) (Prims.of_int (491))
+               (Prims.of_int (34)))))
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "Pulse.Syntax.Pure.fst"
+               (Prims.of_int (491)) (Prims.of_int (4)) (Prims.of_int (491))
+               (Prims.of_int (34))))) (Obj.magic (sort_terms vs))
+      (fun uu___ ->
+         FStar_Tactics_Effect.lift_div_tac
+           (fun uu___1 -> list_as_vprop uu___))
+let (canon_vprop_print :
+  Pulse_Syntax_Base.term ->
+    (Pulse_Syntax_Base.term, unit) FStar_Tactics_Effect.tac_repr)
+  = fun vp -> canon_vprop_list_print (vprop_as_list vp)

--- a/src/ocaml/plugin/generated/Pulse_Typing_Combinators.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_Combinators.ml
@@ -3416,21 +3416,6 @@ let (apply_frame :
 type ('g, 'ctxt, 'postuhint) st_typing_in_ctxt =
   (Pulse_Syntax_Base.st_term, Pulse_Syntax_Base.comp_st,
     (unit, unit, unit) Pulse_Typing.st_typing) FStar_Pervasives.dtuple3
-let rec (vprop_as_list :
-  Pulse_Syntax_Base.term -> Pulse_Syntax_Base.term Prims.list) =
-  fun vp ->
-    match Pulse_Syntax_Pure.inspect_term vp with
-    | Pulse_Syntax_Pure.Tm_Emp -> []
-    | Pulse_Syntax_Pure.Tm_Star (vp0, vp1) ->
-        FStar_List_Tot_Base.op_At (vprop_as_list vp0) (vprop_as_list vp1)
-    | uu___ -> [vp]
-let rec (list_as_vprop :
-  Pulse_Syntax_Base.term Prims.list -> Pulse_Syntax_Base.term) =
-  fun vps ->
-    match vps with
-    | [] -> Pulse_Syntax_Pure.tm_emp
-    | hd::[] -> hd
-    | hd::tl -> Pulse_Syntax_Pure.tm_star hd (list_as_vprop tl)
 let (comp_for_post_hint :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.vprop ->


### PR DESCRIPTION
1- make sure to print one resource per line (unless they all fit in a single line)
2- sort the resources (only at the top level! arguments to combinators will _not_ be sorted) to bring similar things together

The example from #96 goes from
```
- Current context:
    gpu_pts_to_array gr (reveal s) **
    cpu **
    A.pts_to a2 (reveal s) **
    gpu_pts_to_array ga2 (reveal s) **
    pts_to i (reveal v) **
    A.pts_to ar (Seq.Base.create (SZ.v (SZ.uint_to_t size)) 0) **
    A.pts_to a1 (reveal s) ** gpu_pts_to_array ga1 (reveal s)
```
to
```
- Current context:
    cpu **
    A.pts_to a1 (reveal s) **
    A.pts_to a2 (reveal s) **
    A.pts_to ar (Seq.Base.create (SZ.v (SZ.uint_to_t size)) 0) **
    pts_to i (reveal v) **
    gpu_pts_to_array ga1 (reveal s) **
    gpu_pts_to_array ga2 (reveal s) **
    gpu_pts_to_array gr (reveal s)
```

Fixes #96