### PR TITLE
Support for val declarations (in Pulse syntax)

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.Reference.fst
+++ b/lib/pulse/lib/Pulse.Lib.Reference.fst
@@ -31,23 +31,26 @@ let pts_to
 let pts_to_is_small r p x = H.pts_to_is_small r p (U.raise_val x)
 
 ```pulse
-fn alloc' (#a:Type u#0) (v:a)
-requires emp
-returns r:ref a
-ensures pts_to r v
+fn alloc (#a:Type u#0) (v:a)
+  requires emp
+  returns r:ref a
+  ensures pts_to r v
 {
   let r = H.alloc (U.raise_val v);
   fold (pts_to r #1.0R v);
   r
 }
 ```
-let alloc v = alloc' v
 
 ```pulse
-fn read (#a:Type) (r:ref a) (#n:erased a) (#p:perm)
-requires pts_to r #p n
-returns x:a
-ensures pts_to r #p n ** pure (eq2 #a (reveal n) x)
+fn op_Bang
+  (#a:Type)
+  (r:ref a)
+  (#n:erased a)
+  (#p:perm)
+  requires pts_to r #p n
+  returns x:a
+  ensures pts_to r #p n ** pure (eq2 #a (reveal n) x)
 {
   unfold (pts_to r #p n);
   let k = H.( !r );
@@ -55,22 +58,24 @@ ensures pts_to r #p n ** pure (eq2 #a (reveal n) x)
   U.downgrade_val k
 }
 ```
-let ( ! ) #a r #n #p = read #a r #n #p
 
 ```pulse
-fn write (#a:Type) (r:ref a) (x:a) (#n:erased a)
-requires pts_to r #1.0R n
-ensures pts_to r #1.0R x
+fn op_Colon_Equals
+  (#a:Type)
+  (r:ref a)
+  (x:a)
+  (#n:erased a)
+  requires pts_to r #1.0R n
+  ensures pts_to r #1.0R x
 {
   unfold (pts_to r #1.0R n);
   H.(r := (U.raise_val x));
   fold (pts_to r #1.0R x)
 }
 ```
-let ( := ) #a r x #n = write #a r x #n
 
 ```pulse
-fn free' #a (r:ref a) (#n:erased a)
+fn free #a (r:ref a) (#n:erased a)
 requires pts_to r #1.0R n
 ensures emp
 {
@@ -78,11 +83,10 @@ ensures emp
   H.free r;
 }
 ```
-let free = free'
 
 ```pulse
 ghost
-fn share' (#a:Type) (r:ref a) (#v:erased a) (#p:perm)
+fn share (#a:Type) (r:ref a) (#v:erased a) (#p:perm)
 requires pts_to r #p v
 ensures pts_to r #(p /. 2.0R) v ** pts_to r #(p /. 2.0R) v
 {
@@ -92,7 +96,6 @@ ensures pts_to r #(p /. 2.0R) v ** pts_to r #(p /. 2.0R) v
   fold pts_to r #(p /. 2.0R) v
 }
 ```
-let share = share'
 
 ```pulse
 ghost
@@ -107,7 +110,7 @@ ensures pure (x0 == x1)
 
 ```pulse
 ghost
