### PR TITLE
Syntax/Checker: support typeclass arguments

### DIFF
--- a/share/pulse/examples/bug-reports/Bug34.fst
+++ b/share/pulse/examples/bug-reports/Bug34.fst
@@ -1,0 +1,31 @@
+module Bug34
+
+open Pulse.Lib.Pervasives
+
+class eq (a:Type) = {
+  (=?) : a -> a -> bool
+}
+
+instance eq_int : eq int = {
+  (=?) = (=);
+}
+
+```pulse
+fn test (#a:Type0) {| eq a |} (x:a)
+  requires emp
+  returns _:bool
+  ensures emp
+{
+  (x =? x)
+}
+```
+
+```pulse
+fn call ()
+  requires emp
+  ensures  emp
+{
+  let x : bool = test 123;
+  ()
+}
+```

--- a/src/checker/Pulse.Checker.Abs.fst
+++ b/src/checker/Pulse.Checker.Abs.fst
@@ -118,6 +118,7 @@ let qualifier_compat g r (q:option qualifier) (q':T.aqualv) : T.Tac unit =
   | None, T.Q_Explicit -> ()
   | Some Implicit, T.Q_Implicit 
   | Some Implicit, T.Q_Meta _ -> ()
+  | Some TcArg, T.Q_Meta _ -> ()
   | _ -> Env.fail g (Some r) "Unexpected binder qualifier"
 
 let rec rebuild_abs (g:env) (t:st_term) (annot:T.term)

--- a/src/checker/Pulse.Elaborate.Pure.fst
+++ b/src/checker/Pulse.Elaborate.Pure.fst
@@ -32,6 +32,7 @@ let (let!) (f:option 'a) (g: 'a -> option 'b) : option 'b =
 let elab_qual = function
   | None -> R.Q_Explicit
   | Some Implicit -> R.Q_Implicit
+  | Some TcArg -> R.Q_Meta (`FStar.Tactics.Typeclasses.tcresolve)
 
 let elab_observability =
   let open R in

--- a/src/checker/Pulse.Syntax.Base.fsti
+++ b/src/checker/Pulse.Syntax.Base.fsti
@@ -73,6 +73,7 @@ type nm = {
 
 type qualifier =
   | Implicit
+  | TcArg
 
 
 noeq

--- a/src/checker/Pulse.Syntax.Printer.fst
+++ b/src/checker/Pulse.Syntax.Printer.fst
@@ -57,6 +57,7 @@ let univ_to_string u = sprintf "u#%s" (universe_to_string 0 u)
 let qual_to_string = function
   | None -> ""
   | Some Implicit -> "#"
+  | Some TcArg -> "#[tcresolve]"
 
 let indent (level:string) = level ^ "\t"
 

--- a/src/checker/Pulse.Typing.LN.fst
+++ b/src/checker/Pulse.Typing.LN.fst
@@ -605,7 +605,7 @@ let open_proof_hint_ln_inv (ht:proof_hint_type) (x:term { ln x }) (i:index)
     | WILD
     | SHOW_PROOF_STATE _ -> ()
 
-#push-options "--z3rlimit_factor 2 --fuel 2 --ifuel 2"
+#push-options "--z3rlimit_factor 4 --fuel 2 --ifuel 2"
 let rec open_term_ln_inv_st' (t:st_term)
                              (x:term { ln x })
                              (i:index)

--- a/src/ocaml/plugin/PulseSyntaxExtension_SyntaxWrapper.ml
+++ b/src/ocaml/plugin/PulseSyntaxExtension_SyntaxWrapper.ml
@@ -13,6 +13,7 @@ let u_unknown : universe = U.u_unknown
 
 type qualifier = Pulse_Syntax_Base.qualifier
 let as_qual (imp:bool) = if imp then Some Pulse_Syntax_Base.Implicit else None
+let tc_qual = Some Pulse_Syntax_Base.TcArg
 type bv = Pulse_Syntax_Base.bv
 let mk_bv (i:index) (name:string) (r:range) : bv =
  let pp = { name; range=r} in

--- a/src/ocaml/plugin/generated/PulseSyntaxExtension_Desugar.ml
+++ b/src/ocaml/plugin/generated/PulseSyntaxExtension_Desugar.ml
@@ -776,6 +776,8 @@ let (as_qual : FStar_Parser_AST.aqual -> qual) =
     match q with
     | FStar_Pervasives_Native.Some (FStar_Parser_AST.Implicit) ->
         PulseSyntaxExtension_SyntaxWrapper.as_qual true
+    | FStar_Pervasives_Native.Some (FStar_Parser_AST.TypeClassArg) ->
+        PulseSyntaxExtension_SyntaxWrapper.tc_qual
     | uu___ -> PulseSyntaxExtension_SyntaxWrapper.as_qual false
 let (desugar_tac_opt :
   PulseSyntaxExtension_Env.env_t ->

--- a/src/ocaml/plugin/generated/Pulse_Checker_Abs.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Abs.ml
@@ -559,6 +559,12 @@ let (qualifier_compat :
                          (Obj.repr
                             (FStar_Tactics_Effect.lift_div_tac
                                (fun uu___1 -> ())))
+                   | (FStar_Pervasives_Native.Some (Pulse_Syntax_Base.TcArg),
+                      FStar_Reflection_V2_Data.Q_Meta uu___) ->
+                       Obj.magic
+                         (Obj.repr
+                            (FStar_Tactics_Effect.lift_div_tac
+                               (fun uu___1 -> ())))
                    | uu___ ->
                        Obj.magic
                          (Obj.repr
@@ -579,13 +585,13 @@ let rec (rebuild_abs :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                   (Prims.of_int (126)) (Prims.of_int (4))
-                   (Prims.of_int (128)) (Prims.of_int (41)))))
+                   (Prims.of_int (127)) (Prims.of_int (4))
+                   (Prims.of_int (129)) (Prims.of_int (41)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                   (Prims.of_int (129)) (Prims.of_int (4))
-                   (Prims.of_int (178)) (Prims.of_int (47)))))
+                   (Prims.of_int (130)) (Prims.of_int (4))
+                   (Prims.of_int (179)) (Prims.of_int (47)))))
           (Obj.magic
              (debug_abs g
                 (fun uu___ ->
@@ -593,13 +599,13 @@ let rec (rebuild_abs :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                              (Prims.of_int (128)) (Prims.of_int (16))
-                              (Prims.of_int (128)) (Prims.of_int (40)))))
+                              (Prims.of_int (129)) (Prims.of_int (16))
+                              (Prims.of_int (129)) (Prims.of_int (40)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                              (Prims.of_int (126)) (Prims.of_int (26))
-                              (Prims.of_int (128)) (Prims.of_int (40)))))
+                              (Prims.of_int (127)) (Prims.of_int (26))
+                              (Prims.of_int (129)) (Prims.of_int (40)))))
                      (Obj.magic
                         (FStar_Tactics_V2_Builtins.term_to_string annot))
                      (fun uu___1 ->
@@ -610,17 +616,17 @@ let rec (rebuild_abs :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Abs.fst"
-                                         (Prims.of_int (126))
+                                         (Prims.of_int (127))
                                          (Prims.of_int (26))
-                                         (Prims.of_int (128))
+                                         (Prims.of_int (129))
                                          (Prims.of_int (40)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Abs.fst"
-                                         (Prims.of_int (126))
+                                         (Prims.of_int (127))
                                          (Prims.of_int (26))
-                                         (Prims.of_int (128))
+                                         (Prims.of_int (129))
                                          (Prims.of_int (40)))))
                                 (Obj.magic
                                    (FStar_Tactics_Effect.tac_bind
@@ -628,9 +634,9 @@ let rec (rebuild_abs :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Abs.fst"
-                                               (Prims.of_int (127))
+                                               (Prims.of_int (128))
                                                (Prims.of_int (16))
-                                               (Prims.of_int (127))
+                                               (Prims.of_int (128))
                                                (Prims.of_int (39)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
@@ -671,13 +677,13 @@ let rec (rebuild_abs :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (131)) (Prims.of_int (15))
-                                  (Prims.of_int (131)) (Prims.of_int (34)))))
+                                  (Prims.of_int (132)) (Prims.of_int (15))
+                                  (Prims.of_int (132)) (Prims.of_int (34)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (132)) (Prims.of_int (6))
-                                  (Prims.of_int (172)) (Prims.of_int (41)))))
+                                  (Prims.of_int (133)) (Prims.of_int (6))
+                                  (Prims.of_int (173)) (Prims.of_int (41)))))
                          (FStar_Tactics_Effect.lift_div_tac
                             (fun uu___1 ->
                                FStar_Reflection_V2_Builtins.inspect_binder b'))
@@ -689,17 +695,17 @@ let rec (rebuild_abs :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Abs.fst"
-                                             (Prims.of_int (132))
+                                             (Prims.of_int (133))
                                              (Prims.of_int (6))
-                                             (Prims.of_int (132))
+                                             (Prims.of_int (133))
                                              (Prims.of_int (56)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Abs.fst"
-                                             (Prims.of_int (132))
+                                             (Prims.of_int (133))
                                              (Prims.of_int (57))
-                                             (Prims.of_int (172))
+                                             (Prims.of_int (173))
                                              (Prims.of_int (41)))))
                                     (Obj.magic
                                        (qualifier_compat g
@@ -713,17 +719,17 @@ let rec (rebuild_abs :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Abs.fst"
-                                                        (Prims.of_int (133))
+                                                        (Prims.of_int (134))
                                                         (Prims.of_int (15))
-                                                        (Prims.of_int (133))
+                                                        (Prims.of_int (134))
                                                         (Prims.of_int (22)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Abs.fst"
-                                                        (Prims.of_int (133))
+                                                        (Prims.of_int (134))
                                                         (Prims.of_int (25))
-                                                        (Prims.of_int (172))
+                                                        (Prims.of_int (173))
                                                         (Prims.of_int (41)))))
                                                (FStar_Tactics_Effect.lift_div_tac
                                                   (fun uu___2 ->
@@ -736,17 +742,17 @@ let rec (rebuild_abs :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Abs.fst"
-                                                                   (Prims.of_int (134))
+                                                                   (Prims.of_int (135))
                                                                    (Prims.of_int (17))
-                                                                   (Prims.of_int (134))
+                                                                   (Prims.of_int (135))
                                                                    (Prims.of_int (34)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Abs.fst"
-                                                                   (Prims.of_int (135))
+                                                                   (Prims.of_int (136))
                                                                    (Prims.of_int (6))
-                                                                   (Prims.of_int (172))
+                                                                   (Prims.of_int (173))
                                                                    (Prims.of_int (41)))))
                                                           (FStar_Tactics_Effect.lift_div_tac
                                                              (fun uu___2 ->
@@ -770,17 +776,17 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (139))
+                                                                    (Prims.of_int (140))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (139))
+                                                                    (Prims.of_int (140))
                                                                     (Prims.of_int (72)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (139))
+                                                                    (Prims.of_int (140))
                                                                     (Prims.of_int (75))
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (143))
                                                                     (Prims.of_int (64)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -799,17 +805,17 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (140))
+                                                                    (Prims.of_int (141))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (140))
+                                                                    (Prims.of_int (141))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (143))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (143))
                                                                     (Prims.of_int (63)))))
                                                                     (Obj.magic
                                                                     (rebuild_abs
@@ -865,17 +871,17 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (148))
-                                                                    (Prims.of_int (14))
                                                                     (Prims.of_int (149))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (150))
                                                                     (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (148))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (149))
+                                                                    (Prims.of_int (150))
                                                                     (Prims.of_int (44)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -883,9 +889,9 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (149))
+                                                                    (Prims.of_int (150))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (149))
+                                                                    (Prims.of_int (150))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -929,17 +935,17 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (151))
+                                                                    (Prims.of_int (152))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (151))
+                                                                    (Prims.of_int (152))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (150))
+                                                                    (Prims.of_int (151))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (162))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_NamedView.inspect
@@ -961,17 +967,17 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (155))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (155))
                                                                     (Prims.of_int (91)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (153))
-                                                                    (Prims.of_int (14))
                                                                     (Prims.of_int (154))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (155))
                                                                     (Prims.of_int (91)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -979,9 +985,9 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (155))
                                                                     (Prims.of_int (68))
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (155))
                                                                     (Prims.of_int (90)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1022,17 +1028,17 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (158))
+                                                                    (Prims.of_int (159))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (161))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (161))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1040,9 +1046,9 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (161))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (161))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1126,17 +1132,17 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (171))
-                                                                    (Prims.of_int (12))
                                                                     (Prims.of_int (172))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (173))
                                                                     (Prims.of_int (41)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (170))
+                                                                    (Prims.of_int (171))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (173))
                                                                     (Prims.of_int (41)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1144,9 +1150,9 @@ let rec (rebuild_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (173))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (172))
+                                                                    (Prims.of_int (173))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1188,22 +1194,22 @@ let rec (rebuild_abs :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (177)) (Prims.of_int (16))
-                                  (Prims.of_int (178)) (Prims.of_int (47)))))
+                                  (Prims.of_int (178)) (Prims.of_int (16))
+                                  (Prims.of_int (179)) (Prims.of_int (47)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (176)) (Prims.of_int (6))
-                                  (Prims.of_int (178)) (Prims.of_int (47)))))
+                                  (Prims.of_int (177)) (Prims.of_int (6))
+                                  (Prims.of_int (179)) (Prims.of_int (47)))))
                          (Obj.magic
                             (FStar_Tactics_Effect.tac_bind
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.Abs.fst"
-                                        (Prims.of_int (178))
+                                        (Prims.of_int (179))
                                         (Prims.of_int (22))
-                                        (Prims.of_int (178))
+                                        (Prims.of_int (179))
                                         (Prims.of_int (46)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
@@ -1239,12 +1245,12 @@ let (preprocess_abs :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                 (Prims.of_int (184)) (Prims.of_int (19))
-                 (Prims.of_int (184)) (Prims.of_int (35)))))
+                 (Prims.of_int (185)) (Prims.of_int (19))
+                 (Prims.of_int (185)) (Prims.of_int (35)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                 (Prims.of_int (184)) (Prims.of_int (3)) (Prims.of_int (189))
+                 (Prims.of_int (185)) (Prims.of_int (3)) (Prims.of_int (190))
                  (Prims.of_int (7))))) (Obj.magic (arrow_of_abs g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -1255,13 +1261,13 @@ let (preprocess_abs :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                (Prims.of_int (185)) (Prims.of_int (4))
-                                (Prims.of_int (185)) (Prims.of_int (88)))))
+                                (Prims.of_int (186)) (Prims.of_int (4))
+                                (Prims.of_int (186)) (Prims.of_int (88)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                (Prims.of_int (185)) (Prims.of_int (89))
-                                (Prims.of_int (189)) (Prims.of_int (7)))))
+                                (Prims.of_int (186)) (Prims.of_int (89))
+                                (Prims.of_int (190)) (Prims.of_int (7)))))
                        (Obj.magic
                           (debug_abs g
                              (fun uu___1 ->
@@ -1270,9 +1276,9 @@ let (preprocess_abs :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Abs.fst"
-                                           (Prims.of_int (185))
+                                           (Prims.of_int (186))
                                            (Prims.of_int (63))
-                                           (Prims.of_int (185))
+                                           (Prims.of_int (186))
                                            (Prims.of_int (87)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
@@ -1297,17 +1303,17 @@ let (preprocess_abs :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Abs.fst"
-                                           (Prims.of_int (186))
+                                           (Prims.of_int (187))
                                            (Prims.of_int (19))
-                                           (Prims.of_int (186))
+                                           (Prims.of_int (187))
                                            (Prims.of_int (72)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Abs.fst"
-                                           (Prims.of_int (185))
+                                           (Prims.of_int (186))
                                            (Prims.of_int (89))
-                                           (Prims.of_int (189))
+                                           (Prims.of_int (190))
                                            (Prims.of_int (7)))))
                                   (Obj.magic
                                      (Pulse_Checker_Pure.instantiate_term_implicits
@@ -1322,17 +1328,17 @@ let (preprocess_abs :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Abs.fst"
-                                                          (Prims.of_int (187))
+                                                          (Prims.of_int (188))
                                                           (Prims.of_int (14))
-                                                          (Prims.of_int (187))
+                                                          (Prims.of_int (188))
                                                           (Prims.of_int (35)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Abs.fst"
-                                                          (Prims.of_int (188))
-                                                          (Prims.of_int (4))
                                                           (Prims.of_int (189))
+                                                          (Prims.of_int (4))
+                                                          (Prims.of_int (190))
                                                           (Prims.of_int (7)))))
                                                  (Obj.magic
                                                     (rebuild_abs g t1 annot1))
@@ -1344,17 +1350,17 @@ let (preprocess_abs :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (188))
+                                                                    (Prims.of_int (189))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (188))
+                                                                    (Prims.of_int (189))
                                                                     (Prims.of_int (88)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (187))
+                                                                    (Prims.of_int (188))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (187))
+                                                                    (Prims.of_int (188))
                                                                     (Prims.of_int (11)))))
                                                             (Obj.magic
                                                                (debug_abs g
@@ -1365,9 +1371,9 @@ let (preprocess_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (188))
+                                                                    (Prims.of_int (189))
                                                                     (Prims.of_int (62))
-                                                                    (Prims.of_int (188))
+                                                                    (Prims.of_int (189))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1475,13 +1481,13 @@ let (check_effect_annotation :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                     (Prims.of_int (213)) (Prims.of_int (12))
-                     (Prims.of_int (213)) (Prims.of_int (42)))))
+                     (Prims.of_int (214)) (Prims.of_int (12))
+                     (Prims.of_int (214)) (Prims.of_int (42)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                     (Prims.of_int (214)) (Prims.of_int (2))
-                     (Prims.of_int (263)) (Prims.of_int (7)))))
+                     (Prims.of_int (215)) (Prims.of_int (2))
+                     (Prims.of_int (264)) (Prims.of_int (7)))))
             (FStar_Tactics_Effect.lift_div_tac
                (fun uu___ ->
                   Prims.Mkdtuple2
@@ -1523,17 +1529,17 @@ let (check_effect_annotation :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Abs.fst"
-                                                   (Prims.of_int (232))
+                                                   (Prims.of_int (233))
                                                    (Prims.of_int (14))
-                                                   (Prims.of_int (232))
+                                                   (Prims.of_int (233))
                                                    (Prims.of_int (50)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Abs.fst"
-                                                   (Prims.of_int (232))
+                                                   (Prims.of_int (233))
                                                    (Prims.of_int (53))
-                                                   (Prims.of_int (254))
+                                                   (Prims.of_int (255))
                                                    (Prims.of_int (20)))))
                                           (FStar_Tactics_Effect.lift_div_tac
                                              (fun uu___1 ->
@@ -1548,17 +1554,17 @@ let (check_effect_annotation :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Abs.fst"
-                                                              (Prims.of_int (233))
+                                                              (Prims.of_int (234))
                                                               (Prims.of_int (16))
-                                                              (Prims.of_int (233))
+                                                              (Prims.of_int (234))
                                                               (Prims.of_int (36)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Abs.fst"
-                                                              (Prims.of_int (233))
+                                                              (Prims.of_int (234))
                                                               (Prims.of_int (39))
-                                                              (Prims.of_int (254))
+                                                              (Prims.of_int (255))
                                                               (Prims.of_int (20)))))
                                                      (FStar_Tactics_Effect.lift_div_tac
                                                         (fun uu___1 ->
@@ -1572,17 +1578,17 @@ let (check_effect_annotation :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (48)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (20)))))
                                                                 (FStar_Tactics_Effect.lift_div_tac
                                                                    (fun
@@ -1598,17 +1604,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (89)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (20)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.with_policy
@@ -1627,17 +1633,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (20)))))
                                                                     (if
                                                                     FStar_Pervasives_Native.uu___is_None
@@ -1650,17 +1656,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (47))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1668,17 +1674,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (47))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1686,17 +1692,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (80)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (27)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1704,17 +1710,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (74))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (80)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (80)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1741,17 +1747,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (242))
-                                                                    (Prims.of_int (10))
                                                                     (Prims.of_int (243))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (27)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1759,17 +1765,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (93)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (242))
-                                                                    (Prims.of_int (10))
                                                                     (Prims.of_int (243))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (27)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1777,17 +1783,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (87))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (93)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (93)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1898,17 +1904,17 @@ let (check_effect_annotation :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Abs.fst"
-                                                   (Prims.of_int (232))
+                                                   (Prims.of_int (233))
                                                    (Prims.of_int (14))
-                                                   (Prims.of_int (232))
+                                                   (Prims.of_int (233))
                                                    (Prims.of_int (50)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Abs.fst"
-                                                   (Prims.of_int (232))
+                                                   (Prims.of_int (233))
                                                    (Prims.of_int (53))
-                                                   (Prims.of_int (254))
+                                                   (Prims.of_int (255))
                                                    (Prims.of_int (20)))))
                                           (FStar_Tactics_Effect.lift_div_tac
                                              (fun uu___1 ->
@@ -1923,17 +1929,17 @@ let (check_effect_annotation :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Abs.fst"
-                                                              (Prims.of_int (233))
+                                                              (Prims.of_int (234))
                                                               (Prims.of_int (16))
-                                                              (Prims.of_int (233))
+                                                              (Prims.of_int (234))
                                                               (Prims.of_int (36)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Abs.fst"
-                                                              (Prims.of_int (233))
+                                                              (Prims.of_int (234))
                                                               (Prims.of_int (39))
-                                                              (Prims.of_int (254))
+                                                              (Prims.of_int (255))
                                                               (Prims.of_int (20)))))
                                                      (FStar_Tactics_Effect.lift_div_tac
                                                         (fun uu___1 ->
@@ -1947,17 +1953,17 @@ let (check_effect_annotation :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (48)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (20)))))
                                                                 (FStar_Tactics_Effect.lift_div_tac
                                                                    (fun
@@ -1973,17 +1979,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (89)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (20)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.with_policy
@@ -2002,17 +2008,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (20)))))
                                                                     (if
                                                                     FStar_Pervasives_Native.uu___is_None
@@ -2025,17 +2031,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (47))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2043,17 +2049,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (47))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2061,17 +2067,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (80)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (27)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2079,17 +2085,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (74))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (80)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (80)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -2116,17 +2122,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (242))
-                                                                    (Prims.of_int (10))
                                                                     (Prims.of_int (243))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (27)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2134,17 +2140,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (93)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (242))
-                                                                    (Prims.of_int (10))
                                                                     (Prims.of_int (243))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (27)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2152,17 +2158,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (87))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (93)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (93)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -2263,17 +2269,17 @@ let (check_effect_annotation :
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.Abs.fst"
-                                              (Prims.of_int (258))
+                                              (Prims.of_int (259))
                                               (Prims.of_int (26))
-                                              (Prims.of_int (263))
+                                              (Prims.of_int (264))
                                               (Prims.of_int (7)))))
                                      (FStar_Sealed.seal
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.Abs.fst"
-                                              (Prims.of_int (258))
+                                              (Prims.of_int (259))
                                               (Prims.of_int (6))
-                                              (Prims.of_int (263))
+                                              (Prims.of_int (264))
                                               (Prims.of_int (7)))))
                                      (Obj.magic
                                         (FStar_Tactics_Effect.tac_bind
@@ -2281,17 +2287,17 @@ let (check_effect_annotation :
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Abs.fst"
-                                                    (Prims.of_int (259))
+                                                    (Prims.of_int (260))
                                                     (Prims.of_int (8))
-                                                    (Prims.of_int (262))
+                                                    (Prims.of_int (263))
                                                     (Prims.of_int (67)))))
                                            (FStar_Sealed.seal
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Abs.fst"
-                                                    (Prims.of_int (258))
+                                                    (Prims.of_int (259))
                                                     (Prims.of_int (26))
-                                                    (Prims.of_int (263))
+                                                    (Prims.of_int (264))
                                                     (Prims.of_int (7)))))
                                            (Obj.magic
                                               (FStar_Tactics_Effect.tac_bind
@@ -2299,17 +2305,17 @@ let (check_effect_annotation :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Abs.fst"
-                                                          (Prims.of_int (259))
-                                                          (Prims.of_int (8))
                                                           (Prims.of_int (260))
+                                                          (Prims.of_int (8))
+                                                          (Prims.of_int (261))
                                                           (Prims.of_int (58)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Abs.fst"
-                                                          (Prims.of_int (259))
+                                                          (Prims.of_int (260))
                                                           (Prims.of_int (8))
-                                                          (Prims.of_int (262))
+                                                          (Prims.of_int (263))
                                                           (Prims.of_int (67)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_Effect.tac_bind
@@ -2317,17 +2323,17 @@ let (check_effect_annotation :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Abs.fst"
-                                                                (Prims.of_int (260))
+                                                                (Prims.of_int (261))
                                                                 (Prims.of_int (22))
-                                                                (Prims.of_int (260))
+                                                                (Prims.of_int (261))
                                                                 (Prims.of_int (58)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Abs.fst"
-                                                                (Prims.of_int (259))
-                                                                (Prims.of_int (8))
                                                                 (Prims.of_int (260))
+                                                                (Prims.of_int (8))
+                                                                (Prims.of_int (261))
                                                                 (Prims.of_int (58)))))
                                                        (Obj.magic
                                                           (FStar_Tactics_Effect.tac_bind
@@ -2335,17 +2341,17 @@ let (check_effect_annotation :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (57)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (58)))))
                                                              (Obj.magic
                                                                 (Pulse_Syntax_Printer.tag_of_comp
@@ -2373,17 +2379,17 @@ let (check_effect_annotation :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (261))
-                                                                    (Prims.of_int (8))
                                                                     (Prims.of_int (262))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (67)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (260))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (67)))))
                                                             (Obj.magic
                                                                (FStar_Tactics_Effect.tac_bind
@@ -2391,17 +2397,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (67)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (261))
-                                                                    (Prims.of_int (8))
                                                                     (Prims.of_int (262))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (67)))))
                                                                   (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2409,17 +2415,17 @@ let (check_effect_annotation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (67)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.tag_of_comp
@@ -2497,17 +2503,17 @@ let (maybe_rewrite_body_typing :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Checker.Abs.fst"
-                                                (Prims.of_int (277))
+                                                (Prims.of_int (278))
                                                 (Prims.of_int (19))
-                                                (Prims.of_int (277))
+                                                (Prims.of_int (278))
                                                 (Prims.of_int (68)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Checker.Abs.fst"
-                                                (Prims.of_int (276))
+                                                (Prims.of_int (277))
                                                 (Prims.of_int (20))
-                                                (Prims.of_int (290))
+                                                (Prims.of_int (291))
                                                 (Prims.of_int (7)))))
                                        (Obj.magic
                                           (Pulse_Checker_Pure.instantiate_term_implicits
@@ -2522,17 +2528,17 @@ let (maybe_rewrite_body_typing :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Abs.fst"
-                                                               (Prims.of_int (278))
+                                                               (Prims.of_int (279))
                                                                (Prims.of_int (32))
-                                                               (Prims.of_int (278))
+                                                               (Prims.of_int (279))
                                                                (Prims.of_int (69)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Abs.fst"
-                                                               (Prims.of_int (277))
+                                                               (Prims.of_int (278))
                                                                (Prims.of_int (71))
-                                                               (Prims.of_int (289))
+                                                               (Prims.of_int (290))
                                                                (Prims.of_int (26)))))
                                                       (Obj.magic
                                                          (Pulse_Checker_Pure.check_universe
@@ -2549,17 +2555,17 @@ let (maybe_rewrite_body_typing :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (279))
-                                                                    (Prims.of_int (14))
                                                                     (Prims.of_int (280))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (281))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (279))
+                                                                    (Prims.of_int (280))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (26)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.norm_st_typing_inverse
@@ -2591,17 +2597,17 @@ let (maybe_rewrite_body_typing :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (285))
+                                                                    (Prims.of_int (286))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (26)))))
                                                                     (Obj.magic
                                                                     (debug_abs
@@ -2613,17 +2619,17 @@ let (maybe_rewrite_body_typing :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (286))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (42)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.comp_to_string
@@ -2639,17 +2645,17 @@ let (maybe_rewrite_body_typing :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (286))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (286))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (42)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2657,9 +2663,9 @@ let (maybe_rewrite_body_typing :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2717,17 +2723,17 @@ let (maybe_rewrite_body_typing :
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Checker.Abs.fst"
-                                            (Prims.of_int (295))
+                                            (Prims.of_int (296))
                                             (Prims.of_int (15))
-                                            (Prims.of_int (295))
+                                            (Prims.of_int (296))
                                             (Prims.of_int (32)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Checker.Abs.fst"
-                                            (Prims.of_int (296))
+                                            (Prims.of_int (297))
                                             (Prims.of_int (6))
-                                            (Prims.of_int (296))
+                                            (Prims.of_int (297))
                                             (Prims.of_int (92)))))
                                    (FStar_Tactics_Effect.lift_div_tac
                                       (fun uu___ ->
@@ -2776,13 +2782,13 @@ let rec (check_abs_core :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                   (Prims.of_int (311)) (Prims.of_int (14))
-                   (Prims.of_int (311)) (Prims.of_int (21)))))
+                   (Prims.of_int (312)) (Prims.of_int (14))
+                   (Prims.of_int (312)) (Prims.of_int (21)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                   (Prims.of_int (312)) (Prims.of_int (2))
-                   (Prims.of_int (429)) (Prims.of_int (29)))))
+                   (Prims.of_int (313)) (Prims.of_int (2))
+                   (Prims.of_int (430)) (Prims.of_int (29)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ -> t.Pulse_Syntax_Base.range1))
           (fun uu___ ->
@@ -2803,13 +2809,13 @@ let rec (check_abs_core :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (315)) (Prims.of_int (24))
-                                  (Prims.of_int (315)) (Prims.of_int (49)))))
+                                  (Prims.of_int (316)) (Prims.of_int (24))
+                                  (Prims.of_int (316)) (Prims.of_int (49)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                                  (Prims.of_int (313)) (Prims.of_int (99))
-                                  (Prims.of_int (429)) (Prims.of_int (29)))))
+                                  (Prims.of_int (314)) (Prims.of_int (99))
+                                  (Prims.of_int (430)) (Prims.of_int (29)))))
                          (Obj.magic
                             (Pulse_Checker_Pure.compute_tot_term_type g t1))
                          (fun uu___ ->
@@ -2823,17 +2829,17 @@ let rec (check_abs_core :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Abs.fst"
-                                                 (Prims.of_int (316))
+                                                 (Prims.of_int (317))
                                                  (Prims.of_int (28))
-                                                 (Prims.of_int (316))
+                                                 (Prims.of_int (317))
                                                  (Prims.of_int (46)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Abs.fst"
-                                                 (Prims.of_int (315))
+                                                 (Prims.of_int (316))
                                                  (Prims.of_int (52))
-                                                 (Prims.of_int (429))
+                                                 (Prims.of_int (430))
                                                  (Prims.of_int (29)))))
                                         (Obj.magic
                                            (Pulse_Checker_Pure.check_universe
@@ -2849,17 +2855,17 @@ let rec (check_abs_core :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Abs.fst"
-                                                                (Prims.of_int (317))
+                                                                (Prims.of_int (318))
                                                                 (Prims.of_int (12))
-                                                                (Prims.of_int (317))
+                                                                (Prims.of_int (318))
                                                                 (Prims.of_int (19)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Abs.fst"
-                                                                (Prims.of_int (317))
+                                                                (Prims.of_int (318))
                                                                 (Prims.of_int (22))
-                                                                (Prims.of_int (429))
+                                                                (Prims.of_int (430))
                                                                 (Prims.of_int (29)))))
                                                        (FStar_Tactics_Effect.lift_div_tac
                                                           (fun uu___4 ->
@@ -2873,17 +2879,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (22)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                   (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2900,17 +2906,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (319))
+                                                                    (Prims.of_int (320))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (319))
+                                                                    (Prims.of_int (320))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (319))
+                                                                    (Prims.of_int (320))
                                                                     (Prims.of_int (53))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2932,17 +2938,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (320))
+                                                                    (Prims.of_int (321))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (320))
+                                                                    (Prims.of_int (321))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (320))
+                                                                    (Prims.of_int (321))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2960,17 +2966,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (321))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (321))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (321))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2988,17 +2994,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (322))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (322))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (324))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3021,17 +3027,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (326))
+                                                                    (Prims.of_int (327))
                                                                     (Prims.of_int (44))
-                                                                    (Prims.of_int (326))
+                                                                    (Prims.of_int (327))
                                                                     (Prims.of_int (79)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (324))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (check_abs_core
@@ -3056,17 +3062,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (334))
+                                                                    (Prims.of_int (335))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (326))
+                                                                    (Prims.of_int (327))
                                                                     (Prims.of_int (82))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3074,17 +3080,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (334))
+                                                                    (Prims.of_int (335))
                                                                     (Prims.of_int (35)))))
                                                                     (Obj.magic
                                                                     (sub_effect_comp
@@ -3136,17 +3142,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3162,17 +3168,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (340))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (340))
                                                                     (Prims.of_int (80)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (check_effect_annotation
@@ -3196,17 +3202,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3229,17 +3235,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (38))
-                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (79)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (maybe_rewrite_body_typing
@@ -3264,17 +3270,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (348))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (348))
                                                                     (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (349))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3294,17 +3300,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (355))
+                                                                    (Prims.of_int (356))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (360))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3312,17 +3318,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (354))
+                                                                    (Prims.of_int (355))
                                                                     (Prims.of_int (74)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (355))
+                                                                    (Prims.of_int (356))
                                                                     (Prims.of_int (28)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3330,17 +3336,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (352))
-                                                                    (Prims.of_int (8))
                                                                     (Prims.of_int (353))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (354))
                                                                     (Prims.of_int (19)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (354))
+                                                                    (Prims.of_int (355))
                                                                     (Prims.of_int (74)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Unseal.unseal
@@ -3360,17 +3366,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (354))
+                                                                    (Prims.of_int (355))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (354))
+                                                                    (Prims.of_int (355))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (354))
+                                                                    (Prims.of_int (355))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (354))
+                                                                    (Prims.of_int (355))
                                                                     (Prims.of_int (73)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.instantiate_term_implicits
@@ -3471,17 +3477,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (364))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (380))
+                                                                    (Prims.of_int (381))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (361))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (match 
                                                                     asc1.Pulse_Syntax_Base.elaborated
@@ -3507,17 +3513,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (370))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (372))
+                                                                    (Prims.of_int (373))
                                                                     (Prims.of_int (53)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (368))
+                                                                    (Prims.of_int (369))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (373))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3525,9 +3531,9 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (372))
+                                                                    (Prims.of_int (373))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (372))
+                                                                    (Prims.of_int (373))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -3610,17 +3616,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.check_vprop
@@ -3643,17 +3649,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (384))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (384))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (384))
                                                                     (Prims.of_int (42))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3671,17 +3677,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (385))
+                                                                    (Prims.of_int (386))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (398))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (400))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (match post_hint_body
                                                                     with
@@ -3705,17 +3711,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (397))
                                                                     (Prims.of_int (22)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (398))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (398))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.intro_post_hint
@@ -3744,17 +3750,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (401))
+                                                                    (Prims.of_int (402))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (401))
+                                                                    (Prims.of_int (402))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (401))
+                                                                    (Prims.of_int (402))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3772,17 +3778,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (402))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (402))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (73)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (402))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (77))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (check g'
@@ -3799,17 +3805,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (404))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (404))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (402))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (77))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.apply_checker_result_k
@@ -3836,17 +3842,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (404))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (68))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (404))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (68))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3862,17 +3868,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (406))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (406))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (101)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (406))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (106))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3898,17 +3904,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (411))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (414))
+                                                                    (Prims.of_int (415))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (406))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (106))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3916,17 +3922,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (411))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (411))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (411))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (414))
+                                                                    (Prims.of_int (415))
                                                                     (Prims.of_int (35)))))
                                                                     (Obj.magic
                                                                     (sub_effect_comp
@@ -3979,17 +3985,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (416))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (416))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4007,17 +4013,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (85)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (416))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (check_effect_annotation
@@ -4043,17 +4049,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (419))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (419))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (419))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4078,17 +4084,17 @@ let rec (check_abs_core :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (420))
+                                                                    (Prims.of_int (421))
                                                                     (Prims.of_int (38))
-                                                                    (Prims.of_int (420))
+                                                                    (Prims.of_int (421))
                                                                     (Prims.of_int (79)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Abs.fst"
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (419))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (29)))))
                                                                     (Obj.magic
                                                                     (maybe_rewrite_body_typing
@@ -4202,13 +4208,13 @@ let (check_abs :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                   (Prims.of_int (433)) (Prims.of_int (10))
-                   (Prims.of_int (433)) (Prims.of_int (28)))))
+                   (Prims.of_int (434)) (Prims.of_int (10))
+                   (Prims.of_int (434)) (Prims.of_int (28)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Abs.fst"
-                   (Prims.of_int (434)) (Prims.of_int (2))
-                   (Prims.of_int (434)) (Prims.of_int (26)))))
+                   (Prims.of_int (435)) (Prims.of_int (2))
+                   (Prims.of_int (435)) (Prims.of_int (26)))))
           (Obj.magic (preprocess_abs g t))
           (fun uu___ ->
              (fun t1 -> Obj.magic (check_abs_core g t1 check)) uu___)

--- a/src/ocaml/plugin/generated/Pulse_Elaborate_Pure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Elaborate_Pure.ml
@@ -19,6 +19,12 @@ let (elab_qual :
     | FStar_Pervasives_Native.None -> FStar_Reflection_V2_Data.Q_Explicit
     | FStar_Pervasives_Native.Some (Pulse_Syntax_Base.Implicit) ->
         FStar_Reflection_V2_Data.Q_Implicit
+    | FStar_Pervasives_Native.Some (Pulse_Syntax_Base.TcArg) ->
+        FStar_Reflection_V2_Data.Q_Meta
+          (FStar_Reflection_V2_Builtins.pack_ln
+             (FStar_Reflection_V2_Data.Tv_FVar
+                (FStar_Reflection_V2_Builtins.pack_fv
+                   ["FStar"; "Tactics"; "Typeclasses"; "tcresolve"])))
 let (elab_observability :
   Pulse_Syntax_Base.observability -> FStar_Reflection_Types.term) =
   fun uu___ ->

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Base.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Base.ml
@@ -40,7 +40,11 @@ let (__proj__Mknm__item__nm_ppname : nm -> ppname) =
     match projectee with | { nm_index; nm_ppname;_} -> nm_ppname
 type qualifier =
   | Implicit 
-let (uu___is_Implicit : qualifier -> Prims.bool) = fun projectee -> true
+  | TcArg 
+let (uu___is_Implicit : qualifier -> Prims.bool) =
+  fun projectee -> match projectee with | Implicit -> true | uu___ -> false
+let (uu___is_TcArg : qualifier -> Prims.bool) =
+  fun projectee -> match projectee with | TcArg -> true | uu___ -> false
 type fv = {
   fv_name: FStar_Reflection_Types.name ;
   fv_range: range }
@@ -882,32 +886,32 @@ let (ppname_for_uvar :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Base.fsti"
-               (Prims.of_int (413)) (Prims.of_int (18)) (Prims.of_int (413))
+               (Prims.of_int (414)) (Prims.of_int (18)) (Prims.of_int (414))
                (Prims.of_int (48)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Base.fsti"
-               (Prims.of_int (413)) (Prims.of_int (4)) (Prims.of_int (413))
+               (Prims.of_int (414)) (Prims.of_int (4)) (Prims.of_int (414))
                (Prims.of_int (49)))))
       (Obj.magic
          (FStar_Tactics_Effect.tac_bind
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Base.fsti"
-                     (Prims.of_int (413)) (Prims.of_int (25))
-                     (Prims.of_int (413)) (Prims.of_int (48)))))
+                     (Prims.of_int (414)) (Prims.of_int (25))
+                     (Prims.of_int (414)) (Prims.of_int (48)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Base.fsti"
-                     (Prims.of_int (413)) (Prims.of_int (18))
-                     (Prims.of_int (413)) (Prims.of_int (48)))))
+                     (Prims.of_int (414)) (Prims.of_int (18))
+                     (Prims.of_int (414)) (Prims.of_int (48)))))
             (Obj.magic
                (FStar_Tactics_Effect.tac_bind
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Syntax.Base.fsti"
-                           (Prims.of_int (413)) (Prims.of_int (32))
-                           (Prims.of_int (413)) (Prims.of_int (47)))))
+                           (Prims.of_int (414)) (Prims.of_int (32))
+                           (Prims.of_int (414)) (Prims.of_int (47)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "prims.fst"

--- a/src/ocaml/plugin/generated/Pulse_Syntax_Printer.ml
+++ b/src/ocaml/plugin/generated/Pulse_Syntax_Printer.ml
@@ -43,6 +43,8 @@ let (qual_to_string :
     match uu___ with
     | FStar_Pervasives_Native.None -> ""
     | FStar_Pervasives_Native.Some (Pulse_Syntax_Base.Implicit) -> "#"
+    | FStar_Pervasives_Native.Some (Pulse_Syntax_Base.TcArg) ->
+        "#[tcresolve]"
 let (indent : Prims.string -> Prims.string) =
   fun level -> Prims.strcat level "\t"
 let rec (collect_binders :
@@ -73,12 +75,12 @@ let rec (binder_to_string_paren :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (82)) (Prims.of_int (12)) (Prims.of_int (82))
+               (Prims.of_int (83)) (Prims.of_int (12)) (Prims.of_int (83))
                (Prims.of_int (44)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (77)) (Prims.of_int (4)) (Prims.of_int (82))
+               (Prims.of_int (78)) (Prims.of_int (4)) (Prims.of_int (83))
                (Prims.of_int (44)))))
       (Obj.magic (term_to_string' "" b.Pulse_Syntax_Base.binder_ty))
       (fun uu___ ->
@@ -88,25 +90,25 @@ let rec (binder_to_string_paren :
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                          (Prims.of_int (77)) (Prims.of_int (4))
-                          (Prims.of_int (82)) (Prims.of_int (44)))))
+                          (Prims.of_int (78)) (Prims.of_int (4))
+                          (Prims.of_int (83)) (Prims.of_int (44)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                          (Prims.of_int (77)) (Prims.of_int (4))
-                          (Prims.of_int (82)) (Prims.of_int (44)))))
+                          (Prims.of_int (78)) (Prims.of_int (4))
+                          (Prims.of_int (83)) (Prims.of_int (44)))))
                  (Obj.magic
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (81)) (Prims.of_int (12))
-                                (Prims.of_int (81)) (Prims.of_int (43)))))
+                                (Prims.of_int (82)) (Prims.of_int (12))
+                                (Prims.of_int (82)) (Prims.of_int (43)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (77)) (Prims.of_int (4))
-                                (Prims.of_int (82)) (Prims.of_int (44)))))
+                                (Prims.of_int (78)) (Prims.of_int (4))
+                                (Prims.of_int (83)) (Prims.of_int (44)))))
                        (Obj.magic
                           (FStar_Tactics_Unseal.unseal
                              (b.Pulse_Syntax_Base.binder_ppname).Pulse_Syntax_Base.name))
@@ -118,17 +120,17 @@ let rec (binder_to_string_paren :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (77))
+                                           (Prims.of_int (78))
                                            (Prims.of_int (4))
-                                           (Prims.of_int (82))
+                                           (Prims.of_int (83))
                                            (Prims.of_int (44)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (77))
+                                           (Prims.of_int (78))
                                            (Prims.of_int (4))
-                                           (Prims.of_int (82))
+                                           (Prims.of_int (83))
                                            (Prims.of_int (44)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -136,9 +138,9 @@ let rec (binder_to_string_paren :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (78))
+                                                 (Prims.of_int (79))
                                                  (Prims.of_int (12))
-                                                 (Prims.of_int (80))
+                                                 (Prims.of_int (81))
                                                  (Prims.of_int (91)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
@@ -154,17 +156,17 @@ let rec (binder_to_string_paren :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (78))
+                                                       (Prims.of_int (79))
                                                        (Prims.of_int (19))
-                                                       (Prims.of_int (78))
+                                                       (Prims.of_int (79))
                                                        (Prims.of_int (42)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (78))
+                                                       (Prims.of_int (79))
                                                        (Prims.of_int (12))
-                                                       (Prims.of_int (80))
+                                                       (Prims.of_int (81))
                                                        (Prims.of_int (91)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Unseal.unseal
@@ -186,9 +188,9 @@ let rec (binder_to_string_paren :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (90)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
@@ -204,17 +206,17 @@ let rec (binder_to_string_paren :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (59))
-                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (89)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (80))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (90)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Util.map
@@ -279,8 +281,8 @@ and (term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (90)) (Prims.of_int (8))
-                                (Prims.of_int (90)) (Prims.of_int (42)))))
+                                (Prims.of_int (91)) (Prims.of_int (8))
+                                (Prims.of_int (91)) (Prims.of_int (42)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
@@ -298,13 +300,13 @@ and (term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (96)) (Prims.of_int (8))
-                                (Prims.of_int (96)) (Prims.of_int (34)))))
+                                (Prims.of_int (97)) (Prims.of_int (8))
+                                (Prims.of_int (97)) (Prims.of_int (34)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (93)) (Prims.of_int (6))
-                                (Prims.of_int (96)) (Prims.of_int (34)))))
+                                (Prims.of_int (94)) (Prims.of_int (6))
+                                (Prims.of_int (97)) (Prims.of_int (34)))))
                        (Obj.magic (term_to_string' level p2))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -314,17 +316,17 @@ and (term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (93))
+                                           (Prims.of_int (94))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (96))
+                                           (Prims.of_int (97))
                                            (Prims.of_int (34)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (93))
+                                           (Prims.of_int (94))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (96))
+                                           (Prims.of_int (97))
                                            (Prims.of_int (34)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -332,17 +334,17 @@ and (term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (93))
+                                                 (Prims.of_int (94))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (96))
+                                                 (Prims.of_int (97))
                                                  (Prims.of_int (34)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (93))
+                                                 (Prims.of_int (94))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (96))
+                                                 (Prims.of_int (97))
                                                  (Prims.of_int (34)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -350,9 +352,9 @@ and (term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (94))
+                                                       (Prims.of_int (95))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (94))
+                                                       (Prims.of_int (95))
                                                        (Prims.of_int (34)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
@@ -393,13 +395,13 @@ and (term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (99)) (Prims.of_int (21))
-                                (Prims.of_int (99)) (Prims.of_int (51)))))
+                                (Prims.of_int (100)) (Prims.of_int (21))
+                                (Prims.of_int (100)) (Prims.of_int (51)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (98)) (Prims.of_int (26))
-                                (Prims.of_int (103)) (Prims.of_int (51)))))
+                                (Prims.of_int (99)) (Prims.of_int (26))
+                                (Prims.of_int (104)) (Prims.of_int (51)))))
                        (FStar_Tactics_Effect.lift_div_tac
                           (fun uu___3 ->
                              collect_binders
@@ -414,17 +416,17 @@ and (term_to_string' :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (103))
+                                               (Prims.of_int (104))
                                                (Prims.of_int (14))
-                                               (Prims.of_int (103))
+                                               (Prims.of_int (104))
                                                (Prims.of_int (51)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (100))
+                                               (Prims.of_int (101))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (103))
+                                               (Prims.of_int (104))
                                                (Prims.of_int (51)))))
                                       (Obj.magic
                                          (term_to_string' (indent level) body))
@@ -436,17 +438,17 @@ and (term_to_string' :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Syntax.Printer.fst"
-                                                          (Prims.of_int (100))
+                                                          (Prims.of_int (101))
                                                           (Prims.of_int (6))
-                                                          (Prims.of_int (103))
+                                                          (Prims.of_int (104))
                                                           (Prims.of_int (51)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Syntax.Printer.fst"
-                                                          (Prims.of_int (100))
+                                                          (Prims.of_int (101))
                                                           (Prims.of_int (6))
-                                                          (Prims.of_int (103))
+                                                          (Prims.of_int (104))
                                                           (Prims.of_int (51)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_Effect.tac_bind
@@ -454,17 +456,17 @@ and (term_to_string' :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (100))
+                                                                (Prims.of_int (101))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (103))
+                                                                (Prims.of_int (104))
                                                                 (Prims.of_int (51)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (100))
+                                                                (Prims.of_int (101))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (103))
+                                                                (Prims.of_int (104))
                                                                 (Prims.of_int (51)))))
                                                        (Obj.magic
                                                           (FStar_Tactics_Effect.tac_bind
@@ -472,9 +474,9 @@ and (term_to_string' :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (102))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (102))
                                                                     (Prims.of_int (68)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
@@ -490,17 +492,17 @@ and (term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (102))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (102))
                                                                     (Prims.of_int (46)))))
                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (102))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (101))
+                                                                    (Prims.of_int (102))
                                                                     (Prims.of_int (68)))))
                                                                    (Obj.magic
                                                                     (FStar_Tactics_Util.map
@@ -547,13 +549,13 @@ and (term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (106)) (Prims.of_int (21))
-                                (Prims.of_int (106)) (Prims.of_int (51)))))
+                                (Prims.of_int (107)) (Prims.of_int (21))
+                                (Prims.of_int (107)) (Prims.of_int (51)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (105)) (Prims.of_int (29))
-                                (Prims.of_int (110)) (Prims.of_int (51)))))
+                                (Prims.of_int (106)) (Prims.of_int (29))
+                                (Prims.of_int (111)) (Prims.of_int (51)))))
                        (FStar_Tactics_Effect.lift_div_tac
                           (fun uu___ ->
                              collect_binders
@@ -568,17 +570,17 @@ and (term_to_string' :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (110))
+                                               (Prims.of_int (111))
                                                (Prims.of_int (14))
-                                               (Prims.of_int (110))
+                                               (Prims.of_int (111))
                                                (Prims.of_int (51)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (107))
+                                               (Prims.of_int (108))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (110))
+                                               (Prims.of_int (111))
                                                (Prims.of_int (51)))))
                                       (Obj.magic
                                          (term_to_string' (indent level)
@@ -591,17 +593,17 @@ and (term_to_string' :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Syntax.Printer.fst"
-                                                          (Prims.of_int (107))
+                                                          (Prims.of_int (108))
                                                           (Prims.of_int (6))
-                                                          (Prims.of_int (110))
+                                                          (Prims.of_int (111))
                                                           (Prims.of_int (51)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Syntax.Printer.fst"
-                                                          (Prims.of_int (107))
+                                                          (Prims.of_int (108))
                                                           (Prims.of_int (6))
-                                                          (Prims.of_int (110))
+                                                          (Prims.of_int (111))
                                                           (Prims.of_int (51)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_Effect.tac_bind
@@ -609,17 +611,17 @@ and (term_to_string' :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (107))
+                                                                (Prims.of_int (108))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (110))
+                                                                (Prims.of_int (111))
                                                                 (Prims.of_int (51)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (107))
+                                                                (Prims.of_int (108))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (110))
+                                                                (Prims.of_int (111))
                                                                 (Prims.of_int (51)))))
                                                        (Obj.magic
                                                           (FStar_Tactics_Effect.tac_bind
@@ -627,9 +629,9 @@ and (term_to_string' :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (108))
+                                                                    (Prims.of_int (109))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (108))
+                                                                    (Prims.of_int (109))
                                                                     (Prims.of_int (68)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
@@ -645,17 +647,17 @@ and (term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (108))
+                                                                    (Prims.of_int (109))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (108))
+                                                                    (Prims.of_int (109))
                                                                     (Prims.of_int (46)))))
                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (108))
+                                                                    (Prims.of_int (109))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (108))
+                                                                    (Prims.of_int (109))
                                                                     (Prims.of_int (68)))))
                                                                    (Obj.magic
                                                                     (FStar_Tactics_Util.map
@@ -720,13 +722,13 @@ and (term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (119)) (Prims.of_int (8))
-                                (Prims.of_int (119)) (Prims.of_int (33)))))
+                                (Prims.of_int (120)) (Prims.of_int (8))
+                                (Prims.of_int (120)) (Prims.of_int (33)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (117)) (Prims.of_int (6))
-                                (Prims.of_int (119)) (Prims.of_int (33)))))
+                                (Prims.of_int (118)) (Prims.of_int (6))
+                                (Prims.of_int (120)) (Prims.of_int (33)))))
                        (Obj.magic (term_to_string' level p))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -736,17 +738,17 @@ and (term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (117))
+                                           (Prims.of_int (118))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (119))
+                                           (Prims.of_int (120))
                                            (Prims.of_int (33)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (117))
+                                           (Prims.of_int (118))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (119))
+                                           (Prims.of_int (120))
                                            (Prims.of_int (33)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -754,9 +756,9 @@ and (term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (118))
+                                                 (Prims.of_int (119))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (118))
+                                                 (Prims.of_int (119))
                                                  (Prims.of_int (33)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
@@ -813,13 +815,13 @@ let rec fold_right1 :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (130)) (Prims.of_int (19))
-                                (Prims.of_int (130)) (Prims.of_int (37)))))
+                                (Prims.of_int (131)) (Prims.of_int (19))
+                                (Prims.of_int (131)) (Prims.of_int (37)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (130)) (Prims.of_int (14))
-                                (Prims.of_int (130)) (Prims.of_int (37)))))
+                                (Prims.of_int (131)) (Prims.of_int (14))
+                                (Prims.of_int (131)) (Prims.of_int (37)))))
                        (Obj.magic (fold_right1 f tl))
                        (fun uu___ ->
                           (fun uu___ -> Obj.magic (f hd uu___)) uu___))))
@@ -832,12 +834,12 @@ let (should_paren_term :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (132)) (Prims.of_int (23)) (Prims.of_int (132))
+               (Prims.of_int (133)) (Prims.of_int (23)) (Prims.of_int (133))
                (Prims.of_int (24)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (133)) (Prims.of_int (2)) (Prims.of_int (135))
+               (Prims.of_int (134)) (Prims.of_int (2)) (Prims.of_int (136))
                (Prims.of_int (14)))))
       (Obj.magic (FStar_Tactics_NamedView.inspect t))
       (fun uu___ ->
@@ -856,37 +858,37 @@ let rec (binder_to_doc :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (138)) (Prims.of_int (9)) (Prims.of_int (140))
+               (Prims.of_int (139)) (Prims.of_int (9)) (Prims.of_int (141))
                (Prims.of_int (37)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (138)) (Prims.of_int (2)) (Prims.of_int (140))
+               (Prims.of_int (139)) (Prims.of_int (2)) (Prims.of_int (141))
                (Prims.of_int (37)))))
       (Obj.magic
          (FStar_Tactics_Effect.tac_bind
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (138)) (Prims.of_int (10))
-                     (Prims.of_int (138)) (Prims.of_int (55)))))
+                     (Prims.of_int (139)) (Prims.of_int (10))
+                     (Prims.of_int (139)) (Prims.of_int (55)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                     (Prims.of_int (138)) (Prims.of_int (9))
-                     (Prims.of_int (140)) (Prims.of_int (37)))))
+                     (Prims.of_int (139)) (Prims.of_int (9))
+                     (Prims.of_int (141)) (Prims.of_int (37)))))
             (Obj.magic
                (FStar_Tactics_Effect.tac_bind
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                           (Prims.of_int (138)) (Prims.of_int (24))
-                           (Prims.of_int (138)) (Prims.of_int (55)))))
+                           (Prims.of_int (139)) (Prims.of_int (24))
+                           (Prims.of_int (139)) (Prims.of_int (55)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                           (Prims.of_int (138)) (Prims.of_int (10))
-                           (Prims.of_int (138)) (Prims.of_int (55)))))
+                           (Prims.of_int (139)) (Prims.of_int (10))
+                           (Prims.of_int (139)) (Prims.of_int (55)))))
                   (Obj.magic
                      (FStar_Tactics_Unseal.unseal
                         (b.Pulse_Syntax_Base.binder_ppname).Pulse_Syntax_Base.name))
@@ -900,30 +902,30 @@ let rec (binder_to_doc :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (139)) (Prims.of_int (13))
-                                (Prims.of_int (140)) (Prims.of_int (36)))))
+                                (Prims.of_int (140)) (Prims.of_int (13))
+                                (Prims.of_int (141)) (Prims.of_int (36)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (138)) (Prims.of_int (9))
-                                (Prims.of_int (140)) (Prims.of_int (37)))))
+                                (Prims.of_int (139)) (Prims.of_int (9))
+                                (Prims.of_int (141)) (Prims.of_int (37)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (140))
+                                      (Prims.of_int (141))
                                       (Prims.of_int (13))
-                                      (Prims.of_int (140))
+                                      (Prims.of_int (141))
                                       (Prims.of_int (36)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (139))
-                                      (Prims.of_int (13))
                                       (Prims.of_int (140))
+                                      (Prims.of_int (13))
+                                      (Prims.of_int (141))
                                       (Prims.of_int (36)))))
                              (Obj.magic
                                 (term_to_doc b.Pulse_Syntax_Base.binder_ty))
@@ -959,27 +961,27 @@ and (term_to_doc :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (146)) (Prims.of_int (44))
-                            (Prims.of_int (146)) (Prims.of_int (66)))))
+                            (Prims.of_int (147)) (Prims.of_int (44))
+                            (Prims.of_int (147)) (Prims.of_int (66)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (146)) (Prims.of_int (19))
-                            (Prims.of_int (146)) (Prims.of_int (66)))))
+                            (Prims.of_int (147)) (Prims.of_int (19))
+                            (Prims.of_int (147)) (Prims.of_int (66)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Syntax.Printer.fst"
-                                  (Prims.of_int (146)) (Prims.of_int (51))
-                                  (Prims.of_int (146)) (Prims.of_int (66)))))
+                                  (Prims.of_int (147)) (Prims.of_int (51))
+                                  (Prims.of_int (147)) (Prims.of_int (66)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Syntax.Printer.fst"
-                                  (Prims.of_int (146)) (Prims.of_int (44))
-                                  (Prims.of_int (146)) (Prims.of_int (66)))))
+                                  (Prims.of_int (147)) (Prims.of_int (44))
+                                  (Prims.of_int (147)) (Prims.of_int (66)))))
                          (Obj.magic (term_to_doc p))
                          (fun uu___ ->
                             FStar_Tactics_Effect.lift_div_tac
@@ -996,13 +998,13 @@ and (term_to_doc :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (157)) (Prims.of_int (23))
-                            (Prims.of_int (157)) (Prims.of_int (38)))))
+                            (Prims.of_int (158)) (Prims.of_int (23))
+                            (Prims.of_int (158)) (Prims.of_int (38)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (157)) (Prims.of_int (41))
-                            (Prims.of_int (168)) (Prims.of_int (80)))))
+                            (Prims.of_int (158)) (Prims.of_int (41))
+                            (Prims.of_int (169)) (Prims.of_int (80)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___2 -> Pulse_Syntax_Pure.vprop_as_list t))
                    (fun uu___2 ->
@@ -1013,17 +1015,17 @@ and (term_to_doc :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Syntax.Printer.fst"
-                                       (Prims.of_int (159))
+                                       (Prims.of_int (160))
                                        (Prims.of_int (8))
-                                       (Prims.of_int (161))
+                                       (Prims.of_int (162))
                                        (Prims.of_int (26)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Syntax.Printer.fst"
-                                       (Prims.of_int (162))
+                                       (Prims.of_int (163))
                                        (Prims.of_int (8))
-                                       (Prims.of_int (168))
+                                       (Prims.of_int (169))
                                        (Prims.of_int (80)))))
                               (FStar_Tactics_Effect.lift_div_tac
                                  (fun uu___2 ->
@@ -1033,17 +1035,17 @@ and (term_to_doc :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (159))
+                                                 (Prims.of_int (160))
                                                  (Prims.of_int (11))
-                                                 (Prims.of_int (159))
+                                                 (Prims.of_int (160))
                                                  (Prims.of_int (30)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (159))
+                                                 (Prims.of_int (160))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (161))
+                                                 (Prims.of_int (162))
                                                  (Prims.of_int (26)))))
                                         (Obj.magic (should_paren_term t1))
                                         (fun uu___3 ->
@@ -1056,17 +1058,17 @@ and (term_to_doc :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Syntax.Printer.fst"
-                                                              (Prims.of_int (160))
+                                                              (Prims.of_int (161))
                                                               (Prims.of_int (20))
-                                                              (Prims.of_int (160))
+                                                              (Prims.of_int (161))
                                                               (Prims.of_int (35)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Syntax.Printer.fst"
-                                                              (Prims.of_int (160))
+                                                              (Prims.of_int (161))
                                                               (Prims.of_int (13))
-                                                              (Prims.of_int (160))
+                                                              (Prims.of_int (161))
                                                               (Prims.of_int (35)))))
                                                      (Obj.magic
                                                         (term_to_doc t1))
@@ -1085,17 +1087,17 @@ and (term_to_doc :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Syntax.Printer.fst"
-                                                  (Prims.of_int (163))
+                                                  (Prims.of_int (164))
                                                   (Prims.of_int (17))
-                                                  (Prims.of_int (163))
+                                                  (Prims.of_int (164))
                                                   (Prims.of_int (51)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Syntax.Printer.fst"
-                                                  (Prims.of_int (167))
-                                                  (Prims.of_int (6))
                                                   (Prims.of_int (168))
+                                                  (Prims.of_int (6))
+                                                  (Prims.of_int (169))
                                                   (Prims.of_int (80)))))
                                          (Obj.magic
                                             (FStar_Tactics_Util.map
@@ -1108,17 +1110,17 @@ and (term_to_doc :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (168))
+                                                             (Prims.of_int (169))
                                                              (Prims.of_int (8))
-                                                             (Prims.of_int (168))
+                                                             (Prims.of_int (169))
                                                              (Prims.of_int (80)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (167))
-                                                             (Prims.of_int (6))
                                                              (Prims.of_int (168))
+                                                             (Prims.of_int (6))
+                                                             (Prims.of_int (169))
                                                              (Prims.of_int (80)))))
                                                     (Obj.magic
                                                        (fold_right1
@@ -1153,13 +1155,13 @@ and (term_to_doc :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (171)) (Prims.of_int (21))
-                            (Prims.of_int (171)) (Prims.of_int (51)))))
+                            (Prims.of_int (172)) (Prims.of_int (21))
+                            (Prims.of_int (172)) (Prims.of_int (51)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (170)) (Prims.of_int (26))
-                            (Prims.of_int (175)) (Prims.of_int (37)))))
+                            (Prims.of_int (171)) (Prims.of_int (26))
+                            (Prims.of_int (176)) (Prims.of_int (37)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___3 ->
                          collect_binders
@@ -1174,17 +1176,17 @@ and (term_to_doc :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (172))
+                                           (Prims.of_int (173))
                                            (Prims.of_int (19))
-                                           (Prims.of_int (172))
+                                           (Prims.of_int (173))
                                            (Prims.of_int (88)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (173))
+                                           (Prims.of_int (174))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (175))
+                                           (Prims.of_int (176))
                                            (Prims.of_int (37)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -1192,17 +1194,17 @@ and (term_to_doc :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (172))
+                                                 (Prims.of_int (173))
                                                  (Prims.of_int (25))
-                                                 (Prims.of_int (172))
+                                                 (Prims.of_int (173))
                                                  (Prims.of_int (88)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (172))
+                                                 (Prims.of_int (173))
                                                  (Prims.of_int (19))
-                                                 (Prims.of_int (172))
+                                                 (Prims.of_int (173))
                                                  (Prims.of_int (88)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -1210,17 +1212,17 @@ and (term_to_doc :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (172))
+                                                       (Prims.of_int (173))
                                                        (Prims.of_int (32))
-                                                       (Prims.of_int (172))
+                                                       (Prims.of_int (173))
                                                        (Prims.of_int (87)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (172))
+                                                       (Prims.of_int (173))
                                                        (Prims.of_int (25))
-                                                       (Prims.of_int (172))
+                                                       (Prims.of_int (173))
                                                        (Prims.of_int (88)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -1228,17 +1230,17 @@ and (term_to_doc :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (172))
+                                                             (Prims.of_int (173))
                                                              (Prims.of_int (62))
-                                                             (Prims.of_int (172))
+                                                             (Prims.of_int (173))
                                                              (Prims.of_int (86)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (172))
+                                                             (Prims.of_int (173))
                                                              (Prims.of_int (32))
-                                                             (Prims.of_int (172))
+                                                             (Prims.of_int (173))
                                                              (Prims.of_int (87)))))
                                                     (Obj.magic
                                                        (FStar_Tactics_Util.map
@@ -1266,17 +1268,17 @@ and (term_to_doc :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Syntax.Printer.fst"
-                                                      (Prims.of_int (174))
-                                                      (Prims.of_int (8))
                                                       (Prims.of_int (175))
+                                                      (Prims.of_int (8))
+                                                      (Prims.of_int (176))
                                                       (Prims.of_int (37)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Syntax.Printer.fst"
-                                                      (Prims.of_int (173))
+                                                      (Prims.of_int (174))
                                                       (Prims.of_int (6))
-                                                      (Prims.of_int (175))
+                                                      (Prims.of_int (176))
                                                       (Prims.of_int (37)))))
                                              (Obj.magic
                                                 (FStar_Tactics_Effect.tac_bind
@@ -1284,17 +1286,17 @@ and (term_to_doc :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (175))
+                                                            (Prims.of_int (176))
                                                             (Prims.of_int (19))
-                                                            (Prims.of_int (175))
+                                                            (Prims.of_int (176))
                                                             (Prims.of_int (37)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (174))
-                                                            (Prims.of_int (8))
                                                             (Prims.of_int (175))
+                                                            (Prims.of_int (8))
+                                                            (Prims.of_int (176))
                                                             (Prims.of_int (37)))))
                                                    (Obj.magic
                                                       (term_to_doc body))
@@ -1326,13 +1328,13 @@ and (term_to_doc :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (181)) (Prims.of_int (21))
-                            (Prims.of_int (181)) (Prims.of_int (51)))))
+                            (Prims.of_int (182)) (Prims.of_int (21))
+                            (Prims.of_int (182)) (Prims.of_int (51)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (180)) (Prims.of_int (26))
-                            (Prims.of_int (185)) (Prims.of_int (37)))))
+                            (Prims.of_int (181)) (Prims.of_int (26))
+                            (Prims.of_int (186)) (Prims.of_int (37)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___3 ->
                          collect_binders
@@ -1347,17 +1349,17 @@ and (term_to_doc :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (182))
+                                           (Prims.of_int (183))
                                            (Prims.of_int (19))
-                                           (Prims.of_int (182))
+                                           (Prims.of_int (183))
                                            (Prims.of_int (88)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (183))
+                                           (Prims.of_int (184))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (185))
+                                           (Prims.of_int (186))
                                            (Prims.of_int (37)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -1365,17 +1367,17 @@ and (term_to_doc :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (182))
+                                                 (Prims.of_int (183))
                                                  (Prims.of_int (25))
-                                                 (Prims.of_int (182))
+                                                 (Prims.of_int (183))
                                                  (Prims.of_int (88)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (182))
+                                                 (Prims.of_int (183))
                                                  (Prims.of_int (19))
-                                                 (Prims.of_int (182))
+                                                 (Prims.of_int (183))
                                                  (Prims.of_int (88)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -1383,17 +1385,17 @@ and (term_to_doc :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (182))
+                                                       (Prims.of_int (183))
                                                        (Prims.of_int (32))
-                                                       (Prims.of_int (182))
+                                                       (Prims.of_int (183))
                                                        (Prims.of_int (87)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (182))
+                                                       (Prims.of_int (183))
                                                        (Prims.of_int (25))
-                                                       (Prims.of_int (182))
+                                                       (Prims.of_int (183))
                                                        (Prims.of_int (88)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -1401,17 +1403,17 @@ and (term_to_doc :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (182))
+                                                             (Prims.of_int (183))
                                                              (Prims.of_int (62))
-                                                             (Prims.of_int (182))
+                                                             (Prims.of_int (183))
                                                              (Prims.of_int (86)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (182))
+                                                             (Prims.of_int (183))
                                                              (Prims.of_int (32))
-                                                             (Prims.of_int (182))
+                                                             (Prims.of_int (183))
                                                              (Prims.of_int (87)))))
                                                     (Obj.magic
                                                        (FStar_Tactics_Util.map
@@ -1439,17 +1441,17 @@ and (term_to_doc :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Syntax.Printer.fst"
-                                                      (Prims.of_int (184))
-                                                      (Prims.of_int (8))
                                                       (Prims.of_int (185))
+                                                      (Prims.of_int (8))
+                                                      (Prims.of_int (186))
                                                       (Prims.of_int (37)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Syntax.Printer.fst"
-                                                      (Prims.of_int (183))
+                                                      (Prims.of_int (184))
                                                       (Prims.of_int (6))
-                                                      (Prims.of_int (185))
+                                                      (Prims.of_int (186))
                                                       (Prims.of_int (37)))))
                                              (Obj.magic
                                                 (FStar_Tactics_Effect.tac_bind
@@ -1457,17 +1459,17 @@ and (term_to_doc :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (185))
+                                                            (Prims.of_int (186))
                                                             (Prims.of_int (19))
-                                                            (Prims.of_int (185))
+                                                            (Prims.of_int (186))
                                                             (Prims.of_int (37)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (184))
-                                                            (Prims.of_int (8))
                                                             (Prims.of_int (185))
+                                                            (Prims.of_int (8))
+                                                            (Prims.of_int (186))
                                                             (Prims.of_int (37)))))
                                                    (Obj.magic
                                                       (term_to_doc body))
@@ -1514,13 +1516,13 @@ and (term_to_doc :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (192)) (Prims.of_int (16))
-                            (Prims.of_int (192)) (Prims.of_int (31)))))
+                            (Prims.of_int (193)) (Prims.of_int (16))
+                            (Prims.of_int (193)) (Prims.of_int (31)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (191)) (Prims.of_int (6))
-                            (Prims.of_int (193)) (Prims.of_int (31)))))
+                            (Prims.of_int (192)) (Prims.of_int (6))
+                            (Prims.of_int (194)) (Prims.of_int (31)))))
                    (Obj.magic (term_to_doc i))
                    (fun uu___ ->
                       (fun uu___ ->
@@ -1530,17 +1532,17 @@ and (term_to_doc :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Syntax.Printer.fst"
-                                       (Prims.of_int (193))
+                                       (Prims.of_int (194))
                                        (Prims.of_int (16))
-                                       (Prims.of_int (193))
+                                       (Prims.of_int (194))
                                        (Prims.of_int (31)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Syntax.Printer.fst"
-                                       (Prims.of_int (191))
+                                       (Prims.of_int (192))
                                        (Prims.of_int (6))
-                                       (Prims.of_int (193))
+                                       (Prims.of_int (194))
                                        (Prims.of_int (31)))))
                               (Obj.magic (term_to_doc p))
                               (fun uu___1 ->
@@ -1567,12 +1569,12 @@ let (binder_to_string :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (205)) (Prims.of_int (12)) (Prims.of_int (205))
+               (Prims.of_int (206)) (Prims.of_int (12)) (Prims.of_int (206))
                (Prims.of_int (40)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (200)) (Prims.of_int (4)) (Prims.of_int (205))
+               (Prims.of_int (201)) (Prims.of_int (4)) (Prims.of_int (206))
                (Prims.of_int (40)))))
       (Obj.magic (term_to_string b.Pulse_Syntax_Base.binder_ty))
       (fun uu___ ->
@@ -1582,25 +1584,25 @@ let (binder_to_string :
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                          (Prims.of_int (200)) (Prims.of_int (4))
-                          (Prims.of_int (205)) (Prims.of_int (40)))))
+                          (Prims.of_int (201)) (Prims.of_int (4))
+                          (Prims.of_int (206)) (Prims.of_int (40)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                          (Prims.of_int (200)) (Prims.of_int (4))
-                          (Prims.of_int (205)) (Prims.of_int (40)))))
+                          (Prims.of_int (201)) (Prims.of_int (4))
+                          (Prims.of_int (206)) (Prims.of_int (40)))))
                  (Obj.magic
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (204)) (Prims.of_int (12))
-                                (Prims.of_int (204)) (Prims.of_int (43)))))
+                                (Prims.of_int (205)) (Prims.of_int (12))
+                                (Prims.of_int (205)) (Prims.of_int (43)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (200)) (Prims.of_int (4))
-                                (Prims.of_int (205)) (Prims.of_int (40)))))
+                                (Prims.of_int (201)) (Prims.of_int (4))
+                                (Prims.of_int (206)) (Prims.of_int (40)))))
                        (Obj.magic
                           (FStar_Tactics_Unseal.unseal
                              (b.Pulse_Syntax_Base.binder_ppname).Pulse_Syntax_Base.name))
@@ -1612,17 +1614,17 @@ let (binder_to_string :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (200))
+                                           (Prims.of_int (201))
                                            (Prims.of_int (4))
-                                           (Prims.of_int (205))
+                                           (Prims.of_int (206))
                                            (Prims.of_int (40)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (200))
+                                           (Prims.of_int (201))
                                            (Prims.of_int (4))
-                                           (Prims.of_int (205))
+                                           (Prims.of_int (206))
                                            (Prims.of_int (40)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -1630,9 +1632,9 @@ let (binder_to_string :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (201))
+                                                 (Prims.of_int (202))
                                                  (Prims.of_int (12))
-                                                 (Prims.of_int (203))
+                                                 (Prims.of_int (204))
                                                  (Prims.of_int (91)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
@@ -1648,17 +1650,17 @@ let (binder_to_string :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (201))
+                                                       (Prims.of_int (202))
                                                        (Prims.of_int (19))
-                                                       (Prims.of_int (201))
+                                                       (Prims.of_int (202))
                                                        (Prims.of_int (42)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (201))
+                                                       (Prims.of_int (202))
                                                        (Prims.of_int (12))
-                                                       (Prims.of_int (203))
+                                                       (Prims.of_int (204))
                                                        (Prims.of_int (91)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Unseal.unseal
@@ -1680,9 +1682,9 @@ let (binder_to_string :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (204))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (204))
                                                                     (Prims.of_int (90)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
@@ -1698,17 +1700,17 @@ let (binder_to_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (204))
                                                                     (Prims.of_int (59))
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (204))
                                                                     (Prims.of_int (89)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (204))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (204))
                                                                     (Prims.of_int (90)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Util.map
@@ -1783,8 +1785,8 @@ let (effect_annot_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (219)) (Prims.of_int (57))
-                            (Prims.of_int (219)) (Prims.of_int (79)))))
+                            (Prims.of_int (220)) (Prims.of_int (57))
+                            (Prims.of_int (220)) (Prims.of_int (79)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -1803,8 +1805,8 @@ let (effect_annot_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (220)) (Prims.of_int (59))
-                            (Prims.of_int (220)) (Prims.of_int (81)))))
+                            (Prims.of_int (221)) (Prims.of_int (59))
+                            (Prims.of_int (221)) (Prims.of_int (81)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -1824,8 +1826,8 @@ let (effect_annot_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (221)) (Prims.of_int (75))
-                            (Prims.of_int (221)) (Prims.of_int (97)))))
+                            (Prims.of_int (222)) (Prims.of_int (75))
+                            (Prims.of_int (222)) (Prims.of_int (97)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -1848,8 +1850,8 @@ let (comp_to_string :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (227)) (Prims.of_int (23))
-                   (Prims.of_int (227)) (Prims.of_int (41)))))
+                   (Prims.of_int (228)) (Prims.of_int (23))
+                   (Prims.of_int (228)) (Prims.of_int (41)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -1863,13 +1865,13 @@ let (comp_to_string :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (233)) (Prims.of_int (14))
-                   (Prims.of_int (233)) (Prims.of_int (37)))))
+                   (Prims.of_int (234)) (Prims.of_int (14))
+                   (Prims.of_int (234)) (Prims.of_int (37)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (230)) (Prims.of_int (6))
-                   (Prims.of_int (233)) (Prims.of_int (37)))))
+                   (Prims.of_int (231)) (Prims.of_int (6))
+                   (Prims.of_int (234)) (Prims.of_int (37)))))
           (Obj.magic (term_to_string s.Pulse_Syntax_Base.post))
           (fun uu___ ->
              (fun uu___ ->
@@ -1878,27 +1880,27 @@ let (comp_to_string :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (230)) (Prims.of_int (6))
-                              (Prims.of_int (233)) (Prims.of_int (37)))))
+                              (Prims.of_int (231)) (Prims.of_int (6))
+                              (Prims.of_int (234)) (Prims.of_int (37)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (230)) (Prims.of_int (6))
-                              (Prims.of_int (233)) (Prims.of_int (37)))))
+                              (Prims.of_int (231)) (Prims.of_int (6))
+                              (Prims.of_int (234)) (Prims.of_int (37)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (232)) (Prims.of_int (14))
-                                    (Prims.of_int (232)) (Prims.of_int (36)))))
+                                    (Prims.of_int (233)) (Prims.of_int (14))
+                                    (Prims.of_int (233)) (Prims.of_int (36)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (230)) (Prims.of_int (6))
-                                    (Prims.of_int (233)) (Prims.of_int (37)))))
+                                    (Prims.of_int (231)) (Prims.of_int (6))
+                                    (Prims.of_int (234)) (Prims.of_int (37)))))
                            (Obj.magic
                               (term_to_string s.Pulse_Syntax_Base.pre))
                            (fun uu___1 ->
@@ -1909,17 +1911,17 @@ let (comp_to_string :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (230))
+                                               (Prims.of_int (231))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (233))
+                                               (Prims.of_int (234))
                                                (Prims.of_int (37)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (230))
+                                               (Prims.of_int (231))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (233))
+                                               (Prims.of_int (234))
                                                (Prims.of_int (37)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -1927,9 +1929,9 @@ let (comp_to_string :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (231))
+                                                     (Prims.of_int (232))
                                                      (Prims.of_int (14))
-                                                     (Prims.of_int (231))
+                                                     (Prims.of_int (232))
                                                      (Prims.of_int (36)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
@@ -1970,13 +1972,13 @@ let (comp_to_string :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (241)) (Prims.of_int (14))
-                   (Prims.of_int (241)) (Prims.of_int (37)))))
+                   (Prims.of_int (242)) (Prims.of_int (14))
+                   (Prims.of_int (242)) (Prims.of_int (37)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (236)) (Prims.of_int (6))
-                   (Prims.of_int (241)) (Prims.of_int (37)))))
+                   (Prims.of_int (237)) (Prims.of_int (6))
+                   (Prims.of_int (242)) (Prims.of_int (37)))))
           (Obj.magic (term_to_string s.Pulse_Syntax_Base.post))
           (fun uu___ ->
              (fun uu___ ->
@@ -1985,27 +1987,27 @@ let (comp_to_string :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (236)) (Prims.of_int (6))
-                              (Prims.of_int (241)) (Prims.of_int (37)))))
+                              (Prims.of_int (237)) (Prims.of_int (6))
+                              (Prims.of_int (242)) (Prims.of_int (37)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (236)) (Prims.of_int (6))
-                              (Prims.of_int (241)) (Prims.of_int (37)))))
+                              (Prims.of_int (237)) (Prims.of_int (6))
+                              (Prims.of_int (242)) (Prims.of_int (37)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (240)) (Prims.of_int (14))
-                                    (Prims.of_int (240)) (Prims.of_int (36)))))
+                                    (Prims.of_int (241)) (Prims.of_int (14))
+                                    (Prims.of_int (241)) (Prims.of_int (36)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (236)) (Prims.of_int (6))
-                                    (Prims.of_int (241)) (Prims.of_int (37)))))
+                                    (Prims.of_int (237)) (Prims.of_int (6))
+                                    (Prims.of_int (242)) (Prims.of_int (37)))))
                            (Obj.magic
                               (term_to_string s.Pulse_Syntax_Base.pre))
                            (fun uu___1 ->
@@ -2016,17 +2018,17 @@ let (comp_to_string :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (236))
+                                               (Prims.of_int (237))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (241))
+                                               (Prims.of_int (242))
                                                (Prims.of_int (37)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (236))
+                                               (Prims.of_int (237))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (241))
+                                               (Prims.of_int (242))
                                                (Prims.of_int (37)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -2034,17 +2036,17 @@ let (comp_to_string :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (239))
+                                                     (Prims.of_int (240))
                                                      (Prims.of_int (14))
-                                                     (Prims.of_int (239))
+                                                     (Prims.of_int (240))
                                                      (Prims.of_int (37)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (236))
+                                                     (Prims.of_int (237))
                                                      (Prims.of_int (6))
-                                                     (Prims.of_int (241))
+                                                     (Prims.of_int (242))
                                                      (Prims.of_int (37)))))
                                             (Obj.magic
                                                (term_to_string inames))
@@ -2056,17 +2058,17 @@ let (comp_to_string :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (236))
+                                                                (Prims.of_int (237))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (241))
+                                                                (Prims.of_int (242))
                                                                 (Prims.of_int (37)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (236))
+                                                                (Prims.of_int (237))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (241))
+                                                                (Prims.of_int (242))
                                                                 (Prims.of_int (37)))))
                                                        (Obj.magic
                                                           (FStar_Tactics_Effect.tac_bind
@@ -2074,17 +2076,17 @@ let (comp_to_string :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (237))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (37)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (237))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (37)))))
                                                              (Obj.magic
                                                                 (FStar_Tactics_Effect.tac_bind
@@ -2092,9 +2094,9 @@ let (comp_to_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (36)))))
                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2159,13 +2161,13 @@ let (comp_to_string :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (248)) (Prims.of_int (14))
-                   (Prims.of_int (248)) (Prims.of_int (37)))))
+                   (Prims.of_int (249)) (Prims.of_int (14))
+                   (Prims.of_int (249)) (Prims.of_int (37)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (244)) (Prims.of_int (6))
-                   (Prims.of_int (248)) (Prims.of_int (37)))))
+                   (Prims.of_int (245)) (Prims.of_int (6))
+                   (Prims.of_int (249)) (Prims.of_int (37)))))
           (Obj.magic (term_to_string s.Pulse_Syntax_Base.post))
           (fun uu___ ->
              (fun uu___ ->
@@ -2174,27 +2176,27 @@ let (comp_to_string :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (244)) (Prims.of_int (6))
-                              (Prims.of_int (248)) (Prims.of_int (37)))))
+                              (Prims.of_int (245)) (Prims.of_int (6))
+                              (Prims.of_int (249)) (Prims.of_int (37)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (244)) (Prims.of_int (6))
-                              (Prims.of_int (248)) (Prims.of_int (37)))))
+                              (Prims.of_int (245)) (Prims.of_int (6))
+                              (Prims.of_int (249)) (Prims.of_int (37)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (247)) (Prims.of_int (14))
-                                    (Prims.of_int (247)) (Prims.of_int (36)))))
+                                    (Prims.of_int (248)) (Prims.of_int (14))
+                                    (Prims.of_int (248)) (Prims.of_int (36)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Syntax.Printer.fst"
-                                    (Prims.of_int (244)) (Prims.of_int (6))
-                                    (Prims.of_int (248)) (Prims.of_int (37)))))
+                                    (Prims.of_int (245)) (Prims.of_int (6))
+                                    (Prims.of_int (249)) (Prims.of_int (37)))))
                            (Obj.magic
                               (term_to_string s.Pulse_Syntax_Base.pre))
                            (fun uu___1 ->
@@ -2205,17 +2207,17 @@ let (comp_to_string :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (244))
+                                               (Prims.of_int (245))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (248))
+                                               (Prims.of_int (249))
                                                (Prims.of_int (37)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (244))
+                                               (Prims.of_int (245))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (248))
+                                               (Prims.of_int (249))
                                                (Prims.of_int (37)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -2223,17 +2225,17 @@ let (comp_to_string :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (246))
+                                                     (Prims.of_int (247))
                                                      (Prims.of_int (14))
-                                                     (Prims.of_int (246))
+                                                     (Prims.of_int (247))
                                                      (Prims.of_int (37)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Syntax.Printer.fst"
-                                                     (Prims.of_int (244))
+                                                     (Prims.of_int (245))
                                                      (Prims.of_int (6))
-                                                     (Prims.of_int (248))
+                                                     (Prims.of_int (249))
                                                      (Prims.of_int (37)))))
                                             (Obj.magic
                                                (term_to_string inames))
@@ -2245,17 +2247,17 @@ let (comp_to_string :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (244))
+                                                                (Prims.of_int (245))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (248))
+                                                                (Prims.of_int (249))
                                                                 (Prims.of_int (37)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Syntax.Printer.fst"
-                                                                (Prims.of_int (244))
+                                                                (Prims.of_int (245))
                                                                 (Prims.of_int (6))
-                                                                (Prims.of_int (248))
+                                                                (Prims.of_int (249))
                                                                 (Prims.of_int (37)))))
                                                        (Obj.magic
                                                           (FStar_Tactics_Effect.tac_bind
@@ -2263,9 +2265,9 @@ let (comp_to_string :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (36)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
@@ -2336,12 +2338,12 @@ let (term_list_to_string :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                 (Prims.of_int (258)) (Prims.of_int (22))
-                 (Prims.of_int (258)) (Prims.of_int (46)))))
+                 (Prims.of_int (259)) (Prims.of_int (22))
+                 (Prims.of_int (259)) (Prims.of_int (46)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                 (Prims.of_int (258)) (Prims.of_int (4)) (Prims.of_int (258))
+                 (Prims.of_int (259)) (Prims.of_int (4)) (Prims.of_int (259))
                  (Prims.of_int (46)))))
         (Obj.magic (FStar_Tactics_Util.map term_to_string t))
         (fun uu___ ->
@@ -2368,8 +2370,8 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (266)) (Prims.of_int (8))
-                                (Prims.of_int (266)) (Prims.of_int (29)))))
+                                (Prims.of_int (267)) (Prims.of_int (8))
+                                (Prims.of_int (267)) (Prims.of_int (29)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
@@ -2395,13 +2397,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (273)) (Prims.of_int (8))
-                                (Prims.of_int (273)) (Prims.of_int (28)))))
+                                (Prims.of_int (274)) (Prims.of_int (8))
+                                (Prims.of_int (274)) (Prims.of_int (28)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (269)) (Prims.of_int (6))
-                                (Prims.of_int (273)) (Prims.of_int (28)))))
+                                (Prims.of_int (270)) (Prims.of_int (6))
+                                (Prims.of_int (274)) (Prims.of_int (28)))))
                        (Obj.magic (term_to_string arg))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -2411,17 +2413,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (269))
+                                           (Prims.of_int (270))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (273))
+                                           (Prims.of_int (274))
                                            (Prims.of_int (28)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (269))
+                                           (Prims.of_int (270))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (273))
+                                           (Prims.of_int (274))
                                            (Prims.of_int (28)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -2429,17 +2431,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (269))
+                                                 (Prims.of_int (270))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (273))
+                                                 (Prims.of_int (274))
                                                  (Prims.of_int (28)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (269))
+                                                 (Prims.of_int (270))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (273))
+                                                 (Prims.of_int (274))
                                                  (Prims.of_int (28)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -2447,9 +2449,9 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (271))
+                                                       (Prims.of_int (272))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (271))
+                                                       (Prims.of_int (272))
                                                        (Prims.of_int (29)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
@@ -2504,13 +2506,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (286)) (Prims.of_int (10))
-                                (Prims.of_int (286)) (Prims.of_int (41)))))
+                                (Prims.of_int (287)) (Prims.of_int (10))
+                                (Prims.of_int (287)) (Prims.of_int (41)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (282)) (Prims.of_int (8))
-                                (Prims.of_int (286)) (Prims.of_int (41)))))
+                                (Prims.of_int (283)) (Prims.of_int (8))
+                                (Prims.of_int (287)) (Prims.of_int (41)))))
                        (Obj.magic (st_term_to_string' level body))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -2520,17 +2522,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (282))
+                                           (Prims.of_int (283))
                                            (Prims.of_int (8))
-                                           (Prims.of_int (286))
+                                           (Prims.of_int (287))
                                            (Prims.of_int (41)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (282))
+                                           (Prims.of_int (283))
                                            (Prims.of_int (8))
-                                           (Prims.of_int (286))
+                                           (Prims.of_int (287))
                                            (Prims.of_int (41)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -2538,17 +2540,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (282))
+                                                 (Prims.of_int (283))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (286))
+                                                 (Prims.of_int (287))
                                                  (Prims.of_int (41)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (282))
+                                                 (Prims.of_int (283))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (286))
+                                                 (Prims.of_int (287))
                                                  (Prims.of_int (41)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -2556,17 +2558,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (284))
+                                                       (Prims.of_int (285))
                                                        (Prims.of_int (10))
-                                                       (Prims.of_int (284))
+                                                       (Prims.of_int (285))
                                                        (Prims.of_int (41)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (282))
+                                                       (Prims.of_int (283))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (286))
+                                                       (Prims.of_int (287))
                                                        (Prims.of_int (41)))))
                                               (Obj.magic
                                                  (st_term_to_string' level
@@ -2579,17 +2581,17 @@ let rec (st_term_to_string' :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (282))
+                                                                  (Prims.of_int (283))
                                                                   (Prims.of_int (8))
-                                                                  (Prims.of_int (286))
+                                                                  (Prims.of_int (287))
                                                                   (Prims.of_int (41)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (282))
+                                                                  (Prims.of_int (283))
                                                                   (Prims.of_int (8))
-                                                                  (Prims.of_int (286))
+                                                                  (Prims.of_int (287))
                                                                   (Prims.of_int (41)))))
                                                          (Obj.magic
                                                             (FStar_Tactics_Effect.tac_bind
@@ -2597,9 +2599,9 @@ let rec (st_term_to_string' :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (35)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
@@ -2657,13 +2659,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (294)) (Prims.of_int (8))
-                                (Prims.of_int (294)) (Prims.of_int (39)))))
+                                (Prims.of_int (295)) (Prims.of_int (8))
+                                (Prims.of_int (295)) (Prims.of_int (39)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (290)) (Prims.of_int (6))
-                                (Prims.of_int (294)) (Prims.of_int (39)))))
+                                (Prims.of_int (291)) (Prims.of_int (6))
+                                (Prims.of_int (295)) (Prims.of_int (39)))))
                        (Obj.magic (st_term_to_string' level body))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -2673,17 +2675,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (290))
+                                           (Prims.of_int (291))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (294))
+                                           (Prims.of_int (295))
                                            (Prims.of_int (39)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (290))
+                                           (Prims.of_int (291))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (294))
+                                           (Prims.of_int (295))
                                            (Prims.of_int (39)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -2691,17 +2693,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (290))
+                                                 (Prims.of_int (291))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (294))
+                                                 (Prims.of_int (295))
                                                  (Prims.of_int (39)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (290))
+                                                 (Prims.of_int (291))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (294))
+                                                 (Prims.of_int (295))
                                                  (Prims.of_int (39)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -2709,17 +2711,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (292))
+                                                       (Prims.of_int (293))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (292))
+                                                       (Prims.of_int (293))
                                                        (Prims.of_int (29)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (290))
+                                                       (Prims.of_int (291))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (294))
+                                                       (Prims.of_int (295))
                                                        (Prims.of_int (39)))))
                                               (Obj.magic
                                                  (term_to_string head))
@@ -2731,17 +2733,17 @@ let rec (st_term_to_string' :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (290))
+                                                                  (Prims.of_int (291))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (294))
+                                                                  (Prims.of_int (295))
                                                                   (Prims.of_int (39)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (290))
+                                                                  (Prims.of_int (291))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (294))
+                                                                  (Prims.of_int (295))
                                                                   (Prims.of_int (39)))))
                                                          (Obj.magic
                                                             (FStar_Tactics_Effect.tac_bind
@@ -2749,9 +2751,9 @@ let rec (st_term_to_string' :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (291))
+                                                                    (Prims.of_int (292))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (291))
+                                                                    (Prims.of_int (292))
                                                                     (Prims.of_int (33)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
@@ -2809,13 +2811,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (303)) (Prims.of_int (14))
-                                (Prims.of_int (303)) (Prims.of_int (90)))))
+                                (Prims.of_int (304)) (Prims.of_int (14))
+                                (Prims.of_int (304)) (Prims.of_int (90)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (297)) (Prims.of_int (6))
-                                (Prims.of_int (303)) (Prims.of_int (90)))))
+                                (Prims.of_int (298)) (Prims.of_int (6))
+                                (Prims.of_int (304)) (Prims.of_int (90)))))
                        (match c.Pulse_Syntax_Base.elaborated with
                         | FStar_Pervasives_Native.None ->
                             Obj.magic
@@ -2830,9 +2832,9 @@ let rec (st_term_to_string' :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Syntax.Printer.fst"
-                                             (Prims.of_int (303))
+                                             (Prims.of_int (304))
                                              (Prims.of_int (73))
-                                             (Prims.of_int (303))
+                                             (Prims.of_int (304))
                                              (Prims.of_int (89)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
@@ -2854,17 +2856,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (297))
+                                           (Prims.of_int (298))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (303))
+                                           (Prims.of_int (304))
                                            (Prims.of_int (90)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (297))
+                                           (Prims.of_int (298))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (303))
+                                           (Prims.of_int (304))
                                            (Prims.of_int (90)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -2872,17 +2874,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (302))
+                                                 (Prims.of_int (303))
                                                  (Prims.of_int (14))
-                                                 (Prims.of_int (302))
+                                                 (Prims.of_int (303))
                                                  (Prims.of_int (54)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (297))
+                                                 (Prims.of_int (298))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (303))
+                                                 (Prims.of_int (304))
                                                  (Prims.of_int (90)))))
                                         (Obj.magic
                                            (st_term_to_string' (indent level)
@@ -2895,17 +2897,17 @@ let rec (st_term_to_string' :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (297))
+                                                            (Prims.of_int (298))
                                                             (Prims.of_int (6))
-                                                            (Prims.of_int (303))
+                                                            (Prims.of_int (304))
                                                             (Prims.of_int (90)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (297))
+                                                            (Prims.of_int (298))
                                                             (Prims.of_int (6))
-                                                            (Prims.of_int (303))
+                                                            (Prims.of_int (304))
                                                             (Prims.of_int (90)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_Effect.tac_bind
@@ -2913,17 +2915,17 @@ let rec (st_term_to_string' :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (297))
+                                                                  (Prims.of_int (298))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (303))
+                                                                  (Prims.of_int (304))
                                                                   (Prims.of_int (90)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (297))
+                                                                  (Prims.of_int (298))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (303))
+                                                                  (Prims.of_int (304))
                                                                   (Prims.of_int (90)))))
                                                          (Obj.magic
                                                             (FStar_Tactics_Effect.tac_bind
@@ -2931,17 +2933,17 @@ let rec (st_term_to_string' :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (300))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (300))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (80)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (297))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (303))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (90)))))
                                                                (match 
                                                                   c.Pulse_Syntax_Base.annotated
@@ -2969,17 +2971,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (297))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (303))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (90)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (297))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (303))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (90)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2987,9 +2989,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -3066,28 +3068,28 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (306)) (Prims.of_int (6))
-                                (Prims.of_int (316)) (Prims.of_int (13)))))
+                                (Prims.of_int (307)) (Prims.of_int (6))
+                                (Prims.of_int (317)) (Prims.of_int (13)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (306)) (Prims.of_int (6))
-                                (Prims.of_int (316)) (Prims.of_int (13)))))
+                                (Prims.of_int (307)) (Prims.of_int (6))
+                                (Prims.of_int (317)) (Prims.of_int (13)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (315)) (Prims.of_int (8))
-                                      (Prims.of_int (315))
+                                      (Prims.of_int (316)) (Prims.of_int (8))
+                                      (Prims.of_int (316))
                                       (Prims.of_int (49)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (306)) (Prims.of_int (6))
-                                      (Prims.of_int (316))
+                                      (Prims.of_int (307)) (Prims.of_int (6))
+                                      (Prims.of_int (317))
                                       (Prims.of_int (13)))))
                              (Obj.magic
                                 (st_term_to_string' (indent level) else_))
@@ -3099,17 +3101,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (306))
+                                                 (Prims.of_int (307))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (316))
+                                                 (Prims.of_int (317))
                                                  (Prims.of_int (13)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (306))
+                                                 (Prims.of_int (307))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (316))
+                                                 (Prims.of_int (317))
                                                  (Prims.of_int (13)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -3117,17 +3119,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (306))
+                                                       (Prims.of_int (307))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (316))
+                                                       (Prims.of_int (317))
                                                        (Prims.of_int (13)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (306))
+                                                       (Prims.of_int (307))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (316))
+                                                       (Prims.of_int (317))
                                                        (Prims.of_int (13)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -3135,17 +3137,17 @@ let rec (st_term_to_string' :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (306))
+                                                             (Prims.of_int (307))
                                                              (Prims.of_int (6))
-                                                             (Prims.of_int (316))
+                                                             (Prims.of_int (317))
                                                              (Prims.of_int (13)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (306))
+                                                             (Prims.of_int (307))
                                                              (Prims.of_int (6))
-                                                             (Prims.of_int (316))
+                                                             (Prims.of_int (317))
                                                              (Prims.of_int (13)))))
                                                     (Obj.magic
                                                        (FStar_Tactics_Effect.tac_bind
@@ -3153,17 +3155,17 @@ let rec (st_term_to_string' :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (306))
+                                                                   (Prims.of_int (307))
                                                                    (Prims.of_int (6))
-                                                                   (Prims.of_int (316))
+                                                                   (Prims.of_int (317))
                                                                    (Prims.of_int (13)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (306))
+                                                                   (Prims.of_int (307))
                                                                    (Prims.of_int (6))
-                                                                   (Prims.of_int (316))
+                                                                   (Prims.of_int (317))
                                                                    (Prims.of_int (13)))))
                                                           (Obj.magic
                                                              (FStar_Tactics_Effect.tac_bind
@@ -3171,17 +3173,17 @@ let rec (st_term_to_string' :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (306))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (13)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (306))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (13)))))
                                                                 (Obj.magic
                                                                    (FStar_Tactics_Effect.tac_bind
@@ -3189,17 +3191,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (310))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (310))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (306))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (13)))))
                                                                     (Obj.magic
                                                                     (st_term_to_string'
@@ -3216,53 +3218,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (306))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (13)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (306))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (316))
-                                                                    (Prims.of_int (13)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (306))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (316))
-                                                                    (Prims.of_int (13)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (306))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (316))
-                                                                    (Prims.of_int (13)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (306))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (316))
-                                                                    (Prims.of_int (13)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (306))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (13)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3271,8 +3237,44 @@ let rec (st_term_to_string' :
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
                                                                     (Prims.of_int (307))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (13)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (13)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (13)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (13)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (26)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -3393,13 +3395,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (321)) (Prims.of_int (8))
-                                (Prims.of_int (321)) (Prims.of_int (32)))))
+                                (Prims.of_int (322)) (Prims.of_int (8))
+                                (Prims.of_int (322)) (Prims.of_int (32)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (319)) (Prims.of_int (6))
-                                (Prims.of_int (321)) (Prims.of_int (32)))))
+                                (Prims.of_int (320)) (Prims.of_int (6))
+                                (Prims.of_int (322)) (Prims.of_int (32)))))
                        (Obj.magic (branches_to_string brs))
                        (fun uu___1 ->
                           (fun uu___1 ->
@@ -3409,17 +3411,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (319))
+                                           (Prims.of_int (320))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (321))
+                                           (Prims.of_int (322))
                                            (Prims.of_int (32)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (319))
+                                           (Prims.of_int (320))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (321))
+                                           (Prims.of_int (322))
                                            (Prims.of_int (32)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -3427,9 +3429,9 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (320))
+                                                 (Prims.of_int (321))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (320))
+                                                 (Prims.of_int (321))
                                                  (Prims.of_int (27)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
@@ -3460,8 +3462,8 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (326)) (Prims.of_int (8))
-                                (Prims.of_int (326)) (Prims.of_int (42)))))
+                                (Prims.of_int (327)) (Prims.of_int (8))
+                                (Prims.of_int (327)) (Prims.of_int (42)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
@@ -3482,8 +3484,8 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (330)) (Prims.of_int (8))
-                                (Prims.of_int (330)) (Prims.of_int (26)))))
+                                (Prims.of_int (331)) (Prims.of_int (8))
+                                (Prims.of_int (331)) (Prims.of_int (26)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
@@ -3505,13 +3507,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (337)) (Prims.of_int (8))
-                                (Prims.of_int (337)) (Prims.of_int (43)))))
+                                (Prims.of_int (338)) (Prims.of_int (8))
+                                (Prims.of_int (338)) (Prims.of_int (43)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (333)) (Prims.of_int (6))
-                                (Prims.of_int (337)) (Prims.of_int (43)))))
+                                (Prims.of_int (334)) (Prims.of_int (6))
+                                (Prims.of_int (338)) (Prims.of_int (43)))))
                        (Obj.magic (term_list_to_string " " witnesses))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -3521,17 +3523,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (333))
+                                           (Prims.of_int (334))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (337))
+                                           (Prims.of_int (338))
                                            (Prims.of_int (43)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (333))
+                                           (Prims.of_int (334))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (337))
+                                           (Prims.of_int (338))
                                            (Prims.of_int (43)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -3539,17 +3541,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (333))
+                                                 (Prims.of_int (334))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (337))
+                                                 (Prims.of_int (338))
                                                  (Prims.of_int (43)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (333))
+                                                 (Prims.of_int (334))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (337))
+                                                 (Prims.of_int (338))
                                                  (Prims.of_int (43)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -3557,9 +3559,9 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (335))
+                                                       (Prims.of_int (336))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (335))
+                                                       (Prims.of_int (336))
                                                        (Prims.of_int (42)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
@@ -3610,28 +3612,28 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (340)) (Prims.of_int (6))
-                                (Prims.of_int (347)) (Prims.of_int (13)))))
+                                (Prims.of_int (341)) (Prims.of_int (6))
+                                (Prims.of_int (348)) (Prims.of_int (13)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (340)) (Prims.of_int (6))
-                                (Prims.of_int (347)) (Prims.of_int (13)))))
+                                (Prims.of_int (341)) (Prims.of_int (6))
+                                (Prims.of_int (348)) (Prims.of_int (13)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (346)) (Prims.of_int (8))
-                                      (Prims.of_int (346))
+                                      (Prims.of_int (347)) (Prims.of_int (8))
+                                      (Prims.of_int (347))
                                       (Prims.of_int (48)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Syntax.Printer.fst"
-                                      (Prims.of_int (340)) (Prims.of_int (6))
-                                      (Prims.of_int (347))
+                                      (Prims.of_int (341)) (Prims.of_int (6))
+                                      (Prims.of_int (348))
                                       (Prims.of_int (13)))))
                              (Obj.magic
                                 (st_term_to_string' (indent level) body))
@@ -3643,17 +3645,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (340))
+                                                 (Prims.of_int (341))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (347))
+                                                 (Prims.of_int (348))
                                                  (Prims.of_int (13)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (340))
+                                                 (Prims.of_int (341))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (347))
+                                                 (Prims.of_int (348))
                                                  (Prims.of_int (13)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -3661,17 +3663,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (340))
+                                                       (Prims.of_int (341))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (347))
+                                                       (Prims.of_int (348))
                                                        (Prims.of_int (13)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (340))
+                                                       (Prims.of_int (341))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (347))
+                                                       (Prims.of_int (348))
                                                        (Prims.of_int (13)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -3679,17 +3681,17 @@ let rec (st_term_to_string' :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (340))
+                                                             (Prims.of_int (341))
                                                              (Prims.of_int (6))
-                                                             (Prims.of_int (347))
+                                                             (Prims.of_int (348))
                                                              (Prims.of_int (13)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Syntax.Printer.fst"
-                                                             (Prims.of_int (340))
+                                                             (Prims.of_int (341))
                                                              (Prims.of_int (6))
-                                                             (Prims.of_int (347))
+                                                             (Prims.of_int (348))
                                                              (Prims.of_int (13)))))
                                                     (Obj.magic
                                                        (FStar_Tactics_Effect.tac_bind
@@ -3697,17 +3699,17 @@ let rec (st_term_to_string' :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (343))
+                                                                   (Prims.of_int (344))
                                                                    (Prims.of_int (8))
-                                                                   (Prims.of_int (343))
+                                                                   (Prims.of_int (344))
                                                                    (Prims.of_int (34)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (340))
+                                                                   (Prims.of_int (341))
                                                                    (Prims.of_int (6))
-                                                                   (Prims.of_int (347))
+                                                                   (Prims.of_int (348))
                                                                    (Prims.of_int (13)))))
                                                           (Obj.magic
                                                              (term_to_string
@@ -3720,35 +3722,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (348))
                                                                     (Prims.of_int (13)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (347))
-                                                                    (Prims.of_int (13)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (340))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (347))
-                                                                    (Prims.of_int (13)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (340))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (348))
                                                                     (Prims.of_int (13)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3757,8 +3741,26 @@ let rec (st_term_to_string' :
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
                                                                     (Prims.of_int (341))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (13)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (13)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Syntax.Printer.fst"
+                                                                    (Prims.of_int (342))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (342))
                                                                     (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -3851,13 +3853,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (356)) (Prims.of_int (8))
-                                (Prims.of_int (356)) (Prims.of_int (30)))))
+                                (Prims.of_int (357)) (Prims.of_int (8))
+                                (Prims.of_int (357)) (Prims.of_int (30)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (350)) (Prims.of_int (6))
-                                (Prims.of_int (356)) (Prims.of_int (30)))))
+                                (Prims.of_int (351)) (Prims.of_int (6))
+                                (Prims.of_int (357)) (Prims.of_int (30)))))
                        (Obj.magic (term_to_string post2))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -3867,17 +3869,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (350))
+                                           (Prims.of_int (351))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (356))
+                                           (Prims.of_int (357))
                                            (Prims.of_int (30)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (350))
+                                           (Prims.of_int (351))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (356))
+                                           (Prims.of_int (357))
                                            (Prims.of_int (30)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -3885,17 +3887,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (355))
+                                                 (Prims.of_int (356))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (355))
+                                                 (Prims.of_int (356))
                                                  (Prims.of_int (40)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (350))
+                                                 (Prims.of_int (351))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (356))
+                                                 (Prims.of_int (357))
                                                  (Prims.of_int (30)))))
                                         (Obj.magic
                                            (st_term_to_string' level body2))
@@ -3907,17 +3909,17 @@ let rec (st_term_to_string' :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (350))
+                                                            (Prims.of_int (351))
                                                             (Prims.of_int (6))
-                                                            (Prims.of_int (356))
+                                                            (Prims.of_int (357))
                                                             (Prims.of_int (30)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (350))
+                                                            (Prims.of_int (351))
                                                             (Prims.of_int (6))
-                                                            (Prims.of_int (356))
+                                                            (Prims.of_int (357))
                                                             (Prims.of_int (30)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_Effect.tac_bind
@@ -3925,17 +3927,17 @@ let rec (st_term_to_string' :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (354))
+                                                                  (Prims.of_int (355))
                                                                   (Prims.of_int (8))
-                                                                  (Prims.of_int (354))
+                                                                  (Prims.of_int (355))
                                                                   (Prims.of_int (29)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (350))
+                                                                  (Prims.of_int (351))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (356))
+                                                                  (Prims.of_int (357))
                                                                   (Prims.of_int (30)))))
                                                          (Obj.magic
                                                             (term_to_string
@@ -3949,18 +3951,18 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (350))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (356))
+                                                                    (Prims.of_int (357))
                                                                     (Prims.of_int (30)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (350))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (356))
+                                                                    (Prims.of_int (357))
                                                                     (Prims.of_int (30)))))
                                                                     (
                                                                     Obj.magic
@@ -3969,17 +3971,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (353))
+                                                                    (Prims.of_int (354))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (353))
+                                                                    (Prims.of_int (354))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (350))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (356))
+                                                                    (Prims.of_int (357))
                                                                     (Prims.of_int (30)))))
                                                                     (Obj.magic
                                                                     (term_to_string
@@ -3994,17 +3996,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (350))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (356))
+                                                                    (Prims.of_int (357))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (350))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (356))
+                                                                    (Prims.of_int (357))
                                                                     (Prims.of_int (30)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4012,17 +4014,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (350))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (356))
+                                                                    (Prims.of_int (357))
                                                                     (Prims.of_int (30)))))
                                                                     (Obj.magic
                                                                     (st_term_to_string'
@@ -4038,17 +4040,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (350))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (356))
+                                                                    (Prims.of_int (357))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (350))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (356))
+                                                                    (Prims.of_int (357))
                                                                     (Prims.of_int (30)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4056,9 +4058,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (351))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (351))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -4144,13 +4146,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (361)) (Prims.of_int (8))
-                                (Prims.of_int (361)) (Prims.of_int (27)))))
+                                (Prims.of_int (362)) (Prims.of_int (8))
+                                (Prims.of_int (362)) (Prims.of_int (27)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (359)) (Prims.of_int (7))
-                                (Prims.of_int (361)) (Prims.of_int (27)))))
+                                (Prims.of_int (360)) (Prims.of_int (7))
+                                (Prims.of_int (362)) (Prims.of_int (27)))))
                        (Obj.magic (term_to_string t2))
                        (fun uu___1 ->
                           (fun uu___1 ->
@@ -4160,17 +4162,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (359))
+                                           (Prims.of_int (360))
                                            (Prims.of_int (7))
-                                           (Prims.of_int (361))
+                                           (Prims.of_int (362))
                                            (Prims.of_int (27)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (359))
+                                           (Prims.of_int (360))
                                            (Prims.of_int (7))
-                                           (Prims.of_int (361))
+                                           (Prims.of_int (362))
                                            (Prims.of_int (27)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -4178,9 +4180,9 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (360))
+                                                 (Prims.of_int (361))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (360))
+                                                 (Prims.of_int (361))
                                                  (Prims.of_int (27)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
@@ -4215,13 +4217,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (368)) (Prims.of_int (8))
-                                (Prims.of_int (368)) (Prims.of_int (39)))))
+                                (Prims.of_int (369)) (Prims.of_int (8))
+                                (Prims.of_int (369)) (Prims.of_int (39)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (364)) (Prims.of_int (6))
-                                (Prims.of_int (368)) (Prims.of_int (39)))))
+                                (Prims.of_int (365)) (Prims.of_int (6))
+                                (Prims.of_int (369)) (Prims.of_int (39)))))
                        (Obj.magic (st_term_to_string' level body))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -4231,17 +4233,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (364))
+                                           (Prims.of_int (365))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (368))
+                                           (Prims.of_int (369))
                                            (Prims.of_int (39)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (364))
+                                           (Prims.of_int (365))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (368))
+                                           (Prims.of_int (369))
                                            (Prims.of_int (39)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -4249,17 +4251,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (364))
+                                                 (Prims.of_int (365))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (368))
+                                                 (Prims.of_int (369))
                                                  (Prims.of_int (39)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (364))
+                                                 (Prims.of_int (365))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (368))
+                                                 (Prims.of_int (369))
                                                  (Prims.of_int (39)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -4267,17 +4269,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (366))
+                                                       (Prims.of_int (367))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (366))
+                                                       (Prims.of_int (367))
                                                        (Prims.of_int (36)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (364))
+                                                       (Prims.of_int (365))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (368))
+                                                       (Prims.of_int (369))
                                                        (Prims.of_int (39)))))
                                               (Obj.magic
                                                  (term_to_string initializer1))
@@ -4289,17 +4291,17 @@ let rec (st_term_to_string' :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (364))
+                                                                  (Prims.of_int (365))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (368))
+                                                                  (Prims.of_int (369))
                                                                   (Prims.of_int (39)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (364))
+                                                                  (Prims.of_int (365))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (368))
+                                                                  (Prims.of_int (369))
                                                                   (Prims.of_int (39)))))
                                                          (Obj.magic
                                                             (FStar_Tactics_Effect.tac_bind
@@ -4307,9 +4309,9 @@ let rec (st_term_to_string' :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (365))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (365))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (33)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
@@ -4368,13 +4370,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (376)) (Prims.of_int (8))
-                                (Prims.of_int (376)) (Prims.of_int (39)))))
+                                (Prims.of_int (377)) (Prims.of_int (8))
+                                (Prims.of_int (377)) (Prims.of_int (39)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (371)) (Prims.of_int (6))
-                                (Prims.of_int (376)) (Prims.of_int (39)))))
+                                (Prims.of_int (372)) (Prims.of_int (6))
+                                (Prims.of_int (377)) (Prims.of_int (39)))))
                        (Obj.magic (st_term_to_string' level body))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -4384,17 +4386,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (371))
+                                           (Prims.of_int (372))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (376))
+                                           (Prims.of_int (377))
                                            (Prims.of_int (39)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (371))
+                                           (Prims.of_int (372))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (376))
+                                           (Prims.of_int (377))
                                            (Prims.of_int (39)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -4402,17 +4404,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (371))
+                                                 (Prims.of_int (372))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (376))
+                                                 (Prims.of_int (377))
                                                  (Prims.of_int (39)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (371))
+                                                 (Prims.of_int (372))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (376))
+                                                 (Prims.of_int (377))
                                                  (Prims.of_int (39)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -4420,17 +4422,17 @@ let rec (st_term_to_string' :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (374))
+                                                       (Prims.of_int (375))
                                                        (Prims.of_int (8))
-                                                       (Prims.of_int (374))
+                                                       (Prims.of_int (375))
                                                        (Prims.of_int (31)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Syntax.Printer.fst"
-                                                       (Prims.of_int (371))
+                                                       (Prims.of_int (372))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (376))
+                                                       (Prims.of_int (377))
                                                        (Prims.of_int (39)))))
                                               (Obj.magic
                                                  (term_to_string length))
@@ -4442,17 +4444,17 @@ let rec (st_term_to_string' :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (371))
+                                                                  (Prims.of_int (372))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (376))
+                                                                  (Prims.of_int (377))
                                                                   (Prims.of_int (39)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (371))
+                                                                  (Prims.of_int (372))
                                                                   (Prims.of_int (6))
-                                                                  (Prims.of_int (376))
+                                                                  (Prims.of_int (377))
                                                                   (Prims.of_int (39)))))
                                                          (Obj.magic
                                                             (FStar_Tactics_Effect.tac_bind
@@ -4460,17 +4462,17 @@ let rec (st_term_to_string' :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (373))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (373))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (36)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (372))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (376))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (39)))))
                                                                (Obj.magic
                                                                   (term_to_string
@@ -4484,17 +4486,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (372))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (376))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (372))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (376))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4502,9 +4504,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (372))
+                                                                    (Prims.of_int (373))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (372))
+                                                                    (Prims.of_int (373))
                                                                     (Prims.of_int (33)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -4575,13 +4577,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (386)) (Prims.of_int (8))
-                                (Prims.of_int (388)) (Prims.of_int (60)))))
+                                (Prims.of_int (387)) (Prims.of_int (8))
+                                (Prims.of_int (389)) (Prims.of_int (60)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (379)) (Prims.of_int (6))
-                                (Prims.of_int (388)) (Prims.of_int (60)))))
+                                (Prims.of_int (380)) (Prims.of_int (6))
+                                (Prims.of_int (389)) (Prims.of_int (60)))))
                        (match post with
                         | FStar_Pervasives_Native.None ->
                             Obj.magic
@@ -4596,9 +4598,9 @@ let rec (st_term_to_string' :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Syntax.Printer.fst"
-                                             (Prims.of_int (388))
+                                             (Prims.of_int (389))
                                              (Prims.of_int (38))
-                                             (Prims.of_int (388))
+                                             (Prims.of_int (389))
                                              (Prims.of_int (59)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
@@ -4621,17 +4623,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (379))
+                                           (Prims.of_int (380))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (388))
+                                           (Prims.of_int (389))
                                            (Prims.of_int (60)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (379))
+                                           (Prims.of_int (380))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (388))
+                                           (Prims.of_int (389))
                                            (Prims.of_int (60)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -4639,9 +4641,9 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (385))
+                                                 (Prims.of_int (386))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (385))
+                                                 (Prims.of_int (386))
                                                  (Prims.of_int (28)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
@@ -4699,13 +4701,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (394)) (Prims.of_int (8))
-                                (Prims.of_int (396)) (Prims.of_int (86)))))
+                                (Prims.of_int (395)) (Prims.of_int (8))
+                                (Prims.of_int (397)) (Prims.of_int (86)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (397)) (Prims.of_int (8))
-                                (Prims.of_int (422)) (Prims.of_int (36)))))
+                                (Prims.of_int (398)) (Prims.of_int (8))
+                                (Prims.of_int (423)) (Prims.of_int (36)))))
                        (match binders with
                         | [] ->
                             Obj.magic
@@ -4720,9 +4722,9 @@ let rec (st_term_to_string' :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Syntax.Printer.fst"
-                                             (Prims.of_int (396))
+                                             (Prims.of_int (397))
                                              (Prims.of_int (34))
-                                             (Prims.of_int (396))
+                                             (Prims.of_int (397))
                                              (Prims.of_int (86)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
@@ -4737,17 +4739,17 @@ let rec (st_term_to_string' :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Syntax.Printer.fst"
-                                                   (Prims.of_int (396))
+                                                   (Prims.of_int (397))
                                                    (Prims.of_int (53))
-                                                   (Prims.of_int (396))
+                                                   (Prims.of_int (397))
                                                    (Prims.of_int (85)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Syntax.Printer.fst"
-                                                   (Prims.of_int (396))
+                                                   (Prims.of_int (397))
                                                    (Prims.of_int (34))
-                                                   (Prims.of_int (396))
+                                                   (Prims.of_int (397))
                                                    (Prims.of_int (86)))))
                                           (Obj.magic
                                              (FStar_Tactics_Util.map
@@ -4770,17 +4772,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (398))
+                                           (Prims.of_int (399))
                                            (Prims.of_int (28))
-                                           (Prims.of_int (400))
+                                           (Prims.of_int (401))
                                            (Prims.of_int (58)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (401))
+                                           (Prims.of_int (402))
                                            (Prims.of_int (8))
-                                           (Prims.of_int (422))
+                                           (Prims.of_int (423))
                                            (Prims.of_int (36)))))
                                   (FStar_Tactics_Effect.lift_div_tac
                                      (fun uu___ ->
@@ -4801,17 +4803,17 @@ let rec (st_term_to_string' :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Syntax.Printer.fst"
-                                                      (Prims.of_int (403))
+                                                      (Prims.of_int (404))
                                                       (Prims.of_int (8))
-                                                      (Prims.of_int (419))
+                                                      (Prims.of_int (420))
                                                       (Prims.of_int (54)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Syntax.Printer.fst"
-                                                      (Prims.of_int (401))
+                                                      (Prims.of_int (402))
                                                       (Prims.of_int (8))
-                                                      (Prims.of_int (422))
+                                                      (Prims.of_int (423))
                                                       (Prims.of_int (36)))))
                                              (match hint_type with
                                               | Pulse_Syntax_Base.ASSERT
@@ -4825,17 +4827,17 @@ let rec (st_term_to_string' :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (404))
+                                                                   (Prims.of_int (405))
                                                                    (Prims.of_int (36))
-                                                                   (Prims.of_int (404))
+                                                                   (Prims.of_int (405))
                                                                    (Prims.of_int (52)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (404))
+                                                                   (Prims.of_int (405))
                                                                    (Prims.of_int (26))
-                                                                   (Prims.of_int (404))
+                                                                   (Prims.of_int (405))
                                                                    (Prims.of_int (52)))))
                                                           (Obj.magic
                                                              (term_to_string
@@ -4858,17 +4860,17 @@ let rec (st_term_to_string' :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (405))
+                                                                   (Prims.of_int (406))
                                                                    (Prims.of_int (77))
-                                                                   (Prims.of_int (405))
+                                                                   (Prims.of_int (406))
                                                                    (Prims.of_int (93)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (405))
+                                                                   (Prims.of_int (406))
                                                                    (Prims.of_int (33))
-                                                                   (Prims.of_int (405))
+                                                                   (Prims.of_int (406))
                                                                    (Prims.of_int (93)))))
                                                           (Obj.magic
                                                              (term_to_string
@@ -4895,17 +4897,17 @@ let rec (st_term_to_string' :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (406))
+                                                                   (Prims.of_int (407))
                                                                    (Prims.of_int (73))
-                                                                   (Prims.of_int (406))
+                                                                   (Prims.of_int (407))
                                                                    (Prims.of_int (89)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (406))
+                                                                   (Prims.of_int (407))
                                                                    (Prims.of_int (31))
-                                                                   (Prims.of_int (406))
+                                                                   (Prims.of_int (407))
                                                                    (Prims.of_int (89)))))
                                                           (Obj.magic
                                                              (term_to_string
@@ -4935,17 +4937,17 @@ let rec (st_term_to_string' :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (408))
+                                                                   (Prims.of_int (409))
                                                                    (Prims.of_int (10))
-                                                                   (Prims.of_int (412))
+                                                                   (Prims.of_int (413))
                                                                    (Prims.of_int (21)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (408))
+                                                                   (Prims.of_int (409))
                                                                    (Prims.of_int (10))
-                                                                   (Prims.of_int (415))
+                                                                   (Prims.of_int (416))
                                                                    (Prims.of_int (60)))))
                                                           (Obj.magic
                                                              (FStar_Tactics_Effect.tac_bind
@@ -4953,9 +4955,9 @@ let rec (st_term_to_string' :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (409))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (412))
+                                                                    (Prims.of_int (413))
                                                                     (Prims.of_int (21)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
@@ -4971,17 +4973,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (411))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (412))
+                                                                    (Prims.of_int (413))
                                                                     (Prims.of_int (20)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (409))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (412))
+                                                                    (Prims.of_int (413))
                                                                     (Prims.of_int (21)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Util.map
@@ -4996,17 +4998,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (412))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (412))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (412))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (412))
                                                                     (Prims.of_int (87)))))
                                                                     (Obj.magic
                                                                     (term_to_string
@@ -5021,17 +5023,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (412))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (412))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (412))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (412))
                                                                     (Prims.of_int (87)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -5039,9 +5041,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (412))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (412))
                                                                     (Prims.of_int (68)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -5102,17 +5104,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (413))
+                                                                    (Prims.of_int (414))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (416))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (408))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (416))
                                                                     (Prims.of_int (60)))))
                                                                     (match goal
                                                                     with
@@ -5135,9 +5137,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (416))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (416))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -5182,17 +5184,17 @@ let rec (st_term_to_string' :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (417))
+                                                                   (Prims.of_int (418))
                                                                    (Prims.of_int (10))
-                                                                   (Prims.of_int (417))
+                                                                   (Prims.of_int (418))
                                                                    (Prims.of_int (76)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Syntax.Printer.fst"
-                                                                   (Prims.of_int (417))
+                                                                   (Prims.of_int (418))
                                                                    (Prims.of_int (10))
-                                                                   (Prims.of_int (417))
+                                                                   (Prims.of_int (418))
                                                                    (Prims.of_int (80)))))
                                                           (Obj.magic
                                                              (FStar_Tactics_Effect.tac_bind
@@ -5200,17 +5202,17 @@ let rec (st_term_to_string' :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (57))
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (76)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (76)))))
                                                                 (Obj.magic
                                                                    (term_to_string
@@ -5225,17 +5227,17 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (76)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -5243,9 +5245,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (37))
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -5309,9 +5311,9 @@ let rec (st_term_to_string' :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (423))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (423))
                                                                     (Prims.of_int (36)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
@@ -5354,13 +5356,13 @@ let rec (st_term_to_string' :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (428)) (Prims.of_int (8))
-                                (Prims.of_int (434)) (Prims.of_int (32)))))
+                                (Prims.of_int (429)) (Prims.of_int (8))
+                                (Prims.of_int (435)) (Prims.of_int (32)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                                (Prims.of_int (425)) (Prims.of_int (6))
-                                (Prims.of_int (434)) (Prims.of_int (32)))))
+                                (Prims.of_int (426)) (Prims.of_int (6))
+                                (Prims.of_int (435)) (Prims.of_int (32)))))
                        (match returns_inv with
                         | FStar_Pervasives_Native.None ->
                             Obj.magic
@@ -5375,17 +5377,17 @@ let rec (st_term_to_string' :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Syntax.Printer.fst"
-                                             (Prims.of_int (434))
+                                             (Prims.of_int (435))
                                              (Prims.of_int (12))
-                                             (Prims.of_int (434))
+                                             (Prims.of_int (435))
                                              (Prims.of_int (31)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Syntax.Printer.fst"
-                                             (Prims.of_int (431))
+                                             (Prims.of_int (432))
                                              (Prims.of_int (10))
-                                             (Prims.of_int (434))
+                                             (Prims.of_int (435))
                                              (Prims.of_int (31)))))
                                     (Obj.magic (term_to_string is))
                                     (fun uu___ ->
@@ -5396,17 +5398,17 @@ let rec (st_term_to_string' :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Syntax.Printer.fst"
-                                                        (Prims.of_int (431))
+                                                        (Prims.of_int (432))
                                                         (Prims.of_int (10))
-                                                        (Prims.of_int (434))
+                                                        (Prims.of_int (435))
                                                         (Prims.of_int (31)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Syntax.Printer.fst"
-                                                        (Prims.of_int (431))
+                                                        (Prims.of_int (432))
                                                         (Prims.of_int (10))
-                                                        (Prims.of_int (434))
+                                                        (Prims.of_int (435))
                                                         (Prims.of_int (31)))))
                                                (Obj.magic
                                                   (FStar_Tactics_Effect.tac_bind
@@ -5414,17 +5416,17 @@ let rec (st_term_to_string' :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Syntax.Printer.fst"
-                                                              (Prims.of_int (433))
+                                                              (Prims.of_int (434))
                                                               (Prims.of_int (12))
-                                                              (Prims.of_int (433))
+                                                              (Prims.of_int (434))
                                                               (Prims.of_int (30)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Syntax.Printer.fst"
-                                                              (Prims.of_int (431))
+                                                              (Prims.of_int (432))
                                                               (Prims.of_int (10))
-                                                              (Prims.of_int (434))
+                                                              (Prims.of_int (435))
                                                               (Prims.of_int (31)))))
                                                      (Obj.magic
                                                         (term_to_string t1))
@@ -5436,17 +5438,17 @@ let rec (st_term_to_string' :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (431))
+                                                                    (Prims.of_int (432))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (434))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (31)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (431))
+                                                                    (Prims.of_int (432))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (434))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (31)))))
                                                                 (Obj.magic
                                                                    (FStar_Tactics_Effect.tac_bind
@@ -5454,9 +5456,9 @@ let rec (st_term_to_string' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Syntax.Printer.fst"
-                                                                    (Prims.of_int (432))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (432))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -5508,17 +5510,17 @@ let rec (st_term_to_string' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (425))
+                                           (Prims.of_int (426))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (434))
+                                           (Prims.of_int (435))
                                            (Prims.of_int (32)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (425))
+                                           (Prims.of_int (426))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (434))
+                                           (Prims.of_int (435))
                                            (Prims.of_int (32)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -5526,17 +5528,17 @@ let rec (st_term_to_string' :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (427))
+                                                 (Prims.of_int (428))
                                                  (Prims.of_int (8))
-                                                 (Prims.of_int (427))
+                                                 (Prims.of_int (428))
                                                  (Prims.of_int (39)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (425))
+                                                 (Prims.of_int (426))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (434))
+                                                 (Prims.of_int (435))
                                                  (Prims.of_int (32)))))
                                         (Obj.magic
                                            (st_term_to_string' level body))
@@ -5548,17 +5550,17 @@ let rec (st_term_to_string' :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (425))
+                                                            (Prims.of_int (426))
                                                             (Prims.of_int (6))
-                                                            (Prims.of_int (434))
+                                                            (Prims.of_int (435))
                                                             (Prims.of_int (32)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (425))
+                                                            (Prims.of_int (426))
                                                             (Prims.of_int (6))
-                                                            (Prims.of_int (434))
+                                                            (Prims.of_int (435))
                                                             (Prims.of_int (32)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_Effect.tac_bind
@@ -5566,9 +5568,9 @@ let rec (st_term_to_string' :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (426))
+                                                                  (Prims.of_int (427))
                                                                   (Prims.of_int (8))
-                                                                  (Prims.of_int (426))
+                                                                  (Prims.of_int (427))
                                                                   (Prims.of_int (29)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
@@ -5623,13 +5625,13 @@ and (branches_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (439)) (Prims.of_int (13))
-                            (Prims.of_int (439)) (Prims.of_int (31)))))
+                            (Prims.of_int (440)) (Prims.of_int (13))
+                            (Prims.of_int (440)) (Prims.of_int (31)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (439)) (Prims.of_int (13))
-                            (Prims.of_int (439)) (Prims.of_int (55)))))
+                            (Prims.of_int (440)) (Prims.of_int (13))
+                            (Prims.of_int (440)) (Prims.of_int (55)))))
                    (Obj.magic (branch_to_string b))
                    (fun uu___ ->
                       (fun uu___ ->
@@ -5639,9 +5641,9 @@ and (branches_to_string :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Syntax.Printer.fst"
-                                       (Prims.of_int (439))
+                                       (Prims.of_int (440))
                                        (Prims.of_int (34))
-                                       (Prims.of_int (439))
+                                       (Prims.of_int (440))
                                        (Prims.of_int (55)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
@@ -5664,12 +5666,12 @@ and (branch_to_string :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (442)) (Prims.of_int (17)) (Prims.of_int (442))
+               (Prims.of_int (443)) (Prims.of_int (17)) (Prims.of_int (443))
                (Prims.of_int (19)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-               (Prims.of_int (441)) (Prims.of_int (35)) (Prims.of_int (445))
+               (Prims.of_int (442)) (Prims.of_int (35)) (Prims.of_int (446))
                (Prims.of_int (29)))))
       (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> br))
       (fun uu___ ->
@@ -5681,13 +5683,13 @@ and (branch_to_string :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (445)) (Prims.of_int (4))
-                              (Prims.of_int (445)) (Prims.of_int (29)))))
+                              (Prims.of_int (446)) (Prims.of_int (4))
+                              (Prims.of_int (446)) (Prims.of_int (29)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                              (Prims.of_int (443)) (Prims.of_int (2))
-                              (Prims.of_int (445)) (Prims.of_int (29)))))
+                              (Prims.of_int (444)) (Prims.of_int (2))
+                              (Prims.of_int (446)) (Prims.of_int (29)))))
                      (Obj.magic (st_term_to_string' "" e))
                      (fun uu___1 ->
                         (fun uu___1 ->
@@ -5697,17 +5699,17 @@ and (branch_to_string :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Syntax.Printer.fst"
-                                         (Prims.of_int (443))
+                                         (Prims.of_int (444))
                                          (Prims.of_int (2))
-                                         (Prims.of_int (445))
+                                         (Prims.of_int (446))
                                          (Prims.of_int (29)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Syntax.Printer.fst"
-                                         (Prims.of_int (443))
+                                         (Prims.of_int (444))
                                          (Prims.of_int (2))
-                                         (Prims.of_int (445))
+                                         (Prims.of_int (446))
                                          (Prims.of_int (29)))))
                                 (Obj.magic
                                    (FStar_Tactics_Effect.tac_bind
@@ -5715,9 +5717,9 @@ and (branch_to_string :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Syntax.Printer.fst"
-                                               (Prims.of_int (444))
+                                               (Prims.of_int (445))
                                                (Prims.of_int (4))
-                                               (Prims.of_int (444))
+                                               (Prims.of_int (445))
                                                (Prims.of_int (27)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
@@ -5755,8 +5757,8 @@ and (pattern_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (452)) (Prims.of_int (6))
-                            (Prims.of_int (452)) (Prims.of_int (74)))))
+                            (Prims.of_int (453)) (Prims.of_int (6))
+                            (Prims.of_int (453)) (Prims.of_int (74)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -5768,14 +5770,14 @@ and (pattern_to_string :
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Syntax.Printer.fst"
-                                  (Prims.of_int (452)) (Prims.of_int (25))
-                                  (Prims.of_int (452)) (Prims.of_int (73)))))
+                                  (Prims.of_int (453)) (Prims.of_int (25))
+                                  (Prims.of_int (453)) (Prims.of_int (73)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "Pulse.Syntax.Printer.fst"
-                                  (Prims.of_int (452)) (Prims.of_int (6))
-                                  (Prims.of_int (452)) (Prims.of_int (74)))))
+                                  (Prims.of_int (453)) (Prims.of_int (6))
+                                  (Prims.of_int (453)) (Prims.of_int (74)))))
                          (Obj.magic
                             (FStar_Tactics_Util.map
                                (fun uu___ ->
@@ -5872,8 +5874,8 @@ let (tag_of_comp :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                            (Prims.of_int (507)) (Prims.of_int (57))
-                            (Prims.of_int (507)) (Prims.of_int (75)))))
+                            (Prims.of_int (508)) (Prims.of_int (57))
+                            (Prims.of_int (508)) (Prims.of_int (75)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
@@ -5975,8 +5977,8 @@ let (decl_to_string :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (566)) (Prims.of_int (12))
-                   (Prims.of_int (569)) (Prims.of_int (42)))))
+                   (Prims.of_int (567)) (Prims.of_int (12))
+                   (Prims.of_int (570)) (Prims.of_int (42)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -5987,8 +5989,8 @@ let (decl_to_string :
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                         (Prims.of_int (567)) (Prims.of_int (5))
-                         (Prims.of_int (569)) (Prims.of_int (42)))))
+                         (Prims.of_int (568)) (Prims.of_int (5))
+                         (Prims.of_int (570)) (Prims.of_int (42)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -5999,8 +6001,8 @@ let (decl_to_string :
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                               (Prims.of_int (567)) (Prims.of_int (32))
-                               (Prims.of_int (569)) (Prims.of_int (42)))))
+                               (Prims.of_int (568)) (Prims.of_int (32))
+                               (Prims.of_int (570)) (Prims.of_int (42)))))
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "prims.fst"
@@ -6012,8 +6014,8 @@ let (decl_to_string :
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "Pulse.Syntax.Printer.fst"
-                                     (Prims.of_int (568)) (Prims.of_int (5))
-                                     (Prims.of_int (569)) (Prims.of_int (42)))))
+                                     (Prims.of_int (569)) (Prims.of_int (5))
+                                     (Prims.of_int (570)) (Prims.of_int (42)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range "prims.fst"
@@ -6025,17 +6027,17 @@ let (decl_to_string :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (568))
+                                           (Prims.of_int (569))
                                            (Prims.of_int (5))
-                                           (Prims.of_int (568))
+                                           (Prims.of_int (569))
                                            (Prims.of_int (71)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Syntax.Printer.fst"
-                                           (Prims.of_int (568))
-                                           (Prims.of_int (5))
                                            (Prims.of_int (569))
+                                           (Prims.of_int (5))
+                                           (Prims.of_int (570))
                                            (Prims.of_int (42)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -6043,17 +6045,17 @@ let (decl_to_string :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (568))
+                                                 (Prims.of_int (569))
                                                  (Prims.of_int (23))
-                                                 (Prims.of_int (568))
+                                                 (Prims.of_int (569))
                                                  (Prims.of_int (71)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Syntax.Printer.fst"
-                                                 (Prims.of_int (568))
+                                                 (Prims.of_int (569))
                                                  (Prims.of_int (5))
-                                                 (Prims.of_int (568))
+                                                 (Prims.of_int (569))
                                                  (Prims.of_int (71)))))
                                         (Obj.magic
                                            (FStar_Tactics_Util.map
@@ -6074,9 +6076,9 @@ let (decl_to_string :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Syntax.Printer.fst"
-                                                      (Prims.of_int (569))
+                                                      (Prims.of_int (570))
                                                       (Prims.of_int (6))
-                                                      (Prims.of_int (569))
+                                                      (Prims.of_int (570))
                                                       (Prims.of_int (42)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
@@ -6092,9 +6094,9 @@ let (decl_to_string :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Syntax.Printer.fst"
-                                                            (Prims.of_int (569))
+                                                            (Prims.of_int (570))
                                                             (Prims.of_int (14))
-                                                            (Prims.of_int (569))
+                                                            (Prims.of_int (570))
                                                             (Prims.of_int (42)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
@@ -6110,9 +6112,9 @@ let (decl_to_string :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "Pulse.Syntax.Printer.fst"
-                                                                  (Prims.of_int (569))
+                                                                  (Prims.of_int (570))
                                                                   (Prims.of_int (14))
-                                                                  (Prims.of_int (569))
+                                                                  (Prims.of_int (570))
                                                                   (Prims.of_int (36)))))
                                                          (FStar_Sealed.seal
                                                             (Obj.magic
@@ -6165,8 +6167,8 @@ let (decl_to_string :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                   (Prims.of_int (572)) (Prims.of_int (4))
-                   (Prims.of_int (573)) (Prims.of_int (70)))))
+                   (Prims.of_int (573)) (Prims.of_int (4))
+                   (Prims.of_int (574)) (Prims.of_int (70)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -6177,8 +6179,8 @@ let (decl_to_string :
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                         (Prims.of_int (572)) (Prims.of_int (31))
-                         (Prims.of_int (573)) (Prims.of_int (70)))))
+                         (Prims.of_int (573)) (Prims.of_int (31))
+                         (Prims.of_int (574)) (Prims.of_int (70)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "prims.fst" (Prims.of_int (590))
@@ -6189,8 +6191,8 @@ let (decl_to_string :
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "Pulse.Syntax.Printer.fst"
-                               (Prims.of_int (573)) (Prims.of_int (4))
-                               (Prims.of_int (573)) (Prims.of_int (70)))))
+                               (Prims.of_int (574)) (Prims.of_int (4))
+                               (Prims.of_int (574)) (Prims.of_int (70)))))
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "prims.fst"
@@ -6202,14 +6204,14 @@ let (decl_to_string :
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "Pulse.Syntax.Printer.fst"
-                                     (Prims.of_int (573)) (Prims.of_int (22))
-                                     (Prims.of_int (573)) (Prims.of_int (70)))))
+                                     (Prims.of_int (574)) (Prims.of_int (22))
+                                     (Prims.of_int (574)) (Prims.of_int (70)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "Pulse.Syntax.Printer.fst"
-                                     (Prims.of_int (573)) (Prims.of_int (4))
-                                     (Prims.of_int (573)) (Prims.of_int (70)))))
+                                     (Prims.of_int (574)) (Prims.of_int (4))
+                                     (Prims.of_int (574)) (Prims.of_int (70)))))
                             (Obj.magic
                                (FStar_Tactics_Util.map
                                   (fun uu___1 ->

--- a/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
@@ -328,8 +328,8 @@ let qual = option SW.qualifier
 let as_qual (q:A.aqual) : qual =
   match q with
   | Some A.Implicit -> SW.as_qual true
+  | Some A.TypeClassArg -> SW.tc_qual
   | _ -> SW.as_qual false
-
 
 (* We open FStar.Tactics.V2 in the scope of every `by` as a convenience. *)
 let desugar_tac_opt (env:env_t) (topt : option A.term) : err (option SW.term) =

--- a/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
+++ b/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
@@ -37,7 +37,8 @@ new val fv : Type0
 val mk_fv (nm:lident) (r:range) : fv
 
 new val qualifier : Type0
-val as_qual (imp:bool) : option qualifier
+val as_qual (imp:bool)  : option qualifier
+val tc_qual : option qualifier
 new val term : Type0
 new val binder : Type0
 new val comp : Type0


### PR DESCRIPTION
While the plan is to just move to F* binders, this patch was pretty easy
and already allows us to use typeclass in Pulse code.

Fixes https://github.com/FStarLang/pulse/issues/34