-fn gather' (#a:Type) (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
+fn gather (#a:Type) (r:ref a) (#x0 #x1:erased a) (#p0 #p1:perm)
 requires pts_to r #p0 x0 ** pts_to r #p1 x1
 ensures pts_to r #(p0 +. p1) x0 ** pure (x0 == x1)
 {
@@ -118,7 +121,6 @@ ensures pts_to r #(p0 +. p1) x0 ** pure (x0 == x1)
   raise_inj a x0 x1;
 }
 ```
-let gather = gather'
 
 let share2 (#a:Type) (r:ref a) (#v:erased a)
 : stt_ghost unit emp_inames
@@ -172,7 +174,7 @@ let with_local
 
 ```pulse
 ghost
-fn pts_to_injective_eq'
+fn pts_to_injective_eq
   (#a:Type0)
   (#p #q:perm)
   (#v0 #v1:a)
@@ -190,11 +192,10 @@ ensures
   raise_inj _ v0 v1;
 }
 ```
-let pts_to_injective_eq = pts_to_injective_eq'
 
 ```pulse
 ghost
-fn pts_to_perm_bound' (#a:_) (#p:_) (r:ref a) (#v:a)
+fn pts_to_perm_bound (#a:_) (#p:_) (r:ref a) (#v:a)
 requires pts_to r #p v
 ensures pts_to r #p v ** pure (p <=. 1.0R)
 {
@@ -203,10 +204,9 @@ ensures pts_to r #p v ** pure (p <=. 1.0R)
   fold pts_to r #p v;
 }
 ```
-let pts_to_perm_bound = pts_to_perm_bound'
 
 ```pulse
-fn replace' (#a:Type0) (r:ref a) (x:a) (#v:erased a)
+fn replace (#a:Type0) (r:ref a) (x:a) (#v:erased a)
   requires pts_to r v
   returns y:a
   ensures pts_to r x ** pure (y == reveal v)
@@ -216,5 +216,3 @@ fn replace' (#a:Type0) (r:ref a) (x:a) (#v:erased a)
   y
 }
 ```
-
-let replace = replace'

--- a/share/pulse/examples/Val.fst
+++ b/share/pulse/examples/Val.fst
@@ -1,0 +1,14 @@
+module Val
+
+open Pulse.Lib.Pervasives
+
+```pulse
+fn foo ()
+  requires emp
+  ensures emp
+{
+  ()
+}
+```
+
+let x = foo()

--- a/share/pulse/examples/Val.fsti
+++ b/share/pulse/examples/Val.fsti
@@ -1,0 +1,9 @@
+module Val
+
+open Pulse.Lib.Pervasives
+
+```pulse
+val fn foo ()
+  requires emp
+  ensures emp
+```

--- a/src/Makefile
+++ b/src/Makefile
@@ -72,7 +72,7 @@ boot:
 
 .PHONY: boot-checker
 boot-checker:
-	+$(MAKE) extract-checker
+	+$(MAKE) extract-syntax-extension extract-checker
 	+$(MAKE) build-ocaml
 
 .PHONY: clean-snapshot

--- a/src/checker/Pulse.Checker.Admit.fst
+++ b/src/checker/Pulse.Checker.Admit.fst
@@ -78,7 +78,9 @@ let check
   FStar.Tactics.BreakVC.break_vc ();
   // ^ This makes a big difference! Would be good to distill into
   // a smaller F*-only example and file an issue.
-  (if T.ide () then begin
+  let ide = T.ide () in
+  let no_admit_diag = T.ext_getv "pulse:no_admit_diag" = "1" in
+  (if ide && not no_admit_diag then begin
     (* If we're running interactively, print out the context
     and environment. *)
     let open FStar.Stubs.Pprint in

--- a/src/checker/Pulse.Main.fst
+++ b/src/checker/Pulse.Main.fst
@@ -193,7 +193,12 @@ let check_fndecl
   in
   let body = mk_abs g bs body comp in
   let rng = body.range in
-  let (| _, c, t_typing |) = Pulse.Checker.Abs.check_abs g body Pulse.Checker.check in
+  let (| _, c, t_typing |) =
+    (* We don't want to print the diagnostic for the admit in the body. *)
+    RU.with_extv "pulse:no_admit_diag" "1" (fun () ->
+      Pulse.Checker.Abs.check_abs g body Pulse.Checker.check
+    )
+  in
   let typ = elab_comp c in
   let se : sigelt =
     pack_sigelt <|

--- a/src/checker/Pulse.Main.fst
+++ b/src/checker/Pulse.Main.fst
@@ -55,16 +55,17 @@ let rec mk_abs (g:env) (qbs:list (option qualifier & binder & bv)) (body:st_term
     with_range (Pulse.Syntax.Builder.tm_abs b q empty_ascription body) body.range
 
 #push-options "--z3rlimit_factor 4"
-let check_fndecl
-    (d : decl{FnDecl? d.d})
+let check_fndefn
+    (d : decl{FnDefn? d.d})
     (g : Soundness.Common.stt_env{bindings g == []})
     (expected_t : option term)
+    (* Both of these unused: *)
     (pre : term) (pre_typing : tot_typing g pre tm_vprop)
   : T.Tac (RT.dsl_tac_result_t (fstar_env g) expected_t)
 = 
 
   (* Maybe add a recursive knot before starting *)
-  let FnDecl fn_d = d.d in
+  let FnDefn fn_d = d.d in
   let nm_orig = fst (inspect_ident fn_d.id) in // keep the original name
   let d =
     if fn_d.isrec
@@ -72,11 +73,11 @@ let check_fndecl
     else d
   in
 
-  let FnDecl { id; isrec; bs; comp; meas; body } = d.d in
+  let FnDefn { id; isrec; bs; comp; meas; body } = d.d in
   let nm_aux = fst (inspect_ident id) in
 
   if Nil? bs then
-    fail g (Some d.range) "main: FnDecl does not have binders";
+    fail g (Some d.range) "main: FnDefn does not have binders";
   let body = mk_abs g bs body comp in
   let rng = body.range in
   debug_main g (fun _ -> Printf.sprintf "\nbody after mk_abs:\n%s\n" (P.st_term_to_string body));
@@ -177,8 +178,8 @@ let main' (nm:string) (d:decl) (pre:term) (g:RT.fstar_top_env) (expected_t:optio
         fail g (Some (Pulse.RuntimeUtils.range_of_term pre)) "pulse main: cannot typecheck pre at type vprop"; //fix range
       let pre_typing : tot_typing g pre tm_vprop = pre_typing in
       match d.d with
-      | FnDecl _ ->
-        check_fndecl d g expected_t pre pre_typing
+      | FnDefn _ ->
+        check_fndefn d g expected_t pre pre_typing
 
 let join_smt_goals () : Tac unit =
   let open FStar.Tactics.V2 in

--- a/src/checker/Pulse.Main.fst
+++ b/src/checker/Pulse.Main.fst
@@ -166,6 +166,14 @@ let check_fndefn
     [], main_decl, []
   end
 
+let check_fndecl
+    (d : decl{FnDecl? d.d})
+    (g : Soundness.Common.stt_env{bindings g == []})
+    (expected_t : option term)
+  : T.Tac (RT.dsl_tac_result_t (fstar_env g) expected_t)
+=
+  T.fail "FnDecl not implemented yet"
+
 let main' (nm:string) (d:decl) (pre:term) (g:RT.fstar_top_env) (expected_t:option term)
   : T.Tac (RT.dsl_tac_result_t g expected_t)
   = match Pulse.Soundness.Common.check_top_level_environment g with
@@ -178,8 +186,8 @@ let main' (nm:string) (d:decl) (pre:term) (g:RT.fstar_top_env) (expected_t:optio
         fail g (Some (Pulse.RuntimeUtils.range_of_term pre)) "pulse main: cannot typecheck pre at type vprop"; //fix range
       let pre_typing : tot_typing g pre tm_vprop = pre_typing in
       match d.d with
-      | FnDefn _ ->
-        check_fndefn d g expected_t pre pre_typing
+      | FnDefn {} -> check_fndefn d g expected_t pre pre_typing
+      | FnDecl {} -> check_fndecl d g expected_t
 
 let join_smt_goals () : Tac unit =
   let open FStar.Tactics.V2 in

--- a/src/checker/Pulse.Recursion.fst
+++ b/src/checker/Pulse.Recursion.fst
@@ -80,12 +80,12 @@ let elab_b (qbv : option qualifier & binder & bv) : Tot Tactics.NamedView.binder
   }
 
 let add_knot (g : env) (rng : R.range)
-             (d : decl{FnDecl? d.d})
-: Tac decl
+             (d : decl{FnDefn? d.d})
+: Tac (d : decl{FnDefn? d.d})
 =
-  let FnDecl { id; isrec; bs; comp; meas; body } = d.d in
+  let FnDefn { id; isrec; bs; comp; meas; body } = d.d in
   if Nil? bs then
-    fail g (Some d.range) "main: FnDecl does not have binders";
+    fail g (Some d.range) "main: FnDefn does not have binders";
   (* NB: bs and comp are open *)
   let r_res = elab_comp comp in
   debug_main g
@@ -200,7 +200,7 @@ let add_knot (g : env) (rng : R.range)
   (* NB: body and comp unchanged, they are already shifted properly
      (we dropped one binder and added one) *)
   { d with d =
-    FnDecl { id=id'; isrec=false; bs=bs'; comp; meas=None; body }
+    FnDefn { id=id'; isrec=false; bs=bs'; comp; meas=None; body }
   }
 
 let tie_knot (g : env)

--- a/src/checker/Pulse.Recursion.fsti
+++ b/src/checker/Pulse.Recursion.fsti
@@ -24,8 +24,8 @@ open Pulse.Syntax
 open Pulse.Typing
 
 val add_knot (g : env)  (rng : R.range)
-             (d : decl)
-: Tac decl
+             (d : decl{FnDefn? d.d})
+: Tac (d:decl{FnDefn? d.d})
 
 val tie_knot (g : env)  (rng : R.range)
              (nm_orig : string) (nm_aux : string)

--- a/src/checker/Pulse.RuntimeUtils.fsti
+++ b/src/checker/Pulse.RuntimeUtils.fsti
@@ -20,6 +20,7 @@ module T = FStar.Tactics
 type context = FStar.Sealed.Inhabited.sealed #(list (string & option range)) []
 val extend_context (tag:string) (r:option range) (ctx:context) : context
 val with_context (c:context) (f:unit -> T.Tac 'a) : T.Tac 'a
+val with_extv (k v : string) (f:unit -> T.Tac 'a) : T.Tac 'a
 val disable_admit_smt_queries (f:unit -> T.Tac 'a) : T.Tac 'a
 val print_context (c:context) : T.Tac string
 val debug_at_level_no_module (s:string) : bool

--- a/src/checker/Pulse.Syntax.Base.fsti
+++ b/src/checker/Pulse.Syntax.Base.fsti
@@ -302,18 +302,21 @@ and st_term = {
 and branch = pattern & st_term
 
 noeq
+type fn_defn = {
+  (* A function definition. This will be mostly checked as a nested
+  Tm_Abs with bs and body, especially if non-recursive. *)
+  id : R.ident;
+  isrec : bool;
+  bs : list (option qualifier & binder & bv);
+  comp : comp; (* bs in scope *)
+  meas : (meas:option term{Some? meas ==> isrec}); (* bs in scope *)
+  body : st_term; (* bs in scope *)
+}
+
+noeq
 type decl' =
-  | FnDecl {
-      (* A function declaration, currently the only Pulse
-      top-level decl. This will be mostly checked as a nested
-      Tm_Abs with bs and body, especially if non-recursive. *)
-      id : R.ident;
-      isrec : bool;
-      bs : list (option qualifier & binder & bv);
-      comp : comp; (* bs in scope *)
-      meas : (meas:option term{Some? meas ==> isrec}); (* bs in scope *)
-      body : st_term; (* bs in scope *)
-  }
+  | FnDefn of fn_defn
+
 and decl = {
   d : decl';
   range : range;

--- a/src/checker/Pulse.Syntax.Base.fsti
+++ b/src/checker/Pulse.Syntax.Base.fsti
@@ -318,7 +318,7 @@ type fn_decl = {
   (* A function declaration, without a body. *)
   id : R.ident;
   bs : list (option qualifier & binder & bv);
-  comp : comp; (* bs in scope *)
+  comp : comp_st; (* bs in scope *)
 }
 
 noeq

--- a/src/checker/Pulse.Syntax.Base.fsti
+++ b/src/checker/Pulse.Syntax.Base.fsti
@@ -314,8 +314,17 @@ type fn_defn = {
 }
 
 noeq
+type fn_decl = {
+  (* A function declaration, without a body. *)
+  id : R.ident;
+  bs : list (option qualifier & binder & bv);
+  comp : comp; (* bs in scope *)
+}
+
+noeq
 type decl' =
   | FnDefn of fn_defn
+  | FnDecl of fn_decl
 
 and decl = {
   d : decl';

--- a/src/checker/Pulse.Syntax.Builder.fst
+++ b/src/checker/Pulse.Syntax.Builder.fst
@@ -62,4 +62,5 @@ let mk_fold_hint_type names p = FOLD { names; p }
 let mk_rename_hint_type pairs goal tac_opt = RENAME { pairs; goal; tac_opt=map_opt tac_opt thunk }
 let mk_rewrite_hint_type t1 t2 tac_opt = REWRITE { t1; t2; tac_opt=map_opt tac_opt thunk }
 let mk_fn_defn id isrec bs comp meas body : decl' = FnDefn { id; isrec; bs; comp; meas; body }
+let mk_fn_decl id bs comp : decl' = FnDecl { id; bs; comp; }
 let mk_decl d range : decl = {d; range}

--- a/src/checker/Pulse.Syntax.Builder.fst
+++ b/src/checker/Pulse.Syntax.Builder.fst
@@ -61,5 +61,5 @@ let mk_unfold_hint_type names p = UNFOLD { names; p }
 let mk_fold_hint_type names p = FOLD { names; p }
 let mk_rename_hint_type pairs goal tac_opt = RENAME { pairs; goal; tac_opt=map_opt tac_opt thunk }
 let mk_rewrite_hint_type t1 t2 tac_opt = REWRITE { t1; t2; tac_opt=map_opt tac_opt thunk }
-let mk_fn_decl id isrec bs comp meas body : decl' = FnDecl { id; isrec; bs; comp; meas; body }
+let mk_fn_defn id isrec bs comp meas body : decl' = FnDefn { id; isrec; bs; comp; meas; body }
 let mk_decl d range : decl = {d; range}

--- a/src/checker/Pulse.Syntax.Printer.fst
+++ b/src/checker/Pulse.Syntax.Printer.fst
@@ -567,3 +567,7 @@ let decl_to_string (d:decl) : T.Tac string =
      fst (R.inspect_ident id) ^ " " ^ 
      String.concat " " (T.map (fun (_, b, _) -> binder_to_string b) bs) ^
       " { " ^ st_term_to_string body ^ "}"
+  | FnDecl {id; bs} ->
+    "val fn " ^
+    fst (R.inspect_ident id) ^ " " ^
+    String.concat " " (T.map (fun (_, b, _) -> binder_to_string b) bs)

--- a/src/checker/Pulse.Syntax.Printer.fst
+++ b/src/checker/Pulse.Syntax.Printer.fst
@@ -562,7 +562,7 @@ let rec print_skel (t:st_term) =
 
 let decl_to_string (d:decl) : T.Tac string =
   match d.d with
-  | FnDecl {id; isrec; bs; body} ->
+  | FnDefn {id; isrec; bs; body} ->
     "fn " ^ (if isrec then "rec " else "") ^
      fst (R.inspect_ident id) ^ " " ^ 
      String.concat " " (T.map (fun (_, b, _) -> binder_to_string b) bs) ^

--- a/src/ocaml/plugin/PulseSyntaxExtension_SyntaxWrapper.ml
+++ b/src/ocaml/plugin/PulseSyntaxExtension_SyntaxWrapper.ml
@@ -251,5 +251,5 @@ let subst_st_term s t = Pulse_Syntax_Naming.subst_st_term t s
 let subst_proof_hint s t = Pulse_Syntax_Naming.subst_proof_hint t s
 
 
-let fn_decl rng id isrec bs comp meas body =
-  PSB.mk_decl (PSB.mk_fn_decl id isrec bs comp meas body) rng
+let fn_defn rng id isrec bs comp meas body =
+  PSB.mk_decl (PSB.mk_fn_defn id isrec bs comp meas body) rng

--- a/src/ocaml/plugin/PulseSyntaxExtension_SyntaxWrapper.ml
+++ b/src/ocaml/plugin/PulseSyntaxExtension_SyntaxWrapper.ml
@@ -253,5 +253,5 @@ let subst_proof_hint s t = Pulse_Syntax_Naming.subst_proof_hint t s
 
 let fn_defn rng id isrec bs comp meas body =
   PSB.mk_decl (PSB.mk_fn_defn id isrec bs comp meas body) rng
-let fn_decl rng id isrec bs comp meas body =
+let fn_decl rng id bs comp =
   PSB.mk_decl (PSB.mk_fn_decl id bs comp) rng

--- a/src/ocaml/plugin/PulseSyntaxExtension_SyntaxWrapper.ml
+++ b/src/ocaml/plugin/PulseSyntaxExtension_SyntaxWrapper.ml
@@ -253,3 +253,5 @@ let subst_proof_hint s t = Pulse_Syntax_Naming.subst_proof_hint t s
 
 let fn_defn rng id isrec bs comp meas body =
   PSB.mk_decl (PSB.mk_fn_defn id isrec bs comp meas body) rng
+let fn_decl rng id isrec bs comp meas body =
+  PSB.mk_decl (PSB.mk_fn_decl id bs comp) rng

--- a/src/ocaml/plugin/Pulse_RuntimeUtils.ml
+++ b/src/ocaml/plugin/Pulse_RuntimeUtils.ml
@@ -27,6 +27,17 @@ let disable_admit_smt_queries (f: unit -> 'a utac) : 'a utac =
       FStar_Options.set_option "admit_smt_queries" (FStar_Options.Bool false);
       f () ps
     )
+let with_extv (k:string) (v:string) (f: unit -> 'a utac) : 'a utac =
+  fun ps ->
+    let open FStar_Options in
+    with_saved_options (fun _ ->
+      let v0 = get_option "ext" in
+      let v1 = match v0 with
+               | List l0 -> List (String (k^"="^v) :: l0)
+      in
+      set_option "ext" v1;
+      f () ps
+    )
 let env_set_context (g:FStar_Reflection_Types.env) (c:context) = g
 let print_exn (e:exn) = Printexc.to_string e
 let debug_at_level_no_module (s:string) =

--- a/src/ocaml/plugin/generated/PulseSyntaxExtension_Desugar.ml
+++ b/src/ocaml/plugin/generated/PulseSyntaxExtension_Desugar.ml
@@ -3005,7 +3005,7 @@ and (desugar_decl :
                                                      uu___4)) uu___4)))
                                 uu___1))) uu___3 uu___2 uu___1 uu___ in
            match d with
-           | PulseSyntaxExtension_Sugar.FnDecl
+           | PulseSyntaxExtension_Sugar.FnDefn
                { PulseSyntaxExtension_Sugar.id2 = id;
                  PulseSyntaxExtension_Sugar.is_rec = is_rec;
                  PulseSyntaxExtension_Sugar.binders2 = binders;
@@ -3236,7 +3236,7 @@ and (desugar_decl :
                                                                     qbs in
                                                                     let uu___11
                                                                     =
-                                                                    PulseSyntaxExtension_SyntaxWrapper.fn_decl
+                                                                    PulseSyntaxExtension_SyntaxWrapper.fn_defn
                                                                     range id
                                                                     is_rec
                                                                     qbs comp
@@ -3252,7 +3252,7 @@ and (desugar_decl :
                                                                   uu___6)))
                                                        uu___5))) uu___3)))
                          uu___1))
-           | PulseSyntaxExtension_Sugar.FnDecl
+           | PulseSyntaxExtension_Sugar.FnDefn
                { PulseSyntaxExtension_Sugar.id2 = id;
                  PulseSyntaxExtension_Sugar.is_rec = false;
                  PulseSyntaxExtension_Sugar.binders2 = binders;
@@ -3333,7 +3333,7 @@ and (desugar_decl :
                                                                  Obj.magic
                                                                    qbs in
                                                                let uu___5 =
-                                                                 PulseSyntaxExtension_SyntaxWrapper.fn_decl
+                                                                 PulseSyntaxExtension_SyntaxWrapper.fn_defn
                                                                    range id
                                                                    false qbs
                                                                    comp
@@ -3343,8 +3343,50 @@ and (desugar_decl :
                                                                  (PulseSyntaxExtension_Err.return
                                                                     uu___5))
                                                               uu___5)))
-                                                   uu___4))) uu___3))) uu___1)))
-        uu___1 uu___
+                                                   uu___4))) uu___3))) uu___1))
+           | PulseSyntaxExtension_Sugar.FnDecl
+               { PulseSyntaxExtension_Sugar.id3 = id;
+                 PulseSyntaxExtension_Sugar.binders3 = binders;
+                 PulseSyntaxExtension_Sugar.ascription2 =
+                   FStar_Pervasives.Inl ascription;
+                 PulseSyntaxExtension_Sugar.range4 = range;_}
+               ->
+               let uu___ = desugar_binders env binders in
+               Obj.magic
+                 (FStar_Class_Monad.op_let_Bang
+                    PulseSyntaxExtension_Err.err_monad () ()
+                    (Obj.magic uu___)
+                    (fun uu___1 ->
+                       (fun uu___1 ->
+                          let uu___1 = Obj.magic uu___1 in
+                          match uu___1 with
+                          | (env1, bs, bvs) ->
+                              let uu___2 =
+                                desugar_computation_type env1 ascription in
+                              Obj.magic
+                                (FStar_Class_Monad.op_let_Bang
+                                   PulseSyntaxExtension_Err.err_monad () ()
+                                   (Obj.magic uu___2)
+                                   (fun uu___3 ->
+                                      (fun comp ->
+                                         let comp = Obj.magic comp in
+                                         let uu___3 =
+                                           PulseSyntaxExtension_Err.map2 faux
+                                             bs bvs in
+                                         Obj.magic
+                                           (FStar_Class_Monad.op_let_Bang
+                                              PulseSyntaxExtension_Err.err_monad
+                                              () () (Obj.magic uu___3)
+                                              (fun uu___4 ->
+                                                 (fun qbs ->
+                                                    let qbs = Obj.magic qbs in
+                                                    let uu___4 =
+                                                      PulseSyntaxExtension_SyntaxWrapper.fn_decl
+                                                        range id qbs comp in
+                                                    Obj.magic
+                                                      (PulseSyntaxExtension_Err.return
+                                                         uu___4)) uu___4)))
+                                        uu___3))) uu___1))) uu___1 uu___
 let (initialize_env :
   FStar_TypeChecker_Env.env ->
     PulseSyntaxExtension_Env.name Prims.list ->

--- a/src/ocaml/plugin/generated/PulseSyntaxExtension_Sugar.ml
+++ b/src/ocaml/plugin/generated/PulseSyntaxExtension_Sugar.ml
@@ -250,7 +250,7 @@ and lambda =
   ascription: computation_type FStar_Pervasives_Native.option ;
   body2: stmt ;
   range2: rng }
-and fn_decl =
+and fn_defn =
   {
   id2: FStar_Ident.ident ;
   is_rec: Prims.bool ;
@@ -265,7 +265,7 @@ and fn_decl =
 and let_init =
   | Array_initializer of array_init 
   | Default_initializer of FStar_Parser_AST.term 
-  | Lambda_initializer of fn_decl 
+  | Lambda_initializer of fn_defn 
   | Stmt_initializer of stmt 
 let (__proj__Mkstmt'__Expr__payload__item__e :
   stmt'__Expr__payload -> FStar_Parser_AST.term) =
@@ -503,23 +503,23 @@ let (__proj__Mklambda__item__range : lambda -> rng) =
   fun projectee ->
     match projectee with
     | { binders1; ascription; body2 = body; range2 = range;_} -> range
-let (__proj__Mkfn_decl__item__id : fn_decl -> FStar_Ident.ident) =
+let (__proj__Mkfn_defn__item__id : fn_defn -> FStar_Ident.ident) =
   fun projectee ->
     match projectee with
     | { id2 = id; is_rec; binders2 = binders1; ascription1 = ascription;
         measure; body3 = body; range3 = range;_} -> id
-let (__proj__Mkfn_decl__item__is_rec : fn_decl -> Prims.bool) =
+let (__proj__Mkfn_defn__item__is_rec : fn_defn -> Prims.bool) =
   fun projectee ->
     match projectee with
     | { id2 = id; is_rec; binders2 = binders1; ascription1 = ascription;
         measure; body3 = body; range3 = range;_} -> is_rec
-let (__proj__Mkfn_decl__item__binders : fn_decl -> binders) =
+let (__proj__Mkfn_defn__item__binders : fn_defn -> binders) =
   fun projectee ->
     match projectee with
     | { id2 = id; is_rec; binders2 = binders1; ascription1 = ascription;
         measure; body3 = body; range3 = range;_} -> binders1
-let (__proj__Mkfn_decl__item__ascription :
-  fn_decl ->
+let (__proj__Mkfn_defn__item__ascription :
+  fn_defn ->
     (computation_type, FStar_Parser_AST.term FStar_Pervasives_Native.option)
       FStar_Pervasives.either)
   =
@@ -527,19 +527,19 @@ let (__proj__Mkfn_decl__item__ascription :
     match projectee with
     | { id2 = id; is_rec; binders2 = binders1; ascription1 = ascription;
         measure; body3 = body; range3 = range;_} -> ascription
-let (__proj__Mkfn_decl__item__measure :
-  fn_decl -> FStar_Parser_AST.term FStar_Pervasives_Native.option) =
+let (__proj__Mkfn_defn__item__measure :
+  fn_defn -> FStar_Parser_AST.term FStar_Pervasives_Native.option) =
   fun projectee ->
     match projectee with
     | { id2 = id; is_rec; binders2 = binders1; ascription1 = ascription;
         measure; body3 = body; range3 = range;_} -> measure
-let (__proj__Mkfn_decl__item__body :
-  fn_decl -> (stmt, lambda) FStar_Pervasives.either) =
+let (__proj__Mkfn_defn__item__body :
+  fn_defn -> (stmt, lambda) FStar_Pervasives.either) =
   fun projectee ->
     match projectee with
     | { id2 = id; is_rec; binders2 = binders1; ascription1 = ascription;
         measure; body3 = body; range3 = range;_} -> body
-let (__proj__Mkfn_decl__item__range : fn_decl -> rng) =
+let (__proj__Mkfn_defn__item__range : fn_defn -> rng) =
   fun projectee ->
     match projectee with
     | { id2 = id; is_rec; binders2 = binders1; ascription1 = ascription;
@@ -558,13 +558,46 @@ let (__proj__Default_initializer__item___0 :
 let (uu___is_Lambda_initializer : let_init -> Prims.bool) =
   fun projectee ->
     match projectee with | Lambda_initializer _0 -> true | uu___ -> false
-let (__proj__Lambda_initializer__item___0 : let_init -> fn_decl) =
+let (__proj__Lambda_initializer__item___0 : let_init -> fn_defn) =
   fun projectee -> match projectee with | Lambda_initializer _0 -> _0
 let (uu___is_Stmt_initializer : let_init -> Prims.bool) =
   fun projectee ->
     match projectee with | Stmt_initializer _0 -> true | uu___ -> false
 let (__proj__Stmt_initializer__item___0 : let_init -> stmt) =
   fun projectee -> match projectee with | Stmt_initializer _0 -> _0
+type fn_decl =
+  {
+  id3: FStar_Ident.ident ;
+  binders3: binders ;
+  ascription2:
+    (computation_type, FStar_Parser_AST.term FStar_Pervasives_Native.option)
+      FStar_Pervasives.either
+    ;
+  range4: rng }
+let (__proj__Mkfn_decl__item__id : fn_decl -> FStar_Ident.ident) =
+  fun projectee ->
+    match projectee with
+    | { id3 = id; binders3 = binders1; ascription2 = ascription;
+        range4 = range;_} -> id
+let (__proj__Mkfn_decl__item__binders : fn_decl -> binders) =
+  fun projectee ->
+    match projectee with
+    | { id3 = id; binders3 = binders1; ascription2 = ascription;
+        range4 = range;_} -> binders1
+let (__proj__Mkfn_decl__item__ascription :
+  fn_decl ->
+    (computation_type, FStar_Parser_AST.term FStar_Pervasives_Native.option)
+      FStar_Pervasives.either)
+  =
+  fun projectee ->
+    match projectee with
+    | { id3 = id; binders3 = binders1; ascription2 = ascription;
+        range4 = range;_} -> ascription
+let (__proj__Mkfn_decl__item__range : fn_decl -> rng) =
+  fun projectee ->
+    match projectee with
+    | { id3 = id; binders3 = binders1; ascription2 = ascription;
+        range4 = range;_} -> range
 let (tag_of_stmt : stmt -> Prims.string) =
   fun s ->
     match s.s with
@@ -597,8 +630,14 @@ let (tag_of_stmt : stmt -> Prims.string) =
     | WithInvariants { names = uu___; body1 = uu___1; returns_ = uu___2;_} ->
         "WithInvariants"
 type decl =
+  | FnDefn of fn_defn 
   | FnDecl of fn_decl 
-let (uu___is_FnDecl : decl -> Prims.bool) = fun projectee -> true
+let (uu___is_FnDefn : decl -> Prims.bool) =
+  fun projectee -> match projectee with | FnDefn _0 -> true | uu___ -> false
+let (__proj__FnDefn__item___0 : decl -> fn_defn) =
+  fun projectee -> match projectee with | FnDefn _0 -> _0
+let (uu___is_FnDecl : decl -> Prims.bool) =
+  fun projectee -> match projectee with | FnDecl _0 -> true | uu___ -> false
 let (__proj__FnDecl__item___0 : decl -> fn_decl) =
   fun projectee -> match projectee with | FnDecl _0 -> _0
 let (mk_comp :
@@ -672,7 +711,7 @@ let (mk_sequence : stmt -> stmt -> stmt') =
   fun s1 -> fun s2 -> Sequence { s1; s2 }
 let (mk_stmt : stmt' -> rng -> stmt) =
   fun s -> fun range -> { s; range1 = range }
-let (mk_fn_decl :
+let (mk_fn_defn :
   FStar_Ident.ident ->
     Prims.bool ->
       binders ->
@@ -680,7 +719,7 @@ let (mk_fn_decl :
           FStar_Parser_AST.term FStar_Pervasives_Native.option)
           FStar_Pervasives.either ->
           FStar_Parser_AST.term FStar_Pervasives_Native.option ->
-            (stmt, lambda) FStar_Pervasives.either -> rng -> fn_decl)
+            (stmt, lambda) FStar_Pervasives.either -> rng -> fn_defn)
   =
   fun id ->
     fun is_rec ->
@@ -698,6 +737,23 @@ let (mk_fn_decl :
                   body3 = body;
                   range3 = range
                 }
+let (mk_fn_decl :
+  FStar_Ident.ident ->
+    binders ->
+      (computation_type,
+        FStar_Parser_AST.term FStar_Pervasives_Native.option)
+        FStar_Pervasives.either -> rng -> fn_decl)
+  =
+  fun id ->
+    fun binders1 ->
+      fun ascription ->
+        fun range ->
+          {
+            id3 = id;
+            binders3 = binders1;
+            ascription2 = ascription;
+            range4 = range
+          }
 let (mk_open : FStar_Ident.lident -> stmt') = fun lid -> Open lid
 let (mk_par : vprop -> vprop -> vprop -> vprop -> stmt -> stmt -> stmt') =
   fun p1 ->

--- a/src/ocaml/plugin/generated/Pulse_Checker_Admit.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Admit.ml
@@ -25,7 +25,7 @@ let (check :
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Admit.fst"
                          (Prims.of_int (39)) (Prims.of_int (25))
-                         (Prims.of_int (94)) (Prims.of_int (55)))))
+                         (Prims.of_int (96)) (Prims.of_int (55)))))
                 (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> t))
                 (fun uu___ ->
                    (fun t0 ->
@@ -42,7 +42,7 @@ let (check :
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Admit.fst"
                                     (Prims.of_int (40)) (Prims.of_int (66))
-                                    (Prims.of_int (94)) (Prims.of_int (55)))))
+                                    (Prims.of_int (96)) (Prims.of_int (55)))))
                            (FStar_Tactics_Effect.lift_div_tac
                               (fun uu___ ->
                                  Pulse_Typing_Env.push_context g
@@ -65,7 +65,7 @@ let (check :
                                                "Pulse.Checker.Admit.fst"
                                                (Prims.of_int (40))
                                                (Prims.of_int (66))
-                                               (Prims.of_int (94))
+                                               (Prims.of_int (96))
                                                (Prims.of_int (55)))))
                                       (FStar_Tactics_Effect.lift_div_tac
                                          (fun uu___ ->
@@ -97,7 +97,7 @@ let (check :
                                                               "Pulse.Checker.Admit.fst"
                                                               (Prims.of_int (44))
                                                               (Prims.of_int (20))
-                                                              (Prims.of_int (94))
+                                                              (Prims.of_int (96))
                                                               (Prims.of_int (55)))))
                                                      (FStar_Tactics_Effect.lift_div_tac
                                                         (fun uu___2 ->
@@ -121,7 +121,7 @@ let (check :
                                                                     "Pulse.Checker.Admit.fst"
                                                                     (Prims.of_int (45))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (96))
                                                                     (Prims.of_int (55)))))
                                                                 (FStar_Tactics_Effect.lift_div_tac
                                                                    (fun
@@ -147,7 +147,7 @@ let (check :
                                                                     "Pulse.Checker.Admit.fst"
                                                                     (Prims.of_int (75))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (96))
                                                                     (Prims.of_int (55)))))
                                                                     (match 
                                                                     (post,
@@ -570,7 +570,7 @@ let (check :
                                                                     "Pulse.Checker.Admit.fst"
                                                                     (Prims.of_int (75))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (96))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -602,7 +602,7 @@ let (check :
                                                                     "Pulse.Checker.Admit.fst"
                                                                     (Prims.of_int (78))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (96))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -627,9 +627,9 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (81))
-                                                                    (Prims.of_int (2))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (78))
+                                                                    (Prims.of_int (36))
+                                                                    (Prims.of_int (96))
                                                                     (Prims.of_int (55)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_BreakVC.break_vc
@@ -645,16 +645,41 @@ let (check :
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
                                                                     (Prims.of_int (81))
-                                                                    (Prims.of_int (2))
-                                                                    (Prims.of_int (93))
-                                                                    (Prims.of_int (28)))))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (81))
+                                                                    (Prims.of_int (20)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (81))
+                                                                    (Prims.of_int (23))
+                                                                    (Prims.of_int (96))
+                                                                    (Prims.of_int (55)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Builtins.ide
+                                                                    ()))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    (fun ide
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Admit.fst"
+                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (60)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Admit.fst"
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (96))
                                                                     (Prims.of_int (55)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -662,26 +687,55 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (81))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (81))
-                                                                    (Prims.of_int (14)))))
+                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (81))
-                                                                    (Prims.of_int (2))
-                                                                    (Prims.of_int (93))
-                                                                    (Prims.of_int (14)))))
+                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (60)))))
                                                                     (Obj.magic
-                                                                    (FStar_Tactics_V2_Builtins.ide
-                                                                    ()))
+                                                                    (FStar_Tactics_V2_Builtins.ext_getv
+                                                                    "pulse:no_admit_diag"))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    uu___4 =
+                                                                    "1"))))
                                                                     (fun
                                                                     uu___4 ->
                                                                     (fun
-                                                                    uu___4 ->
-                                                                    if uu___4
+                                                                    no_admit_diag
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Admit.fst"
+                                                                    (Prims.of_int (83))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (28)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Admit.fst"
+                                                                    (Prims.of_int (96))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (96))
+                                                                    (Prims.of_int (55)))))
+                                                                    (if
+                                                                    ide &&
+                                                                    (Prims.op_Negation
+                                                                    no_admit_diag)
                                                                     then
                                                                     Obj.magic
                                                                     (Obj.repr
@@ -690,17 +744,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (88))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (88))
                                                                     (Prims.of_int (91)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (88))
                                                                     (Prims.of_int (94))
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (94))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.norm_well_typed_term
@@ -711,7 +765,7 @@ let (check :
                                                                     FStar_Pervasives.iota]
                                                                     pre))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___4 ->
                                                                     (fun pre1
                                                                     ->
                                                                     Obj.magic
@@ -720,17 +774,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (87))
+                                                                    (Prims.of_int (89))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (91))
+                                                                    (Prims.of_int (93))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (94))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (94))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -738,35 +792,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (87))
+                                                                    (Prims.of_int (89))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (91))
+                                                                    (Prims.of_int (93))
                                                                     (Prims.of_int (5)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (87))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (91))
-                                                                    (Prims.of_int (5)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
                                                                     (Prims.of_int (89))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (90))
-                                                                    (Prims.of_int (44)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (87))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (91))
+                                                                    (Prims.of_int (93))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -774,17 +810,35 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (91))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (44)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Admit.fst"
+                                                                    (Prims.of_int (89))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (5)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Admit.fst"
+                                                                    (Prims.of_int (92))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (92))
                                                                     (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (89))
+                                                                    (Prims.of_int (91))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (92))
                                                                     (Prims.of_int (44)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -792,17 +846,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (92))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (92))
                                                                     (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (92))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (92))
                                                                     (Prims.of_int (44)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -810,62 +864,62 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (92))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (92))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Admit.fst"
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (92))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (92))
                                                                     (Prims.of_int (44)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Pure.canon_vprop_print
                                                                     pre1))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___4 ->
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___4 ->
                                                                     Obj.magic
                                                                     (Pulse_PP.pp
                                                                     Pulse_PP.printable_term
-                                                                    uu___5))
-                                                                    uu___5)))
+                                                                    uu___4))
+                                                                    uu___4)))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___4 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___5 ->
                                                                     Pulse_PP.indent
-                                                                    uu___5))))
+                                                                    uu___4))))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___4 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___5 ->
                                                                     FStar_Pprint.op_Hat_Hat
                                                                     (Pulse_PP.text
                                                                     "Current context:")
-                                                                    uu___5))))
+                                                                    uu___4))))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___4 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___6 ->
-                                                                    [uu___5]))))
-                                                                    (fun
                                                                     uu___5 ->
+                                                                    [uu___4]))))
+                                                                    (fun
+                                                                    uu___4 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___5 ->
                                                                     (Pulse_PP.text
                                                                     "Admitting continuation.")
-                                                                    :: uu___5))))
+                                                                    :: uu___4))))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___4 ->
                                                                     (fun msg
                                                                     ->
                                                                     Obj.magic
@@ -874,16 +928,15 @@ let (check :
                                                                     (FStar_Pervasives_Native.Some
                                                                     (t0.Pulse_Syntax_Base.range1))
                                                                     msg))
-                                                                    uu___5)))
-                                                                    uu___5)))
+                                                                    uu___4)))
+                                                                    uu___4)))
                                                                     else
                                                                     Obj.magic
                                                                     (Obj.repr
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___5 ->
                                                                     ()))))
-                                                                    uu___4)))
                                                                     (fun
                                                                     uu___4 ->
                                                                     (fun
@@ -917,6 +970,8 @@ let (check :
                                                                     })), c1,
                                                                     d))
                                                                     res_ppname))
+                                                                    uu___4)))
+                                                                    uu___4)))
                                                                     uu___4)))
                                                                     uu___3)))
                                                                     uu___3)))

--- a/src/ocaml/plugin/generated/Pulse_Main.ml
+++ b/src/ocaml/plugin/generated/Pulse_Main.ml
@@ -122,7 +122,7 @@ let rec (mk_abs :
                                            body1
                                            bv.Pulse_Syntax_Base.bv_index).Pulse_Syntax_Base.range1)))))
                  uu___)
-let (check_fndecl :
+let (check_fndefn :
   Pulse_Syntax_Base.decl ->
     Pulse_Soundness_Common.stt_env ->
       Pulse_Syntax_Base.term FStar_Pervasives_Native.option ->
@@ -140,31 +140,31 @@ let (check_fndecl :
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Main.fst"
-                       (Prims.of_int (67)) (Prims.of_int (20))
-                       (Prims.of_int (67)) (Prims.of_int (23)))))
+                       (Prims.of_int (68)) (Prims.of_int (20))
+                       (Prims.of_int (68)) (Prims.of_int (23)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Main.fst"
-                       (Prims.of_int (64)) Prims.int_one (Prims.of_int (166))
+                       (Prims.of_int (65)) Prims.int_one (Prims.of_int (167))
                        (Prims.of_int (5)))))
               (FStar_Tactics_Effect.lift_div_tac
                  (fun uu___ -> d.Pulse_Syntax_Base.d))
               (fun uu___ ->
                  (fun uu___ ->
                     match uu___ with
-                    | Pulse_Syntax_Base.FnDecl fn_d ->
+                    | Pulse_Syntax_Base.FnDefn fn_d ->
                         Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range "Pulse.Main.fst"
-                                      (Prims.of_int (68)) (Prims.of_int (16))
-                                      (Prims.of_int (68)) (Prims.of_int (43)))))
+                                      (Prims.of_int (69)) (Prims.of_int (16))
+                                      (Prims.of_int (69)) (Prims.of_int (43)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range "Pulse.Main.fst"
-                                      (Prims.of_int (68)) (Prims.of_int (46))
-                                      (Prims.of_int (166)) (Prims.of_int (5)))))
+                                      (Prims.of_int (69)) (Prims.of_int (46))
+                                      (Prims.of_int (167)) (Prims.of_int (5)))))
                              (FStar_Tactics_Effect.lift_div_tac
                                 (fun uu___1 ->
                                    FStar_Pervasives_Native.fst
@@ -178,17 +178,17 @@ let (check_fndecl :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Main.fst"
-                                                 (Prims.of_int (70))
+                                                 (Prims.of_int (71))
                                                  (Prims.of_int (4))
-                                                 (Prims.of_int (72))
+                                                 (Prims.of_int (73))
                                                  (Prims.of_int (10)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Main.fst"
-                                                 (Prims.of_int (73))
+                                                 (Prims.of_int (74))
                                                  (Prims.of_int (4))
-                                                 (Prims.of_int (166))
+                                                 (Prims.of_int (167))
                                                  (Prims.of_int (5)))))
                                         (if fn_d.Pulse_Syntax_Base.isrec
                                          then
@@ -210,17 +210,17 @@ let (check_fndecl :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Main.fst"
-                                                            (Prims.of_int (75))
+                                                            (Prims.of_int (76))
                                                             (Prims.of_int (51))
-                                                            (Prims.of_int (75))
+                                                            (Prims.of_int (76))
                                                             (Prims.of_int (54)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Main.fst"
-                                                            (Prims.of_int (73))
+                                                            (Prims.of_int (74))
                                                             (Prims.of_int (4))
-                                                            (Prims.of_int (166))
+                                                            (Prims.of_int (167))
                                                             (Prims.of_int (5)))))
                                                    (FStar_Tactics_Effect.lift_div_tac
                                                       (fun uu___1 ->
@@ -228,7 +228,7 @@ let (check_fndecl :
                                                    (fun uu___1 ->
                                                       (fun uu___1 ->
                                                          match uu___1 with
-                                                         | Pulse_Syntax_Base.FnDecl
+                                                         | Pulse_Syntax_Base.FnDefn
                                                              {
                                                                Pulse_Syntax_Base.id
                                                                  = id;
@@ -249,17 +249,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (76))
+                                                                    (Prims.of_int (77))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (76))
+                                                                    (Prims.of_int (77))
                                                                     (Prims.of_int (37)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (78))
+                                                                    (Prims.of_int (79))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (5)))))
                                                                   (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -277,17 +277,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (78))
-                                                                    (Prims.of_int (2))
                                                                     (Prims.of_int (79))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (80))
                                                                     (Prims.of_int (62)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (79))
+                                                                    (Prims.of_int (80))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (5)))))
                                                                     (if
                                                                     Prims.uu___is_Nil
@@ -299,7 +299,7 @@ let (check_fndecl :
                                                                     g
                                                                     (FStar_Pervasives_Native.Some
                                                                     (d1.Pulse_Syntax_Base.range2))
-                                                                    "main: FnDecl does not have binders"))
+                                                                    "main: FnDefn does not have binders"))
                                                                     else
                                                                     Obj.magic
                                                                     (Obj.repr
@@ -317,17 +317,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (37))
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (mk_abs g
@@ -343,17 +343,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (81))
+                                                                    (Prims.of_int (82))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (81))
+                                                                    (Prims.of_int (82))
                                                                     (Prims.of_int (22)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -369,17 +369,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (96)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (97))
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug_main
@@ -391,9 +391,9 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (95)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -426,17 +426,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (84))
+                                                                    (Prims.of_int (85))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (84))
+                                                                    (Prims.of_int (85))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (97))
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Abs.check_abs
@@ -460,17 +460,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (86))
+                                                                    (Prims.of_int (87))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (89))
+                                                                    (Prims.of_int (90))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (91))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover_Util.debug_prover
@@ -482,17 +482,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (89))
+                                                                    (Prims.of_int (90))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (89))
+                                                                    (Prims.of_int (90))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (87))
+                                                                    (Prims.of_int (88))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (89))
+                                                                    (Prims.of_int (90))
                                                                     (Prims.of_int (34)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.comp_to_string
@@ -507,17 +507,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (87))
+                                                                    (Prims.of_int (88))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (89))
+                                                                    (Prims.of_int (90))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (87))
+                                                                    (Prims.of_int (88))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (89))
+                                                                    (Prims.of_int (90))
                                                                     (Prims.of_int (34)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -525,9 +525,9 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (88))
+                                                                    (Prims.of_int (89))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (88))
+                                                                    (Prims.of_int (89))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -572,17 +572,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (91))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (94))
                                                                     (Prims.of_int (62)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (94))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug_main
@@ -594,17 +594,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (94))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (94))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (91))
+                                                                    (Prims.of_int (92))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (94))
                                                                     (Prims.of_int (61)))))
                                                                     (Obj.magic
                                                                     (Pulse_Typing_Printer.print_st_typing
@@ -620,17 +620,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (91))
+                                                                    (Prims.of_int (92))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (94))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (91))
+                                                                    (Prims.of_int (92))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (94))
                                                                     (Prims.of_int (61)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -638,9 +638,9 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (93))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (93))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -685,17 +685,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (96))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (96))
                                                                     (Prims.of_int (26)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (96))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -712,17 +712,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (97))
+                                                                    (Prims.of_int (98))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (97))
+                                                                    (Prims.of_int (98))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (97))
+                                                                    (Prims.of_int (98))
                                                                     (Prims.of_int (90))
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -741,17 +741,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (98))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (98))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (99))
+                                                                    (Prims.of_int (100))
                                                                     (Prims.of_int (36))
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -768,17 +768,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (102))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (102))
                                                                     (Prims.of_int (64)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (102))
                                                                     (Prims.of_int (67))
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -786,17 +786,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (102))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (102))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (102))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (102))
                                                                     (Prims.of_int (64)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.ext_getv
@@ -819,17 +819,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (102))
+                                                                    (Prims.of_int (103))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (102))
+                                                                    (Prims.of_int (103))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (102))
+                                                                    (Prims.of_int (103))
                                                                     (Prims.of_int (37))
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.cur_module
@@ -845,17 +845,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (106))
+                                                                    (Prims.of_int (107))
                                                                     (Prims.of_int (78))
-                                                                    (Prims.of_int (110))
+                                                                    (Prims.of_int (111))
                                                                     (Prims.of_int (105)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (113))
+                                                                    (Prims.of_int (114))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (166))
+                                                                    (Prims.of_int (167))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -870,17 +870,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (107))
+                                                                    (Prims.of_int (108))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (107))
+                                                                    (Prims.of_int (108))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (108))
+                                                                    (Prims.of_int (109))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (110))
+                                                                    (Prims.of_int (111))
                                                                     (Prims.of_int (105)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -933,17 +933,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (122))
+                                                                    (Prims.of_int (123))
                                                                     (Prims.of_int (45))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (35)))))
                                                                     (Obj.magic
                                                                     (mk_main_decl
@@ -959,17 +959,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (124))
                                                                     (Prims.of_int (54))
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (124))
                                                                     (Prims.of_int (63)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (124))
                                                                     (Prims.of_int (66))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -986,17 +986,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (124))
+                                                                    (Prims.of_int (125))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (124))
+                                                                    (Prims.of_int (125))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (124))
                                                                     (Prims.of_int (66))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1018,17 +1018,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (125))
+                                                                    (Prims.of_int (126))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (125))
+                                                                    (Prims.of_int (126))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (125))
+                                                                    (Prims.of_int (126))
                                                                     (Prims.of_int (59))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1047,17 +1047,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (126))
+                                                                    (Prims.of_int (127))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (126))
+                                                                    (Prims.of_int (127))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (126))
+                                                                    (Prims.of_int (127))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1091,17 +1091,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (127))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (127))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (127))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (60))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1131,17 +1131,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (129))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (129))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (129))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1158,17 +1158,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (129))
+                                                                    (Prims.of_int (130))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (129))
+                                                                    (Prims.of_int (130))
                                                                     (Prims.of_int (53)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (129))
+                                                                    (Prims.of_int (130))
                                                                     (Prims.of_int (56))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1186,17 +1186,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1216,17 +1216,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (132))
+                                                                    (Prims.of_int (133))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (132))
+                                                                    (Prims.of_int (133))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (35)))))
                                                                     (Obj.magic
                                                                     (Pulse_Recursion.tie_knot
@@ -1260,17 +1260,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (144))
+                                                                    (Prims.of_int (145))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (19)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (135))
+                                                                    (Prims.of_int (136))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (165))
+                                                                    (Prims.of_int (166))
                                                                     (Prims.of_int (21)))))
                                                                     (match expected_t
                                                                     with
@@ -1295,17 +1295,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (148))
+                                                                    (Prims.of_int (149))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (148))
+                                                                    (Prims.of_int (149))
                                                                     (Prims.of_int (63)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (19)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_subtyping
@@ -1335,17 +1335,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (161))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (165))
+                                                                    (Prims.of_int (166))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (161))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (165))
+                                                                    (Prims.of_int (166))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1363,17 +1363,17 @@ let (check_fndecl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (163))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (163))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (163))
                                                                     (Prims.of_int (45))
-                                                                    (Prims.of_int (165))
+                                                                    (Prims.of_int (166))
                                                                     (Prims.of_int (21)))))
                                                                     (Obj.magic
                                                                     (mk_main_decl
@@ -1415,6 +1415,420 @@ let (check_fndecl :
                                                                     uu___2)))
                                                         uu___1))) uu___1)))
                                   uu___1))) uu___)
+let (check_fndecl :
+  Pulse_Syntax_Base.decl ->
+    Pulse_Soundness_Common.stt_env ->
+      ((unit, unit) FStar_Reflection_Typing.dsl_tac_result_t, unit)
+        FStar_Tactics_Effect.tac_repr)
+  =
+  fun d ->
+    fun g ->
+      FStar_Tactics_Effect.tac_bind
+        (FStar_Sealed.seal
+           (Obj.magic
+              (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (174))
+                 (Prims.of_int (32)) (Prims.of_int (174)) (Prims.of_int (35)))))
+        (FStar_Sealed.seal
+           (Obj.magic
+              (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (173))
+                 Prims.int_one (Prims.of_int (211)) (Prims.of_int (29)))))
+        (FStar_Tactics_Effect.lift_div_tac
+           (fun uu___ -> d.Pulse_Syntax_Base.d))
+        (fun uu___ ->
+           (fun uu___ ->
+              match uu___ with
+              | Pulse_Syntax_Base.FnDecl
+                  { Pulse_Syntax_Base.id1 = id; Pulse_Syntax_Base.bs1 = bs;
+                    Pulse_Syntax_Base.comp1 = comp;_}
+                  ->
+                  Obj.magic
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Main.fst"
+                                (Prims.of_int (175)) (Prims.of_int (2))
+                                (Prims.of_int (176)) (Prims.of_int (62)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range "Pulse.Main.fst"
+                                (Prims.of_int (176)) (Prims.of_int (63))
+                                (Prims.of_int (211)) (Prims.of_int (29)))))
+                       (if Prims.uu___is_Nil bs
+                        then
+                          Obj.magic
+                            (Obj.repr
+                               (Pulse_Typing_Env.fail g
+                                  (FStar_Pervasives_Native.Some
+                                     (d.Pulse_Syntax_Base.range2))
+                                  "main: FnDecl does not have binders"))
+                        else
+                          Obj.magic
+                            (Obj.repr
+                               (FStar_Tactics_Effect.lift_div_tac
+                                  (fun uu___2 -> ()))))
+                       (fun uu___1 ->
+                          (fun uu___1 ->
+                             Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Main.fst"
+                                           (Prims.of_int (178))
+                                           (Prims.of_int (11))
+                                           (Prims.of_int (178))
+                                           (Prims.of_int (33)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "Pulse.Main.fst"
+                                           (Prims.of_int (178))
+                                           (Prims.of_int (36))
+                                           (Prims.of_int (211))
+                                           (Prims.of_int (29)))))
+                                  (FStar_Tactics_Effect.lift_div_tac
+                                     (fun uu___2 ->
+                                        FStar_Pervasives_Native.fst
+                                          (FStar_Reflection_V2_Builtins.inspect_ident
+                                             id)))
+                                  (fun uu___2 ->
+                                     (fun nm ->
+                                        Obj.magic
+                                          (FStar_Tactics_Effect.tac_bind
+                                             (FStar_Sealed.seal
+                                                (Obj.magic
+                                                   (FStar_Range.mk_range
+                                                      "Pulse.Main.fst"
+                                                      (Prims.of_int (179))
+                                                      (Prims.of_int (12))
+                                                      (Prims.of_int (179))
+                                                      (Prims.of_int (32)))))
+                                             (FStar_Sealed.seal
+                                                (Obj.magic
+                                                   (FStar_Range.mk_range
+                                                      "Pulse.Main.fst"
+                                                      (Prims.of_int (179))
+                                                      (Prims.of_int (35))
+                                                      (Prims.of_int (211))
+                                                      (Prims.of_int (29)))))
+                                             (FStar_Tactics_Effect.lift_div_tac
+                                                (fun uu___2 ->
+                                                   Pulse_Syntax_Base.st_comp_of_comp
+                                                     comp))
+                                             (fun uu___2 ->
+                                                (fun stc ->
+                                                   Obj.magic
+                                                     (FStar_Tactics_Effect.tac_bind
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Main.fst"
+                                                                 (Prims.of_int (184))
+                                                                 (Prims.of_int (4))
+                                                                 (Prims.of_int (191))
+                                                                 (Prims.of_int (27)))))
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Main.fst"
+                                                                 (Prims.of_int (193))
+                                                                 (Prims.of_int (4))
+                                                                 (Prims.of_int (211))
+                                                                 (Prims.of_int (29)))))
+                                                        (FStar_Tactics_Effect.lift_div_tac
+                                                           (fun uu___2 ->
+                                                              {
+                                                                Pulse_Syntax_Base.term1
+                                                                  =
+                                                                  (Pulse_Syntax_Base.Tm_Admit
+                                                                    {
+                                                                    Pulse_Syntax_Base.ctag
+                                                                    =
+                                                                    (Pulse_Syntax_Base.ctag_of_comp_st
+                                                                    comp);
+                                                                    Pulse_Syntax_Base.u1
+                                                                    =
+                                                                    (stc.Pulse_Syntax_Base.u);
+                                                                    Pulse_Syntax_Base.typ
+                                                                    =
+                                                                    (stc.Pulse_Syntax_Base.res);
+                                                                    Pulse_Syntax_Base.post3
+                                                                    =
+                                                                    FStar_Pervasives_Native.None
+                                                                    });
+                                                                Pulse_Syntax_Base.range1
+                                                                  =
+                                                                  (d.Pulse_Syntax_Base.range2);
+                                                                Pulse_Syntax_Base.effect_tag
+                                                                  =
+                                                                  (FStar_Sealed.seal
+                                                                    FStar_Pervasives_Native.None)
+                                                              }))
+                                                        (fun uu___2 ->
+                                                           (fun body ->
+                                                              Obj.magic
+                                                                (FStar_Tactics_Effect.tac_bind
+                                                                   (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (194))
+                                                                    (Prims.of_int (13))
+                                                                    (Prims.of_int (194))
+                                                                    (Prims.of_int (34)))))
+                                                                   (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (194))
+                                                                    (Prims.of_int (37))
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (29)))))
+                                                                   (Obj.magic
+                                                                    (mk_abs g
+                                                                    bs body
+                                                                    comp))
+                                                                   (fun
+                                                                    uu___2 ->
+                                                                    (fun
+                                                                    body1 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (22)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (29)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    body1.Pulse_Syntax_Base.range1))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun rng
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (5)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (29)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_RuntimeUtils.with_extv
+                                                                    "pulse:no_admit_diag"
+                                                                    "1"
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    Pulse_Checker_Abs.check_abs
+                                                                    g body1
+                                                                    Pulse_Checker.check)))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    match uu___2
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives.Mkdtuple3
+                                                                    (uu___3,
+                                                                    c,
+                                                                    t_typing)
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (202))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (202))
+                                                                    (Prims.of_int (23)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (202))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (29)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    Pulse_Elaborate_Pure.elab_comp
+                                                                    c))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    (fun typ
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (204))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (5)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (29)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (205))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (5)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (204))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (5)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (208))
+                                                                    (Prims.of_int (15)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (205))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (5)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (11))
+                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (31)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (208))
+                                                                    (Prims.of_int (15)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (11))
+                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (24)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Main.fst"
+                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (11))
+                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (31)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Derived.cur_module
+                                                                    ()))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    FStar_List_Tot_Base.append
+                                                                    uu___4
+                                                                    [nm]))))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    {
+                                                                    FStar_Tactics_NamedView.nm1
+                                                                    = uu___4;
+                                                                    FStar_Tactics_NamedView.univs2
+                                                                    = [];
+                                                                    FStar_Tactics_NamedView.typ1
+                                                                    = typ
+                                                                    }))))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    FStar_Tactics_NamedView.Sg_Val
+                                                                    uu___4))))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_NamedView.pack_sigelt
+                                                                    uu___4))
+                                                                    uu___4)))
+                                                                    (fun se
+                                                                    ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    ([],
+                                                                    (false,
+                                                                    se,
+                                                                    FStar_Pervasives_Native.None),
+                                                                    [])))))
+                                                                    uu___4)))
+                                                                    uu___2)))
+                                                                    uu___2)))
+                                                                    uu___2)))
+                                                             uu___2))) uu___2)))
+                                       uu___2))) uu___1))) uu___)
 let (main' :
   Prims.string ->
     Pulse_Syntax_Base.decl ->
@@ -1450,18 +1864,18 @@ let (main' :
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Main.fst"
-                                            (Prims.of_int (173))
+                                            (Prims.of_int (218))
                                             (Prims.of_int (6))
-                                            (Prims.of_int (174))
+                                            (Prims.of_int (219))
                                             (Prims.of_int (88)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Main.fst"
-                                            (Prims.of_int (174))
+                                            (Prims.of_int (219))
                                             (Prims.of_int (89))
-                                            (Prims.of_int (181))
-                                            (Prims.of_int (50)))))
+                                            (Prims.of_int (230))
+                                            (Prims.of_int (82)))))
                                    (if
                                       Pulse_RuntimeUtils.debug_at_level
                                         (Pulse_Typing_Env.fstar_env g1)
@@ -1474,17 +1888,17 @@ let (main' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Main.fst"
-                                                       (Prims.of_int (174))
+                                                       (Prims.of_int (219))
                                                        (Prims.of_int (16))
-                                                       (Prims.of_int (174))
+                                                       (Prims.of_int (219))
                                                        (Prims.of_int (88)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Main.fst"
-                                                       (Prims.of_int (174))
+                                                       (Prims.of_int (219))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (174))
+                                                       (Prims.of_int (219))
                                                        (Prims.of_int (88)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -1492,9 +1906,9 @@ let (main' :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Main.fst"
-                                                             (Prims.of_int (174))
+                                                             (Prims.of_int (219))
                                                              (Prims.of_int (67))
-                                                             (Prims.of_int (174))
+                                                             (Prims.of_int (219))
                                                              (Prims.of_int (87)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
@@ -1532,18 +1946,18 @@ let (main' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Main.fst"
-                                                       (Prims.of_int (175))
+                                                       (Prims.of_int (220))
                                                        (Prims.of_int (38))
-                                                       (Prims.of_int (175))
+                                                       (Prims.of_int (220))
                                                        (Prims.of_int (84)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Main.fst"
-                                                       (Prims.of_int (174))
+                                                       (Prims.of_int (219))
                                                        (Prims.of_int (89))
-                                                       (Prims.of_int (181))
-                                                       (Prims.of_int (50)))))
+                                                       (Prims.of_int (230))
+                                                       (Prims.of_int (82)))))
                                               (Obj.magic
                                                  (Pulse_Checker_Pure.compute_tot_term_type
                                                     g1 pre))
@@ -1560,18 +1974,18 @@ let (main' :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (176))
+                                                                    (Prims.of_int (221))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (222))
                                                                     (Prims.of_int (109)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (177))
+                                                                    (Prims.of_int (222))
                                                                     (Prims.of_int (110))
-                                                                    (Prims.of_int (181))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (82)))))
                                                              (if
                                                                 Prims.op_Negation
                                                                   (Pulse_Syntax_Base.eq_tm
@@ -1602,18 +2016,18 @@ let (main' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (223))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (223))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (181))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (82)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___3 ->
@@ -1627,13 +2041,50 @@ let (main' :
                                                                     d.Pulse_Syntax_Base.d
                                                                     with
                                                                     | 
-                                                                    Pulse_Syntax_Base.FnDecl
-                                                                    uu___3 ->
+                                                                    Pulse_Syntax_Base.FnDefn
+                                                                    {
+                                                                    Pulse_Syntax_Base.id
+                                                                    = uu___3;
+                                                                    Pulse_Syntax_Base.isrec
+                                                                    = uu___4;
+                                                                    Pulse_Syntax_Base.bs
+                                                                    = uu___5;
+                                                                    Pulse_Syntax_Base.comp
+                                                                    = uu___6;
+                                                                    Pulse_Syntax_Base.meas
+                                                                    = uu___7;
+                                                                    Pulse_Syntax_Base.body7
+                                                                    = uu___8;_}
+                                                                    ->
                                                                     Obj.magic
-                                                                    (check_fndecl
+                                                                    (check_fndefn
                                                                     d g1
                                                                     expected_t
-                                                                    pre1 ()))
+                                                                    pre1 ())
+                                                                    | 
+                                                                    Pulse_Syntax_Base.FnDecl
+                                                                    {
+                                                                    Pulse_Syntax_Base.id1
+                                                                    = uu___3;
+                                                                    Pulse_Syntax_Base.bs1
+                                                                    = uu___4;
+                                                                    Pulse_Syntax_Base.comp1
+                                                                    = uu___5;_}
+                                                                    ->
+                                                                    if
+                                                                    FStar_Pervasives_Native.uu___is_None
+                                                                    expected_t
+                                                                    then
+                                                                    Obj.magic
+                                                                    (check_fndecl
+                                                                    d g1)
+                                                                    else
+                                                                    Obj.magic
+                                                                    (Pulse_Typing_Env.fail
+                                                                    g1
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    (d.Pulse_Syntax_Base.range2))
+                                                                    "pulse main: expected type provided for a FnDecl?"))
                                                                     uu___3)))
                                                                   uu___2)))
                                                    uu___1))) uu___)))) uu___4
@@ -1643,36 +2094,36 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
     FStar_Tactics_Effect.tac_bind
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (187))
-               (Prims.of_int (2)) (Prims.of_int (188)) (Prims.of_int (35)))))
+            (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (236))
+               (Prims.of_int (2)) (Prims.of_int (237)) (Prims.of_int (35)))))
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (188))
-               (Prims.of_int (36)) (Prims.of_int (209)) (Prims.of_int (4)))))
+            (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (237))
+               (Prims.of_int (36)) (Prims.of_int (258)) (Prims.of_int (4)))))
       (Obj.magic
          (FStar_Tactics_Effect.tac_bind
             (FStar_Sealed.seal
                (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (187))
-                     (Prims.of_int (5)) (Prims.of_int (187))
+                  (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (236))
+                     (Prims.of_int (5)) (Prims.of_int (236))
                      (Prims.of_int (48)))))
             (FStar_Sealed.seal
                (Obj.magic
-                  (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (187))
-                     (Prims.of_int (2)) (Prims.of_int (188))
+                  (FStar_Range.mk_range "Pulse.Main.fst" (Prims.of_int (236))
+                     (Prims.of_int (2)) (Prims.of_int (237))
                      (Prims.of_int (35)))))
             (Obj.magic
                (FStar_Tactics_Effect.tac_bind
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Main.fst"
-                           (Prims.of_int (187)) (Prims.of_int (23))
-                           (Prims.of_int (187)) (Prims.of_int (35)))))
+                           (Prims.of_int (236)) (Prims.of_int (23))
+                           (Prims.of_int (236)) (Prims.of_int (35)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Main.fst"
-                           (Prims.of_int (187)) (Prims.of_int (5))
-                           (Prims.of_int (187)) (Prims.of_int (48)))))
+                           (Prims.of_int (236)) (Prims.of_int (5))
+                           (Prims.of_int (236)) (Prims.of_int (48)))))
                   (Obj.magic (FStar_Tactics_V2_Builtins.top_env ()))
                   (fun uu___1 ->
                      FStar_Tactics_Effect.lift_div_tac
@@ -1699,13 +2150,13 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "Pulse.Main.fst"
-                          (Prims.of_int (191)) (Prims.of_int (18))
-                          (Prims.of_int (191)) (Prims.of_int (30)))))
+                          (Prims.of_int (240)) (Prims.of_int (18))
+                          (Prims.of_int (240)) (Prims.of_int (30)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "Pulse.Main.fst"
-                          (Prims.of_int (192)) (Prims.of_int (2))
-                          (Prims.of_int (209)) (Prims.of_int (4)))))
+                          (Prims.of_int (241)) (Prims.of_int (2))
+                          (Prims.of_int (258)) (Prims.of_int (4)))))
                  (Obj.magic (FStar_Tactics_V2_Derived.smt_goals ()))
                  (fun uu___2 ->
                     (fun smt_goals ->
@@ -1714,30 +2165,30 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range "Pulse.Main.fst"
-                                     (Prims.of_int (192)) (Prims.of_int (2))
-                                     (Prims.of_int (192)) (Prims.of_int (34)))))
+                                     (Prims.of_int (241)) (Prims.of_int (2))
+                                     (Prims.of_int (241)) (Prims.of_int (34)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range "Pulse.Main.fst"
-                                     (Prims.of_int (193)) (Prims.of_int (2))
-                                     (Prims.of_int (209)) (Prims.of_int (4)))))
+                                     (Prims.of_int (242)) (Prims.of_int (2))
+                                     (Prims.of_int (258)) (Prims.of_int (4)))))
                             (Obj.magic
                                (FStar_Tactics_Effect.tac_bind
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Main.fst"
-                                           (Prims.of_int (192))
+                                           (Prims.of_int (241))
                                            (Prims.of_int (12))
-                                           (Prims.of_int (192))
+                                           (Prims.of_int (241))
                                            (Prims.of_int (34)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Main.fst"
-                                           (Prims.of_int (192))
+                                           (Prims.of_int (241))
                                            (Prims.of_int (2))
-                                           (Prims.of_int (192))
+                                           (Prims.of_int (241))
                                            (Prims.of_int (34)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -1745,17 +2196,17 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Main.fst"
-                                                 (Prims.of_int (192))
+                                                 (Prims.of_int (241))
                                                  (Prims.of_int (13))
-                                                 (Prims.of_int (192))
+                                                 (Prims.of_int (241))
                                                  (Prims.of_int (21)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Main.fst"
-                                                 (Prims.of_int (192))
+                                                 (Prims.of_int (241))
                                                  (Prims.of_int (12))
-                                                 (Prims.of_int (192))
+                                                 (Prims.of_int (241))
                                                  (Prims.of_int (34)))))
                                         (Obj.magic
                                            (FStar_Tactics_V2_Derived.goals ()))
@@ -1777,17 +2228,17 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Main.fst"
-                                                (Prims.of_int (193))
+                                                (Prims.of_int (242))
                                                 (Prims.of_int (2))
-                                                (Prims.of_int (193))
+                                                (Prims.of_int (242))
                                                 (Prims.of_int (18)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Main.fst"
-                                                (Prims.of_int (193))
+                                                (Prims.of_int (242))
                                                 (Prims.of_int (19))
-                                                (Prims.of_int (209))
+                                                (Prims.of_int (258))
                                                 (Prims.of_int (4)))))
                                        (Obj.magic
                                           (FStar_Tactics_V2_Builtins.set_smt_goals
@@ -1800,17 +2251,17 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Main.fst"
-                                                           (Prims.of_int (194))
+                                                           (Prims.of_int (243))
                                                            (Prims.of_int (10))
-                                                           (Prims.of_int (194))
+                                                           (Prims.of_int (243))
                                                            (Prims.of_int (36)))))
                                                   (FStar_Sealed.seal
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Main.fst"
-                                                           (Prims.of_int (195))
+                                                           (Prims.of_int (244))
                                                            (Prims.of_int (2))
-                                                           (Prims.of_int (209))
+                                                           (Prims.of_int (258))
                                                            (Prims.of_int (4)))))
                                                   (Obj.magic
                                                      (FStar_Tactics_Effect.tac_bind
@@ -1818,17 +2269,17 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Main.fst"
-                                                                 (Prims.of_int (194))
+                                                                 (Prims.of_int (243))
                                                                  (Prims.of_int (26))
-                                                                 (Prims.of_int (194))
+                                                                 (Prims.of_int (243))
                                                                  (Prims.of_int (36)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Main.fst"
-                                                                 (Prims.of_int (194))
+                                                                 (Prims.of_int (243))
                                                                  (Prims.of_int (10))
-                                                                 (Prims.of_int (194))
+                                                                 (Prims.of_int (243))
                                                                  (Prims.of_int (36)))))
                                                         (Obj.magic
                                                            (FStar_Tactics_V2_Derived.goals
@@ -1846,17 +2297,17 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (22)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (4)))))
                                                              (Obj.magic
                                                                 (FStar_Tactics_Effect.tac_bind
@@ -1864,17 +2315,17 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (22)))))
                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (22)))))
                                                                    (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.repeat
@@ -1894,17 +2345,17 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (204))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (3)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (4)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1912,17 +2363,17 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (5))
-                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (26)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (204))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (3)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1930,17 +2381,17 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (26)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (5))
-                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (26)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1948,17 +2399,17 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (25)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (200))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (26)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.goals
@@ -1990,17 +2441,17 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (202))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (202))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (21)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2008,17 +2459,17 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (202))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (202))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (202))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (202))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_SMT.get_rlimit
@@ -2059,17 +2510,17 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (256))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (4)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2077,17 +2528,17 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (5))
-                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (256))
                                                                     (Prims.of_int (34)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2095,17 +2546,17 @@ let (join_smt_goals : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (5))
-                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (48)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.top_env
@@ -2192,13 +2643,13 @@ let (main :
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Main.fst"
-                         (Prims.of_int (228)) (Prims.of_int (2))
-                         (Prims.of_int (228)) (Prims.of_int (27)))))
+                         (Prims.of_int (277)) (Prims.of_int (2))
+                         (Prims.of_int (277)) (Prims.of_int (27)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Main.fst"
-                         (Prims.of_int (229)) (Prims.of_int (2))
-                         (Prims.of_int (239)) (Prims.of_int (5)))))
+                         (Prims.of_int (278)) (Prims.of_int (2))
+                         (Prims.of_int (288)) (Prims.of_int (5)))))
                 (Obj.magic
                    (FStar_Tactics_V2_Builtins.set_guard_policy
                       FStar_Tactics_Types.ForceSMT))
@@ -2209,28 +2660,28 @@ let (main :
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Main.fst"
-                                    (Prims.of_int (229)) (Prims.of_int (2))
-                                    (Prims.of_int (230)) (Prims.of_int (73)))))
+                                    (Prims.of_int (278)) (Prims.of_int (2))
+                                    (Prims.of_int (279)) (Prims.of_int (73)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Main.fst"
-                                    (Prims.of_int (230)) (Prims.of_int (74))
-                                    (Prims.of_int (239)) (Prims.of_int (5)))))
+                                    (Prims.of_int (279)) (Prims.of_int (74))
+                                    (Prims.of_int (288)) (Prims.of_int (5)))))
                            (Obj.magic
                               (FStar_Tactics_Effect.tac_bind
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "Pulse.Main.fst"
-                                          (Prims.of_int (229))
+                                          (Prims.of_int (278))
                                           (Prims.of_int (5))
-                                          (Prims.of_int (229))
+                                          (Prims.of_int (278))
                                           (Prims.of_int (40)))))
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "Pulse.Main.fst"
-                                          (Prims.of_int (229))
+                                          (Prims.of_int (278))
                                           (Prims.of_int (2))
-                                          (Prims.of_int (230))
+                                          (Prims.of_int (279))
                                           (Prims.of_int (73)))))
                                  (Obj.magic
                                     (FStar_Tactics_Effect.tac_bind
@@ -2238,17 +2689,17 @@ let (main :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Main.fst"
-                                                (Prims.of_int (229))
+                                                (Prims.of_int (278))
                                                 (Prims.of_int (5))
-                                                (Prims.of_int (229))
+                                                (Prims.of_int (278))
                                                 (Prims.of_int (34)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Main.fst"
-                                                (Prims.of_int (229))
+                                                (Prims.of_int (278))
                                                 (Prims.of_int (5))
-                                                (Prims.of_int (229))
+                                                (Prims.of_int (278))
                                                 (Prims.of_int (40)))))
                                        (Obj.magic
                                           (FStar_Tactics_V2_Builtins.ext_getv
@@ -2267,17 +2718,17 @@ let (main :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Main.fst"
-                                                          (Prims.of_int (230))
+                                                          (Prims.of_int (279))
                                                           (Prims.of_int (21))
-                                                          (Prims.of_int (230))
+                                                          (Prims.of_int (279))
                                                           (Prims.of_int (73)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Main.fst"
-                                                          (Prims.of_int (230))
+                                                          (Prims.of_int (279))
                                                           (Prims.of_int (4))
-                                                          (Prims.of_int (230))
+                                                          (Prims.of_int (279))
                                                           (Prims.of_int (73)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_Effect.tac_bind
@@ -2285,17 +2736,17 @@ let (main :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Main.fst"
-                                                                (Prims.of_int (230))
+                                                                (Prims.of_int (279))
                                                                 (Prims.of_int (41))
-                                                                (Prims.of_int (230))
+                                                                (Prims.of_int (279))
                                                                 (Prims.of_int (72)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Main.fst"
-                                                                (Prims.of_int (230))
+                                                                (Prims.of_int (279))
                                                                 (Prims.of_int (21))
-                                                                (Prims.of_int (230))
+                                                                (Prims.of_int (279))
                                                                 (Prims.of_int (73)))))
                                                        (Obj.magic
                                                           (FStar_Tactics_V2_Builtins.ext_getv
@@ -2324,17 +2775,17 @@ let (main :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Main.fst"
-                                               (Prims.of_int (232))
+                                               (Prims.of_int (281))
                                                (Prims.of_int (12))
-                                               (Prims.of_int (232))
+                                               (Prims.of_int (281))
                                                (Prims.of_int (39)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Main.fst"
-                                               (Prims.of_int (234))
+                                               (Prims.of_int (283))
                                                (Prims.of_int (2))
-                                               (Prims.of_int (239))
+                                               (Prims.of_int (288))
                                                (Prims.of_int (5)))))
                                       (Obj.magic
                                          (main' nm t pre g expected_t))
@@ -2346,17 +2797,17 @@ let (main :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Main.fst"
-                                                          (Prims.of_int (234))
+                                                          (Prims.of_int (283))
                                                           (Prims.of_int (2))
-                                                          (Prims.of_int (238))
+                                                          (Prims.of_int (287))
                                                           (Prims.of_int (20)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Main.fst"
-                                                          (Prims.of_int (232))
+                                                          (Prims.of_int (281))
                                                           (Prims.of_int (6))
-                                                          (Prims.of_int (232))
+                                                          (Prims.of_int (281))
                                                           (Prims.of_int (9)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_Effect.tac_bind
@@ -2364,17 +2815,17 @@ let (main :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Main.fst"
-                                                                (Prims.of_int (234))
+                                                                (Prims.of_int (283))
                                                                 (Prims.of_int (5))
-                                                                (Prims.of_int (234))
+                                                                (Prims.of_int (283))
                                                                 (Prims.of_int (32)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Main.fst"
-                                                                (Prims.of_int (234))
+                                                                (Prims.of_int (283))
                                                                 (Prims.of_int (2))
-                                                                (Prims.of_int (238))
+                                                                (Prims.of_int (287))
                                                                 (Prims.of_int (20)))))
                                                        (Obj.magic
                                                           (FStar_Tactics_Effect.tac_bind
@@ -2382,17 +2833,17 @@ let (main :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (283))
                                                                     (Prims.of_int (5))
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (283))
                                                                     (Prims.of_int (26)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (283))
                                                                     (Prims.of_int (5))
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (283))
                                                                     (Prims.of_int (32)))))
                                                              (Obj.magic
                                                                 (FStar_Tactics_V2_Builtins.ext_getv
@@ -2447,28 +2898,28 @@ let (check_pulse :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "Pulse.Main.fst"
-                                 (Prims.of_int (250)) (Prims.of_int (6))
-                                 (Prims.of_int (251)) (Prims.of_int (33)))))
+                                 (Prims.of_int (299)) (Prims.of_int (6))
+                                 (Prims.of_int (300)) (Prims.of_int (33)))))
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "Pulse.Main.fst"
-                                 (Prims.of_int (252)) (Prims.of_int (6))
-                                 (Prims.of_int (268)) (Prims.of_int (36)))))
+                                 (Prims.of_int (301)) (Prims.of_int (6))
+                                 (Prims.of_int (317)) (Prims.of_int (36)))))
                         (Obj.magic
                            (FStar_Tactics_Effect.tac_bind
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range "Pulse.Main.fst"
-                                       (Prims.of_int (250))
+                                       (Prims.of_int (299))
                                        (Prims.of_int (9))
-                                       (Prims.of_int (250))
+                                       (Prims.of_int (299))
                                        (Prims.of_int (48)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range "Pulse.Main.fst"
-                                       (Prims.of_int (250))
+                                       (Prims.of_int (299))
                                        (Prims.of_int (6))
-                                       (Prims.of_int (251))
+                                       (Prims.of_int (300))
                                        (Prims.of_int (33)))))
                               (Obj.magic
                                  (FStar_Tactics_Effect.tac_bind
@@ -2476,17 +2927,17 @@ let (check_pulse :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Main.fst"
-                                             (Prims.of_int (250))
+                                             (Prims.of_int (299))
                                              (Prims.of_int (9))
-                                             (Prims.of_int (250))
+                                             (Prims.of_int (299))
                                              (Prims.of_int (41)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Main.fst"
-                                             (Prims.of_int (250))
+                                             (Prims.of_int (299))
                                              (Prims.of_int (9))
-                                             (Prims.of_int (250))
+                                             (Prims.of_int (299))
                                              (Prims.of_int (48)))))
                                     (Obj.magic
                                        (FStar_Tactics_V2_Builtins.ext_getv
@@ -2515,17 +2966,17 @@ let (check_pulse :
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Main.fst"
-                                            (Prims.of_int (252))
+                                            (Prims.of_int (301))
                                             (Prims.of_int (12))
-                                            (Prims.of_int (252))
+                                            (Prims.of_int (301))
                                             (Prims.of_int (112)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Main.fst"
-                                            (Prims.of_int (252))
+                                            (Prims.of_int (301))
                                             (Prims.of_int (6))
-                                            (Prims.of_int (268))
+                                            (Prims.of_int (317))
                                             (Prims.of_int (36)))))
                                    (FStar_Tactics_Effect.lift_div_tac
                                       (fun uu___2 ->
@@ -2558,17 +3009,17 @@ let (check_pulse :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Main.fst"
-                                                              (Prims.of_int (261))
+                                                              (Prims.of_int (310))
                                                               (Prims.of_int (10))
-                                                              (Prims.of_int (265))
+                                                              (Prims.of_int (314))
                                                               (Prims.of_int (21)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Main.fst"
-                                                              (Prims.of_int (267))
+                                                              (Prims.of_int (316))
                                                               (Prims.of_int (8))
-                                                              (Prims.of_int (268))
+                                                              (Prims.of_int (317))
                                                               (Prims.of_int (36)))))
                                                      (Obj.magic
                                                         (FStar_Tactics_Effect.tac_bind
@@ -2576,9 +3027,9 @@ let (check_pulse :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (74)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
@@ -2595,18 +3046,18 @@ let (check_pulse :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (74)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (74)))))
                                                                  (Obj.magic
                                                                     (
@@ -2615,9 +3066,9 @@ let (check_pulse :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (44))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (69)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2672,17 +3123,17 @@ let (check_pulse :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (316))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (316))
                                                                     (Prims.of_int (24)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Main.fst"
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (36)))))
                                                                 (Obj.magic
                                                                    (FStar_Tactics_V2_Builtins.log_issues

--- a/src/ocaml/plugin/generated/Pulse_Recursion.ml
+++ b/src/ocaml/plugin/generated/Pulse_Recursion.ml
@@ -230,7 +230,7 @@ let (add_knot :
           (fun uu___ ->
              (fun uu___ ->
                 match uu___ with
-                | Pulse_Syntax_Base.FnDecl
+                | Pulse_Syntax_Base.FnDefn
                     { Pulse_Syntax_Base.id = id;
                       Pulse_Syntax_Base.isrec = isrec;
                       Pulse_Syntax_Base.bs = bs;
@@ -257,7 +257,7 @@ let (add_knot :
                                  (Pulse_Typing_Env.fail g
                                     (FStar_Pervasives_Native.Some
                                        (d.Pulse_Syntax_Base.range2))
-                                    "main: FnDecl does not have binders"))
+                                    "main: FnDefn does not have binders"))
                           else
                             Obj.magic
                               (Obj.repr
@@ -804,7 +804,7 @@ let (add_knot :
                                                                     {
                                                                     Pulse_Syntax_Base.d
                                                                     =
-                                                                    (Pulse_Syntax_Base.FnDecl
+                                                                    (Pulse_Syntax_Base.FnDefn
                                                                     {
                                                                     Pulse_Syntax_Base.id
                                                                     =

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Base.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Base.ml
@@ -506,7 +506,7 @@ let uu___is_Tm_ProofHintWithBinders uu___ =
 let uu___is_Tm_WithInv uu___ =
   match uu___ with | Tm_WithInv _ -> true | _ -> false
 type branch = (pattern * st_term)
-type decl'__FnDecl__payload =
+type fn_defn =
   {
   id: FStar_Reflection_Types.ident ;
   isrec: Prims.bool ;
@@ -514,45 +514,64 @@ type decl'__FnDecl__payload =
   comp: comp ;
   meas: term FStar_Pervasives_Native.option ;
   body7: st_term }
-and decl' =
-  | FnDecl of decl'__FnDecl__payload 
-and decl = {
-  d: decl' ;
-  range2: range }
-let (__proj__Mkdecl'__FnDecl__payload__item__id :
-  decl'__FnDecl__payload -> FStar_Reflection_Types.ident) =
+let (__proj__Mkfn_defn__item__id : fn_defn -> FStar_Reflection_Types.ident) =
   fun projectee ->
     match projectee with
     | { id; isrec; bs; comp = comp1; meas; body7 = body;_} -> id
-let (__proj__Mkdecl'__FnDecl__payload__item__isrec :
-  decl'__FnDecl__payload -> Prims.bool) =
+let (__proj__Mkfn_defn__item__isrec : fn_defn -> Prims.bool) =
   fun projectee ->
     match projectee with
     | { id; isrec; bs; comp = comp1; meas; body7 = body;_} -> isrec
-let (__proj__Mkdecl'__FnDecl__payload__item__bs :
-  decl'__FnDecl__payload ->
+let (__proj__Mkfn_defn__item__bs :
+  fn_defn ->
     (qualifier FStar_Pervasives_Native.option * binder * bv) Prims.list)
   =
   fun projectee ->
     match projectee with
     | { id; isrec; bs; comp = comp1; meas; body7 = body;_} -> bs
-let (__proj__Mkdecl'__FnDecl__payload__item__comp :
-  decl'__FnDecl__payload -> comp) =
+let (__proj__Mkfn_defn__item__comp : fn_defn -> comp) =
   fun projectee ->
     match projectee with
     | { id; isrec; bs; comp = comp1; meas; body7 = body;_} -> comp1
-let (__proj__Mkdecl'__FnDecl__payload__item__meas :
-  decl'__FnDecl__payload -> term FStar_Pervasives_Native.option) =
+let (__proj__Mkfn_defn__item__meas :
+  fn_defn -> term FStar_Pervasives_Native.option) =
   fun projectee ->
     match projectee with
     | { id; isrec; bs; comp = comp1; meas; body7 = body;_} -> meas
-let (__proj__Mkdecl'__FnDecl__payload__item__body :
-  decl'__FnDecl__payload -> st_term) =
+let (__proj__Mkfn_defn__item__body : fn_defn -> st_term) =
   fun projectee ->
     match projectee with
     | { id; isrec; bs; comp = comp1; meas; body7 = body;_} -> body
-let (uu___is_FnDecl : decl' -> Prims.bool) = fun projectee -> true
-let (__proj__FnDecl__item___0 : decl' -> decl'__FnDecl__payload) =
+type fn_decl =
+  {
+  id1: FStar_Reflection_Types.ident ;
+  bs1: (qualifier FStar_Pervasives_Native.option * binder * bv) Prims.list ;
+  comp1: comp_st }
+let (__proj__Mkfn_decl__item__id : fn_decl -> FStar_Reflection_Types.ident) =
+  fun projectee ->
+    match projectee with | { id1 = id; bs1 = bs; comp1;_} -> id
+let (__proj__Mkfn_decl__item__bs :
+  fn_decl ->
+    (qualifier FStar_Pervasives_Native.option * binder * bv) Prims.list)
+  =
+  fun projectee ->
+    match projectee with | { id1 = id; bs1 = bs; comp1;_} -> bs
+let (__proj__Mkfn_decl__item__comp : fn_decl -> comp_st) =
+  fun projectee ->
+    match projectee with | { id1 = id; bs1 = bs; comp1;_} -> comp1
+type decl' =
+  | FnDefn of fn_defn 
+  | FnDecl of fn_decl 
+and decl = {
+  d: decl' ;
+  range2: range }
+let (uu___is_FnDefn : decl' -> Prims.bool) =
+  fun projectee -> match projectee with | FnDefn _0 -> true | uu___ -> false
+let (__proj__FnDefn__item___0 : decl' -> fn_defn) =
+  fun projectee -> match projectee with | FnDefn _0 -> _0
+let (uu___is_FnDecl : decl' -> Prims.bool) =
+  fun projectee -> match projectee with | FnDecl _0 -> true | uu___ -> false
+let (__proj__FnDecl__item___0 : decl' -> fn_decl) =
   fun projectee -> match projectee with | FnDecl _0 -> _0
 let (__proj__Mkdecl__item__d : decl -> decl') =
   fun projectee -> match projectee with | { d; range2 = range1;_} -> d
@@ -863,32 +882,32 @@ let (ppname_for_uvar :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Base.fsti"
-               (Prims.of_int (401)) (Prims.of_int (18)) (Prims.of_int (401))
+               (Prims.of_int (413)) (Prims.of_int (18)) (Prims.of_int (413))
                (Prims.of_int (48)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Base.fsti"
-               (Prims.of_int (401)) (Prims.of_int (4)) (Prims.of_int (401))
+               (Prims.of_int (413)) (Prims.of_int (4)) (Prims.of_int (413))
                (Prims.of_int (49)))))
       (Obj.magic
          (FStar_Tactics_Effect.tac_bind
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Base.fsti"
-                     (Prims.of_int (401)) (Prims.of_int (25))
-                     (Prims.of_int (401)) (Prims.of_int (48)))))
+                     (Prims.of_int (413)) (Prims.of_int (25))
+                     (Prims.of_int (413)) (Prims.of_int (48)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Base.fsti"
-                     (Prims.of_int (401)) (Prims.of_int (18))
-                     (Prims.of_int (401)) (Prims.of_int (48)))))
+                     (Prims.of_int (413)) (Prims.of_int (18))
+                     (Prims.of_int (413)) (Prims.of_int (48)))))
             (Obj.magic
                (FStar_Tactics_Effect.tac_bind
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Syntax.Base.fsti"
-                           (Prims.of_int (401)) (Prims.of_int (32))
-                           (Prims.of_int (401)) (Prims.of_int (47)))))
+                           (Prims.of_int (413)) (Prims.of_int (32))
+                           (Prims.of_int (413)) (Prims.of_int (47)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "prims.fst"

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Builder.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Builder.ml
@@ -337,7 +337,7 @@ let (mk_rewrite_hint_type :
             Pulse_Syntax_Base.t2 = t2;
             Pulse_Syntax_Base.tac_opt1 = (map_opt tac_opt thunk)
           }
-let (mk_fn_decl :
+let (mk_fn_defn :
   FStar_Reflection_Types.ident ->
     Prims.bool ->
       (Pulse_Syntax_Base.qualifier FStar_Pervasives_Native.option *
@@ -352,7 +352,7 @@ let (mk_fn_decl :
         fun comp ->
           fun meas ->
             fun body ->
-              Pulse_Syntax_Base.FnDecl
+              Pulse_Syntax_Base.FnDefn
                 {
                   Pulse_Syntax_Base.id = id;
                   Pulse_Syntax_Base.isrec = isrec;
@@ -361,6 +361,21 @@ let (mk_fn_decl :
                   Pulse_Syntax_Base.meas = meas;
                   Pulse_Syntax_Base.body7 = body
                 }
+let (mk_fn_decl :
+  FStar_Reflection_Types.ident ->
+    (Pulse_Syntax_Base.qualifier FStar_Pervasives_Native.option *
+      Pulse_Syntax_Base.binder * Pulse_Syntax_Base.bv) Prims.list ->
+      Pulse_Syntax_Base.comp_st -> Pulse_Syntax_Base.decl')
+  =
+  fun id ->
+    fun bs ->
+      fun comp ->
+        Pulse_Syntax_Base.FnDecl
+          {
+            Pulse_Syntax_Base.id1 = id;
+            Pulse_Syntax_Base.bs1 = bs;
+            Pulse_Syntax_Base.comp1 = comp
+          }
 let (mk_decl :
   Pulse_Syntax_Base.decl' ->
     Pulse_Syntax_Base.range -> Pulse_Syntax_Base.decl)

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Printer.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Printer.ml
@@ -5966,7 +5966,7 @@ let (decl_to_string :
   =
   fun d ->
     match d.Pulse_Syntax_Base.d with
-    | Pulse_Syntax_Base.FnDecl
+    | Pulse_Syntax_Base.FnDefn
         { Pulse_Syntax_Base.id = id; Pulse_Syntax_Base.isrec = isrec;
           Pulse_Syntax_Base.bs = bs; Pulse_Syntax_Base.comp = uu___;
           Pulse_Syntax_Base.meas = uu___1; Pulse_Syntax_Base.body7 = body;_}
@@ -6157,3 +6157,79 @@ let (decl_to_string :
           (fun uu___2 ->
              FStar_Tactics_Effect.lift_div_tac
                (fun uu___3 -> Prims.strcat "fn " uu___2))
+    | Pulse_Syntax_Base.FnDecl
+        { Pulse_Syntax_Base.id1 = id; Pulse_Syntax_Base.bs1 = bs;
+          Pulse_Syntax_Base.comp1 = uu___;_}
+        ->
+        FStar_Tactics_Effect.tac_bind
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                   (Prims.of_int (572)) (Prims.of_int (4))
+                   (Prims.of_int (573)) (Prims.of_int (70)))))
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
+                   (Prims.of_int (19)) (Prims.of_int (590))
+                   (Prims.of_int (31)))))
+          (Obj.magic
+             (FStar_Tactics_Effect.tac_bind
+                (FStar_Sealed.seal
+                   (Obj.magic
+                      (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                         (Prims.of_int (572)) (Prims.of_int (31))
+                         (Prims.of_int (573)) (Prims.of_int (70)))))
+                (FStar_Sealed.seal
+                   (Obj.magic
+                      (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
+                         (Prims.of_int (19)) (Prims.of_int (590))
+                         (Prims.of_int (31)))))
+                (Obj.magic
+                   (FStar_Tactics_Effect.tac_bind
+                      (FStar_Sealed.seal
+                         (Obj.magic
+                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
+                               (Prims.of_int (573)) (Prims.of_int (4))
+                               (Prims.of_int (573)) (Prims.of_int (70)))))
+                      (FStar_Sealed.seal
+                         (Obj.magic
+                            (FStar_Range.mk_range "prims.fst"
+                               (Prims.of_int (590)) (Prims.of_int (19))
+                               (Prims.of_int (590)) (Prims.of_int (31)))))
+                      (Obj.magic
+                         (FStar_Tactics_Effect.tac_bind
+                            (FStar_Sealed.seal
+                               (Obj.magic
+                                  (FStar_Range.mk_range
+                                     "Pulse.Syntax.Printer.fst"
+                                     (Prims.of_int (573)) (Prims.of_int (22))
+                                     (Prims.of_int (573)) (Prims.of_int (70)))))
+                            (FStar_Sealed.seal
+                               (Obj.magic
+                                  (FStar_Range.mk_range
+                                     "Pulse.Syntax.Printer.fst"
+                                     (Prims.of_int (573)) (Prims.of_int (4))
+                                     (Prims.of_int (573)) (Prims.of_int (70)))))
+                            (Obj.magic
+                               (FStar_Tactics_Util.map
+                                  (fun uu___1 ->
+                                     match uu___1 with
+                                     | (uu___2, b, uu___3) ->
+                                         binder_to_string b) bs))
+                            (fun uu___1 ->
+                               FStar_Tactics_Effect.lift_div_tac
+                                 (fun uu___2 ->
+                                    FStar_String.concat " " uu___1))))
+                      (fun uu___1 ->
+                         FStar_Tactics_Effect.lift_div_tac
+                           (fun uu___2 -> Prims.strcat " " uu___1))))
+                (fun uu___1 ->
+                   FStar_Tactics_Effect.lift_div_tac
+                     (fun uu___2 ->
+                        Prims.strcat
+                          (FStar_Pervasives_Native.fst
+                             (FStar_Reflection_V2_Builtins.inspect_ident id))
+                          uu___1))))
+          (fun uu___1 ->
+             FStar_Tactics_Effect.lift_div_tac
+               (fun uu___2 -> Prims.strcat "val fn " uu___1))

--- a/src/ocaml/plugin/pulseparser.mly
+++ b/src/ocaml/plugin/pulseparser.mly
@@ -52,14 +52,14 @@ let with_computation_tag (c:PulseSyntaxExtension_Sugar.computation_type) t =
   | None -> c
   | Some t -> { c with tag = t }
 
-let mk_fn_decl q id is_rec bs body range = 
+let mk_fn_defn q id is_rec bs body range =
     match body with
     | Inl (ascription, measure, body) ->
       let ascription = with_computation_tag ascription q in 
-      PulseSyntaxExtension_Sugar.mk_fn_decl id is_rec (List.flatten bs) (Inl ascription) measure (Inl body) range
+      PulseSyntaxExtension_Sugar.mk_fn_defn id is_rec (List.flatten bs) (Inl ascription) measure (Inl body) range
 
     | Inr (lambda, typ) ->
-      PulseSyntaxExtension_Sugar.mk_fn_decl id is_rec (List.flatten bs) (Inr typ) None (Inr lambda) range
+      PulseSyntaxExtension_Sugar.mk_fn_defn id is_rec (List.flatten bs) (Inr typ) None (Inr lambda) range
 
 %}
 
@@ -95,7 +95,7 @@ pulseDecl:
     FN isRec=maybeRec lid=lident bs=pulseBinderList
     body=fnBody EOF
     {
-      PulseSyntaxExtension_Sugar.FnDecl (mk_fn_decl q lid isRec bs body (rr $loc))
+      PulseSyntaxExtension_Sugar.FnDefn (mk_fn_defn q lid isRec bs body (rr $loc))
     }
 
 pulseBinderList:
@@ -103,12 +103,12 @@ pulseBinderList:
   | bs=nonempty_list(multiBinder)
     {  bs }
 
-localFnDecl:
+localFnDefn:
   | q=option(qual) FN lid=lident
     bs=pulseBinderList
     body=fnBody
     {
-      lid, mk_fn_decl q lid false bs body (rr $loc)
+      lid, mk_fn_defn q lid false bs body (rr $loc)
     }
 
 fnBody:
@@ -183,10 +183,10 @@ pulseStmtNoSeq:
     { PulseSyntaxExtension_Sugar.mk_proof_hint_with_binders WILD bs }
   | SHOW_PROOF_STATE
     { PulseSyntaxExtension_Sugar.mk_proof_hint_with_binders (SHOW_PROOF_STATE (rr $loc)) [] }
-  | f=localFnDecl
+  | f=localFnDefn
     {
-      let id, fndecl = f in
-      PulseSyntaxExtension_Sugar.mk_let_binding None id None (Some (Lambda_initializer fndecl))
+      let id, fndefn = f in
+      PulseSyntaxExtension_Sugar.mk_let_binding None id None (Some (Lambda_initializer fndefn))
     }
   | p=ifStmt { p }
   | p=matchStmt { p }

--- a/src/ocaml/plugin/pulseparser.mly
+++ b/src/ocaml/plugin/pulseparser.mly
@@ -84,6 +84,8 @@ maybeRec:
 peekFnId:
   | q=option(qual) FN maybeRec id=lident
       { FStar_Ident.string_of_id id }
+  | q=option(qual) VAL FN id=lident
+      { FStar_Ident.string_of_id id }
 
 qual:
   | GHOST { PulseSyntaxExtension_Sugar.STGhost }
@@ -96,6 +98,15 @@ pulseDecl:
     body=fnBody EOF
     {
       PulseSyntaxExtension_Sugar.FnDefn (mk_fn_defn q lid isRec bs body (rr $loc))
+    }
+  | q=option(qual)
+    VAL FN lid=lident bs=pulseBinderList
+    ascription=pulseComputationType
+    EOF
+    {
+      let open PulseSyntaxExtension_Sugar in
+      let ascription = with_computation_tag ascription q in
+      FnDecl (mk_fn_decl lid (List.flatten bs) (Inl ascription) (rr $loc))
     }
 
 pulseBinderList:

--- a/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
@@ -749,7 +749,7 @@ and desugar_decl (env:env_t)
     return (A.mk_term (A.Product (bs'', res_t)) r A.Expr)
   in
   match d with
-  | Sugar.FnDecl { id; is_rec; binders; ascription=Inl ascription; measure; body=Inl body; range } ->
+  | Sugar.FnDefn { id; is_rec; binders; ascription=Inl ascription; measure; body=Inl body; range } ->
     let! env, bs, bvs = desugar_binders env binders in
     let fvs = free_vars_comp env ascription in
     let! env, bs', bvs' = idents_as_binders env fvs in
@@ -776,9 +776,9 @@ and desugar_decl (env:env_t)
     in
     let! body = desugar_stmt env body in
     let! qbs = map2 faux bs bvs in
-    return (SW.fn_decl range id is_rec qbs comp meas body)
+    return (SW.fn_defn range id is_rec qbs comp meas body)
 
-  | Sugar.FnDecl { id; is_rec=false; binders; ascription=Inr ascription; measure=None; body=Inr body; range } ->
+  | Sugar.FnDefn { id; is_rec=false; binders; ascription=Inr ascription; measure=None; body=Inr body; range } ->
     let! env, bs, bvs = desugar_binders env binders in
     let! comp = 
       match ascription with
@@ -787,7 +787,7 @@ and desugar_decl (env:env_t)
     in
     let! body = desugar_lambda env body in
     let! qbs = map2 faux bs bvs in
-    return (SW.fn_decl range id false qbs comp None body)
+    return (SW.fn_defn range id false qbs comp None body)
 
 
 let initialize_env (env:TcEnv.env)

--- a/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
@@ -789,6 +789,11 @@ and desugar_decl (env:env_t)
     let! qbs = map2 faux bs bvs in
     return (SW.fn_defn range id false qbs comp None body)
 
+  | Sugar.FnDecl { id; binders; ascription=Inl ascription; range } ->
+    let! env, bs, bvs = desugar_binders env binders in
+    let! comp = desugar_computation_type env ascription in
+    let! qbs = map2 faux bs bvs in
+    return (SW.fn_decl range id qbs comp)
 
 let initialize_env (env:TcEnv.env)
                    (open_namespaces: list name)

--- a/src/syntax_extension/PulseSyntaxExtension.Sugar.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.Sugar.fst
@@ -172,7 +172,7 @@ and lambda = {
   range:rng
 }
 
-and fn_decl = {
+and fn_defn = {
   id:ident;
   is_rec:bool;
   binders:binders;
@@ -185,7 +185,7 @@ and fn_decl = {
 and let_init =
   | Array_initializer of array_init
   | Default_initializer of A.term
-  | Lambda_initializer of fn_decl
+  | Lambda_initializer of fn_defn
   | Stmt_initializer of stmt
 
 let tag_of_stmt (s:stmt) : string =
@@ -206,7 +206,7 @@ let tag_of_stmt (s:stmt) : string =
   | WithInvariants {} -> "WithInvariants"
 
 type decl =
-  | FnDecl of fn_decl
+  | FnDefn of fn_defn
   
 (* Convenience builders for use from OCaml/Menhir, since field names get mangled in OCaml *)
 let mk_comp tag precondition return_name return_type postcondition opens range = 
@@ -232,7 +232,7 @@ let mk_while guard id invariant body = While { guard; id; invariant; body }
 let mk_intro vprop witnesses = Introduce { vprop; witnesses }
 let mk_sequence s1 s2 = Sequence { s1; s2 }
 let mk_stmt s range = { s; range }
-let mk_fn_decl id is_rec binders ascription measure body range = { id; is_rec; binders; ascription; measure; body; range }
+let mk_fn_defn id is_rec binders ascription measure body range = { id; is_rec; binders; ascription; measure; body; range }
 let mk_open lid = Open lid
 let mk_par p1 p2 q1 q2 b1 b2 = Parallel { p1; p2; q1; q2; b1; b2 }
 let mk_proof_hint_with_binders ht bs =  ProofHintWithBinders { hint_type=ht; binders=bs }

--- a/src/syntax_extension/PulseSyntaxExtension.Sugar.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.Sugar.fst
@@ -188,6 +188,13 @@ and let_init =
   | Lambda_initializer of fn_defn
   | Stmt_initializer of stmt
 
+type fn_decl = {
+  id:ident;
+  binders:binders;
+  ascription:either computation_type (option A.term); (* always Inl for now *)
+  range:rng
+}
+
 let tag_of_stmt (s:stmt) : string =
   match s.s with
   | Open _ -> "Open"
@@ -207,6 +214,7 @@ let tag_of_stmt (s:stmt) : string =
 
 type decl =
   | FnDefn of fn_defn
+  | FnDecl of fn_decl
   
 (* Convenience builders for use from OCaml/Menhir, since field names get mangled in OCaml *)
 let mk_comp tag precondition return_name return_type postcondition opens range = 
@@ -232,7 +240,8 @@ let mk_while guard id invariant body = While { guard; id; invariant; body }
 let mk_intro vprop witnesses = Introduce { vprop; witnesses }
 let mk_sequence s1 s2 = Sequence { s1; s2 }
 let mk_stmt s range = { s; range }
-let mk_fn_defn id is_rec binders ascription measure body range = { id; is_rec; binders; ascription; measure; body; range }
+let mk_fn_defn id is_rec binders ascription measure body range : fn_defn = { id; is_rec; binders; ascription; measure; body; range }
+let mk_fn_decl id binders ascription range : fn_decl = { id; binders; ascription; range }
 let mk_open lid = Open lid
 let mk_par p1 p2 q1 q2 b1 b2 = Parallel { p1; p2; q1; q2; b1; b2 }
 let mk_proof_hint_with_binders ht bs =  ProofHintWithBinders { hint_type=ht; binders=bs }

--- a/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
+++ b/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
@@ -138,3 +138,10 @@ val fn_defn :
   meas:option term ->
   body:st_term ->
   decl
+
+val fn_decl :
+  range ->
+  name:ident ->
+  bs:list (option qualifier & binder & bv) ->
+  comp:comp ->
+  decl

--- a/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
+++ b/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
@@ -129,7 +129,7 @@ new
 val decl : Type0
 val decl_to_string (env:FStar.TypeChecker.Env.env) (_:decl) : string
 
-val fn_decl :
+val fn_defn :
   range ->
   name:ident ->
   isrec:bool ->


### PR DESCRIPTION
After some fixes in F* (FStarLang/FStar#3329) this now works more reliably.

~~There is one giant problem still, which is that the check for all vals being defined is done during interleaving, and at that time there are no vals for the Pulse definitions (they are just syntax extension blobs) so we never report an error if we forgot to define something (or made a typo in the name). I think we can fix this in F* by keeping track of yet-undefined vals in the typechecker.~~ Fixed by https://github.com/FStarLang/FStar/pull/3330

Also, the syntax blobs don't really have a name, so they do not get interleaved properly.