### PR TITLE
Some refactor in the prover

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.Codeable.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Codeable.fsti
@@ -22,7 +22,7 @@ let encode (#code:vcode) (v:vprop) {| d : codeable code v |} : code.t =
 let decode (#code:vcode) (c:code.t) : vprop =
   code.up c
 
-(* Small vprops for a trivial code by lifting with up2. *)
+(* Small vprops form a trivial code by lifting with up2. *)
 let small_code : vcode = {
   t = Pulse.Lib.Core.small_vprop;
   up = (fun c -> up2_is_small c; Pulse.Lib.Core.up2 c);

--- a/src/checker/Pulse.Checker.Prover.ElimExists.fst
+++ b/src/checker/Pulse.Checker.Prover.ElimExists.fst
@@ -75,6 +75,10 @@ let elim_exists_pst (#preamble:_) (pst:prover_state preamble)
   : T.Tac (pst':prover_state preamble { pst' `pst_extends` pst /\
                                         pst'.unsolved == pst.unsolved }) =
 
+  (* Hacking progress checking: we eliminate all exists, so if
+  there's any in the ctxt then we will make progress. *)
+  let prog = List.Tot.existsb (fun t -> Tm_ExistsSL? (inspect_term t)) pst.remaining_ctxt in
+
   let (| g', remaining_ctxt', ty, k |) =
     elim_exists_frame
       #pst.pg
@@ -105,6 +109,7 @@ let elim_exists_pst (#preamble:_) (pst:prover_state preamble)
   assume (list_as_vprop (vprop_as_list remaining_ctxt') == remaining_ctxt');
 
   { pst with
+    progress = prog;
     pg = g';
     remaining_ctxt = vprop_as_list remaining_ctxt';
     remaining_ctxt_frame_typing = RU.magic ();

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover.ml
@@ -872,6 +872,331 @@ let (intro_any_exists :
         __intro_any_exists
           (FStar_List_Tot_Base.length pst.Pulse_Checker_Prover_Base.unsolved)
           preamble pst prover
+type ('preamble, 'pst0) prover_iteration_res_t =
+  | Stepped of unit Pulse_Checker_Prover_Base.prover_state 
+  | NoProgress 
+let (uu___is_Stepped :
+  Pulse_Checker_Prover_Base.preamble ->
+    unit Pulse_Checker_Prover_Base.prover_state ->
+      (unit, unit) prover_iteration_res_t -> Prims.bool)
+  =
+  fun preamble ->
+    fun pst0 ->
+      fun projectee ->
+        match projectee with | Stepped _0 -> true | uu___ -> false
+let (__proj__Stepped__item___0 :
+  Pulse_Checker_Prover_Base.preamble ->
+    unit Pulse_Checker_Prover_Base.prover_state ->
+      (unit, unit) prover_iteration_res_t ->
+        unit Pulse_Checker_Prover_Base.prover_state)
+  =
+  fun preamble ->
+    fun pst0 -> fun projectee -> match projectee with | Stepped _0 -> _0
+let (uu___is_NoProgress :
+  Pulse_Checker_Prover_Base.preamble ->
+    unit Pulse_Checker_Prover_Base.prover_state ->
+      (unit, unit) prover_iteration_res_t -> Prims.bool)
+  =
+  fun preamble ->
+    fun pst0 ->
+      fun projectee ->
+        match projectee with | NoProgress -> true | uu___ -> false
+let (res_advance :
+  Pulse_Checker_Prover_Base.preamble ->
+    unit Pulse_Checker_Prover_Base.prover_state ->
+      unit Pulse_Checker_Prover_Base.prover_state ->
+        (unit, unit) prover_iteration_res_t ->
+          (unit, unit) prover_iteration_res_t)
+  =
+  fun preamble ->
+    fun pst0 ->
+      fun pst1 ->
+        fun ir ->
+          match ir with
+          | Stepped pst1' -> Stepped pst1'
+          | NoProgress -> NoProgress
+type prover_pass_t =
+  Pulse_Checker_Prover_Base.preamble ->
+    unit Pulse_Checker_Prover_Base.prover_state ->
+      (unit Pulse_Checker_Prover_Base.prover_state, unit)
+        FStar_Tactics_Effect.tac_repr
+type prover_pass =
+  | P of Prims.string * prover_pass_t 
+let (uu___is_P : prover_pass -> Prims.bool) = fun projectee -> true
+let (__proj__P__item___0 : prover_pass -> Prims.string) =
+  fun projectee -> match projectee with | P (_0, _1) -> _0
+let (__proj__P__item___1 : prover_pass -> prover_pass_t) =
+  fun projectee -> match projectee with | P (_0, _1) -> _1
+let rec (prover_iteration_loop :
+  Pulse_Checker_Prover_Base.preamble ->
+    unit Pulse_Checker_Prover_Base.prover_state ->
+      prover_pass Prims.list ->
+        ((unit, unit) prover_iteration_res_t, unit)
+          FStar_Tactics_Effect.tac_repr)
+  =
+  fun uu___2 ->
+    fun uu___1 ->
+      fun uu___ ->
+        (fun preamble ->
+           fun pst0 ->
+             fun passes ->
+               match passes with
+               | [] ->
+                   Obj.magic
+                     (Obj.repr
+                        (FStar_Tactics_Effect.lift_div_tac
+                           (fun uu___ -> NoProgress)))
+               | (P (name, pass))::passes' ->
+                   Obj.magic
+                     (Obj.repr
+                        (FStar_Tactics_Effect.tac_bind
+                           (FStar_Sealed.seal
+                              (Obj.magic
+                                 (FStar_Range.mk_range
+                                    "Pulse.Checker.Prover.fst"
+                                    (Prims.of_int (235)) (Prims.of_int (14))
+                                    (Prims.of_int (235)) (Prims.of_int (23)))))
+                           (FStar_Sealed.seal
+                              (Obj.magic
+                                 (FStar_Range.mk_range
+                                    "Pulse.Checker.Prover.fst"
+                                    (Prims.of_int (236)) (Prims.of_int (4))
+                                    (Prims.of_int (247)) (Prims.of_int (5)))))
+                           (Obj.magic (pass preamble pst0))
+                           (fun uu___ ->
+                              (fun pst ->
+                                 if pst.Pulse_Checker_Prover_Base.progress
+                                 then
+                                   Obj.magic
+                                     (FStar_Tactics_Effect.tac_bind
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Checker.Prover.fst"
+                                                 (Prims.of_int (237))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (239))
+                                                 (Prims.of_int (41)))))
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Checker.Prover.fst"
+                                                 (Prims.of_int (240))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (240))
+                                                 (Prims.of_int (17)))))
+                                        (Obj.magic
+                                           (Pulse_Checker_Prover_Util.debug_prover
+                                              pst.Pulse_Checker_Prover_Base.pg
+                                              (fun uu___ ->
+                                                 FStar_Tactics_Effect.tac_bind
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "Pulse.Checker.Prover.fst"
+                                                            (Prims.of_int (239))
+                                                            (Prims.of_int (15))
+                                                            (Prims.of_int (239))
+                                                            (Prims.of_int (40)))))
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "prims.fst"
+                                                            (Prims.of_int (590))
+                                                            (Prims.of_int (19))
+                                                            (Prims.of_int (590))
+                                                            (Prims.of_int (31)))))
+                                                   (Obj.magic
+                                                      (Pulse_Show.show
+                                                         (Pulse_Show.tac_showable_list
+                                                            Pulse_Show.tac_showable_r_term)
+                                                         pst.Pulse_Checker_Prover_Base.remaining_ctxt))
+                                                   (fun uu___1 ->
+                                                      FStar_Tactics_Effect.lift_div_tac
+                                                        (fun uu___2 ->
+                                                           Prims.strcat
+                                                             (Prims.strcat
+                                                                "prover: "
+                                                                (Prims.strcat
+                                                                   name
+                                                                   ": made progress, remaining_ctxt after pass = "))
+                                                             (Prims.strcat
+                                                                uu___1 "\n"))))))
+                                        (fun uu___ ->
+                                           FStar_Tactics_Effect.lift_div_tac
+                                             (fun uu___1 -> Stepped pst)))
+                                 else
+                                   Obj.magic
+                                     (FStar_Tactics_Effect.tac_bind
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Checker.Prover.fst"
+                                                 (Prims.of_int (242))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (243))
+                                                 (Prims.of_int (56)))))
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "Pulse.Checker.Prover.fst"
+                                                 (Prims.of_int (246))
+                                                 (Prims.of_int (6))
+                                                 (Prims.of_int (246))
+                                                 (Prims.of_int (40)))))
+                                        (Obj.magic
+                                           (Pulse_Checker_Prover_Util.debug_prover
+                                              pst.Pulse_Checker_Prover_Base.pg
+                                              (fun uu___1 ->
+                                                 (fun uu___1 ->
+                                                    Obj.magic
+                                                      (FStar_Tactics_Effect.lift_div_tac
+                                                         (fun uu___2 ->
+                                                            Prims.strcat
+                                                              "prover: "
+                                                              (Prims.strcat
+                                                                 name
+                                                                 ": no progress\n"))))
+                                                   uu___1)))
+                                        (fun uu___1 ->
+                                           (fun uu___1 ->
+                                              Obj.magic
+                                                (prover_iteration_loop
+                                                   preamble pst0 passes'))
+                                             uu___1))) uu___)))) uu___2
+          uu___1 uu___
+let (prover_pass_collect_exists :
+  Pulse_Checker_Prover_Base.preamble ->
+    unit Pulse_Checker_Prover_Base.prover_state ->
+      (unit Pulse_Checker_Prover_Base.prover_state, unit)
+        FStar_Tactics_Effect.tac_repr)
+  =
+  fun uu___1 ->
+    fun uu___ ->
+      (fun preamble ->
+         fun pst0 ->
+           Obj.magic
+             (FStar_Tactics_Effect.lift_div_tac
+                (fun uu___ ->
+                   match collect_exists
+                           (Pulse_Typing_Env.push_env
+                              pst0.Pulse_Checker_Prover_Base.pg
+                              pst0.Pulse_Checker_Prover_Base.uvs)
+                           pst0.Pulse_Checker_Prover_Base.unsolved
+                   with
+                   | FStar_Pervasives.Mkdtuple3 (exs, rest, d) ->
+                       unsolved_equiv_pst preamble pst0
+                         (FStar_List_Tot_Base.op_At exs rest) ()))) uu___1
+        uu___
+let (prover_iteration :
+  Pulse_Checker_Prover_Base.preamble ->
+    unit Pulse_Checker_Prover_Base.prover_state ->
+      ((unit, unit) prover_iteration_res_t, unit)
+        FStar_Tactics_Effect.tac_repr)
+  =
+  fun preamble ->
+    fun pst0 ->
+      FStar_Tactics_Effect.tac_bind
+        (FStar_Sealed.seal
+           (Obj.magic
+              (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
+                 (Prims.of_int (263)) (Prims.of_int (12))
+                 (Prims.of_int (263)) (Prims.of_int (16)))))
+        (FStar_Sealed.seal
+           (Obj.magic
+              (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
+                 (Prims.of_int (263)) (Prims.of_int (19))
+                 (Prims.of_int (275)) (Prims.of_int (3)))))
+        (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> pst0))
+        (fun uu___ ->
+           (fun pst ->
+              Obj.magic
+                (FStar_Tactics_Effect.tac_bind
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
+                            (Prims.of_int (264)) (Prims.of_int (14))
+                            (Prims.of_int (264)) (Prims.of_int (39)))))
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
+                            (Prims.of_int (266)) (Prims.of_int (2))
+                            (Prims.of_int (275)) (Prims.of_int (3)))))
+                   (FStar_Tactics_Effect.lift_div_tac
+                      (fun uu___ ->
+                         {
+                           Pulse_Checker_Prover_Base.pg =
+                             (pst.Pulse_Checker_Prover_Base.pg);
+                           Pulse_Checker_Prover_Base.remaining_ctxt =
+                             (pst.Pulse_Checker_Prover_Base.remaining_ctxt);
+                           Pulse_Checker_Prover_Base.remaining_ctxt_frame_typing
+                             = ();
+                           Pulse_Checker_Prover_Base.uvs =
+                             (pst.Pulse_Checker_Prover_Base.uvs);
+                           Pulse_Checker_Prover_Base.ss =
+                             (pst.Pulse_Checker_Prover_Base.ss);
+                           Pulse_Checker_Prover_Base.nts =
+                             (pst.Pulse_Checker_Prover_Base.nts);
+                           Pulse_Checker_Prover_Base.solved =
+                             (pst.Pulse_Checker_Prover_Base.solved);
+                           Pulse_Checker_Prover_Base.unsolved =
+                             (pst.Pulse_Checker_Prover_Base.unsolved);
+                           Pulse_Checker_Prover_Base.k =
+                             (pst.Pulse_Checker_Prover_Base.k);
+                           Pulse_Checker_Prover_Base.goals_inv = ();
+                           Pulse_Checker_Prover_Base.solved_inv = ();
+                           Pulse_Checker_Prover_Base.progress = false;
+                           Pulse_Checker_Prover_Base.allow_ambiguous =
+                             (pst.Pulse_Checker_Prover_Base.allow_ambiguous)
+                         }))
+                   (fun uu___ ->
+                      (fun pst1 ->
+                         Obj.magic
+                           (FStar_Tactics_Effect.tac_bind
+                              (FStar_Sealed.seal
+                                 (Obj.magic
+                                    (FStar_Range.mk_range
+                                       "Pulse.Checker.Prover.fst"
+                                       (Prims.of_int (266))
+                                       (Prims.of_int (17))
+                                       (Prims.of_int (275))
+                                       (Prims.of_int (3)))))
+                              (FStar_Sealed.seal
+                                 (Obj.magic
+                                    (FStar_Range.mk_range
+                                       "Pulse.Checker.Prover.fst"
+                                       (Prims.of_int (266))
+                                       (Prims.of_int (2))
+                                       (Prims.of_int (275))
+                                       (Prims.of_int (3)))))
+                              (Obj.magic
+                                 (prover_iteration_loop preamble pst1
+                                    [P
+                                       ("elim_exists",
+                                         Pulse_Checker_Prover_ElimExists.elim_exists_pst);
+                                    P
+                                      ("collect_exists",
+                                        prover_pass_collect_exists);
+                                    P
+                                      ("explode",
+                                        Pulse_Checker_Prover_Explode.explode);
+                                    P
+                                      ("match_syntactic",
+                                        Pulse_Checker_Prover_Match.match_syntactic);
+                                    P
+                                      ("match_fastunif",
+                                        Pulse_Checker_Prover_Match.match_fastunif);
+                                    P
+                                      ("match_fastunif_i",
+                                        Pulse_Checker_Prover_Match.match_fastunif_i);
+                                    P
+                                      ("match_full",
+                                        Pulse_Checker_Prover_Match.match_full)]))
+                              (fun uu___ ->
+                                 FStar_Tactics_Effect.lift_div_tac
+                                   (fun uu___1 ->
+                                      res_advance preamble pst0 pst1 uu___))))
+                        uu___))) uu___)
 let rec (prover :
   Pulse_Checker_Prover_Base.preamble ->
     unit Pulse_Checker_Prover_Base.prover_state ->
@@ -884,13 +1209,13 @@ let rec (prover :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                 (Prims.of_int (206)) (Prims.of_int (2)) (Prims.of_int (210))
+                 (Prims.of_int (283)) (Prims.of_int (2)) (Prims.of_int (287))
                  (Prims.of_int (34)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                 (Prims.of_int (210)) (Prims.of_int (35))
-                 (Prims.of_int (344)) (Prims.of_int (38)))))
+                 (Prims.of_int (287)) (Prims.of_int (35))
+                 (Prims.of_int (352)) (Prims.of_int (40)))))
         (Obj.magic
            (Pulse_Checker_Prover_Util.debug_prover
               pst0.Pulse_Checker_Prover_Base.pg
@@ -899,13 +1224,13 @@ let rec (prover :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                            (Prims.of_int (210)) (Prims.of_int (6))
-                            (Prims.of_int (210)) (Prims.of_int (33)))))
+                            (Prims.of_int (287)) (Prims.of_int (6))
+                            (Prims.of_int (287)) (Prims.of_int (33)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                            (Prims.of_int (207)) (Prims.of_int (4))
-                            (Prims.of_int (210)) (Prims.of_int (33)))))
+                            (Prims.of_int (284)) (Prims.of_int (4))
+                            (Prims.of_int (287)) (Prims.of_int (33)))))
                    (Obj.magic
                       (Pulse_Show.show Pulse_Show.tac_showable_bool
                          pst0.Pulse_Checker_Prover_Base.allow_ambiguous))
@@ -917,17 +1242,17 @@ let rec (prover :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Prover.fst"
-                                       (Prims.of_int (207))
+                                       (Prims.of_int (284))
                                        (Prims.of_int (4))
-                                       (Prims.of_int (210))
+                                       (Prims.of_int (287))
                                        (Prims.of_int (33)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Prover.fst"
-                                       (Prims.of_int (207))
+                                       (Prims.of_int (284))
                                        (Prims.of_int (4))
-                                       (Prims.of_int (210))
+                                       (Prims.of_int (287))
                                        (Prims.of_int (33)))))
                               (Obj.magic
                                  (FStar_Tactics_Effect.tac_bind
@@ -935,17 +1260,17 @@ let rec (prover :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Prover.fst"
-                                             (Prims.of_int (209))
+                                             (Prims.of_int (286))
                                              (Prims.of_int (6))
-                                             (Prims.of_int (209))
+                                             (Prims.of_int (286))
                                              (Prims.of_int (42)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Prover.fst"
-                                             (Prims.of_int (207))
+                                             (Prims.of_int (284))
                                              (Prims.of_int (4))
-                                             (Prims.of_int (210))
+                                             (Prims.of_int (287))
                                              (Prims.of_int (33)))))
                                     (Obj.magic
                                        (Pulse_Show.show
@@ -960,17 +1285,17 @@ let rec (prover :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.fst"
-                                                        (Prims.of_int (207))
+                                                        (Prims.of_int (284))
                                                         (Prims.of_int (4))
-                                                        (Prims.of_int (210))
+                                                        (Prims.of_int (287))
                                                         (Prims.of_int (33)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.fst"
-                                                        (Prims.of_int (207))
+                                                        (Prims.of_int (284))
                                                         (Prims.of_int (4))
-                                                        (Prims.of_int (210))
+                                                        (Prims.of_int (287))
                                                         (Prims.of_int (33)))))
                                                (Obj.magic
                                                   (FStar_Tactics_Effect.tac_bind
@@ -978,9 +1303,9 @@ let rec (prover :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Prover.fst"
-                                                              (Prims.of_int (208))
+                                                              (Prims.of_int (285))
                                                               (Prims.of_int (6))
-                                                              (Prims.of_int (208))
+                                                              (Prims.of_int (285))
                                                               (Prims.of_int (48)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
@@ -1027,1146 +1352,190 @@ let rec (prover :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                            (Prims.of_int (212)) (Prims.of_int (12))
-                            (Prims.of_int (212)) (Prims.of_int (16)))))
+                            (Prims.of_int (291)) (Prims.of_int (13))
+                            (Prims.of_int (291)) (Prims.of_int (40)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                            (Prims.of_int (212)) (Prims.of_int (19))
-                            (Prims.of_int (344)) (Prims.of_int (38)))))
-                   (FStar_Tactics_Effect.lift_div_tac (fun uu___1 -> pst0))
+                            (Prims.of_int (293)) (Prims.of_int (2))
+                            (Prims.of_int (352)) (Prims.of_int (40)))))
+                   (Obj.magic
+                      (Pulse_Checker_Prover_ElimPure.elim_pure_pst preamble
+                         pst0))
                    (fun uu___1 ->
-                      (fun pst ->
-                         Obj.magic
-                           (FStar_Tactics_Effect.tac_bind
-                              (FStar_Sealed.seal
-                                 (Obj.magic
-                                    (FStar_Range.mk_range
-                                       "Pulse.Checker.Prover.fst"
-                                       (Prims.of_int (213))
-                                       (Prims.of_int (14))
-                                       (Prims.of_int (213))
-                                       (Prims.of_int (39)))))
-                              (FStar_Sealed.seal
-                                 (Obj.magic
-                                    (FStar_Range.mk_range
-                                       "Pulse.Checker.Prover.fst"
-                                       (Prims.of_int (214))
-                                       (Prims.of_int (2))
-                                       (Prims.of_int (344))
-                                       (Prims.of_int (38)))))
-                              (FStar_Tactics_Effect.lift_div_tac
-                                 (fun uu___1 ->
-                                    {
-                                      Pulse_Checker_Prover_Base.pg =
-                                        (pst.Pulse_Checker_Prover_Base.pg);
-                                      Pulse_Checker_Prover_Base.remaining_ctxt
-                                        =
-                                        (pst.Pulse_Checker_Prover_Base.remaining_ctxt);
-                                      Pulse_Checker_Prover_Base.remaining_ctxt_frame_typing
-                                        = ();
-                                      Pulse_Checker_Prover_Base.uvs =
-                                        (pst.Pulse_Checker_Prover_Base.uvs);
-                                      Pulse_Checker_Prover_Base.ss =
-                                        (pst.Pulse_Checker_Prover_Base.ss);
-                                      Pulse_Checker_Prover_Base.nts =
-                                        (pst.Pulse_Checker_Prover_Base.nts);
-                                      Pulse_Checker_Prover_Base.solved =
-                                        (pst.Pulse_Checker_Prover_Base.solved);
-                                      Pulse_Checker_Prover_Base.unsolved =
-                                        (pst.Pulse_Checker_Prover_Base.unsolved);
-                                      Pulse_Checker_Prover_Base.k =
-                                        (pst.Pulse_Checker_Prover_Base.k);
-                                      Pulse_Checker_Prover_Base.goals_inv =
-                                        ();
-                                      Pulse_Checker_Prover_Base.solved_inv =
-                                        ();
-                                      Pulse_Checker_Prover_Base.progress =
-                                        false;
-                                      Pulse_Checker_Prover_Base.allow_ambiguous
-                                        =
-                                        (pst.Pulse_Checker_Prover_Base.allow_ambiguous)
-                                    }))
-                              (fun uu___1 ->
-                                 (fun pst1 ->
-                                    match pst1.Pulse_Checker_Prover_Base.unsolved
-                                    with
-                                    | [] ->
-                                        Obj.magic
-                                          (Obj.repr
-                                             (FStar_Tactics_Effect.lift_div_tac
-                                                (fun uu___1 -> pst0)))
-                                    | uu___1 ->
-                                        Obj.magic
-                                          (Obj.repr
+                      (fun pst01 ->
+                         match pst01.Pulse_Checker_Prover_Base.unsolved with
+                         | [] ->
+                             Obj.magic
+                               (Obj.repr
+                                  (FStar_Tactics_Effect.lift_div_tac
+                                     (fun uu___1 -> pst01)))
+                         | uu___1 ->
+                             Obj.magic
+                               (Obj.repr
+                                  (FStar_Tactics_Effect.tac_bind
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "Pulse.Checker.Prover.fst"
+                                              (Prims.of_int (302))
+                                              (Prims.of_int (14))
+                                              (Prims.of_int (302))
+                                              (Prims.of_int (42)))))
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "Pulse.Checker.Prover.fst"
+                                              (Prims.of_int (302))
+                                              (Prims.of_int (45))
+                                              (Prims.of_int (352))
+                                              (Prims.of_int (40)))))
+                                     (Obj.magic
+                                        (normalize_vprop_context preamble
+                                           pst01))
+                                     (fun uu___2 ->
+                                        (fun pst ->
+                                           Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Prover.fst"
-                                                         (Prims.of_int (223))
-                                                         (Prims.of_int (14))
-                                                         (Prims.of_int (223))
+                                                         (Prims.of_int (303))
+                                                         (Prims.of_int (16))
+                                                         (Prims.of_int (303))
                                                          (Prims.of_int (41)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Prover.fst"
-                                                         (Prims.of_int (223))
-                                                         (Prims.of_int (44))
-                                                         (Prims.of_int (344))
-                                                         (Prims.of_int (38)))))
-                                                (Obj.magic
-                                                   (normalize_vprop_context
-                                                      preamble pst1))
+                                                         (Prims.of_int (305))
+                                                         (Prims.of_int (4))
+                                                         (Prims.of_int (352))
+                                                         (Prims.of_int (40)))))
+                                                (FStar_Tactics_Effect.lift_div_tac
+                                                   (fun uu___2 ->
+                                                      {
+                                                        Pulse_Checker_Prover_Base.pg
+                                                          =
+                                                          (pst.Pulse_Checker_Prover_Base.pg);
+                                                        Pulse_Checker_Prover_Base.remaining_ctxt
+                                                          =
+                                                          (pst.Pulse_Checker_Prover_Base.remaining_ctxt);
+                                                        Pulse_Checker_Prover_Base.remaining_ctxt_frame_typing
+                                                          = ();
+                                                        Pulse_Checker_Prover_Base.uvs
+                                                          =
+                                                          (pst.Pulse_Checker_Prover_Base.uvs);
+                                                        Pulse_Checker_Prover_Base.ss
+                                                          =
+                                                          (pst.Pulse_Checker_Prover_Base.ss);
+                                                        Pulse_Checker_Prover_Base.nts
+                                                          =
+                                                          (pst.Pulse_Checker_Prover_Base.nts);
+                                                        Pulse_Checker_Prover_Base.solved
+                                                          =
+                                                          (pst.Pulse_Checker_Prover_Base.solved);
+                                                        Pulse_Checker_Prover_Base.unsolved
+                                                          =
+                                                          (pst.Pulse_Checker_Prover_Base.unsolved);
+                                                        Pulse_Checker_Prover_Base.k
+                                                          =
+                                                          (pst.Pulse_Checker_Prover_Base.k);
+                                                        Pulse_Checker_Prover_Base.goals_inv
+                                                          = ();
+                                                        Pulse_Checker_Prover_Base.solved_inv
+                                                          = ();
+                                                        Pulse_Checker_Prover_Base.progress
+                                                          = false;
+                                                        Pulse_Checker_Prover_Base.allow_ambiguous
+                                                          =
+                                                          (pst.Pulse_Checker_Prover_Base.allow_ambiguous)
+                                                      }))
                                                 (fun uu___2 ->
-                                                   (fun pst2 ->
+                                                   (fun pst1 ->
                                                       Obj.magic
                                                         (FStar_Tactics_Effect.tac_bind
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (226))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (226))
-                                                                    (Prims.of_int (44)))))
+                                                                    (Prims.of_int (305))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (305))
+                                                                    (Prims.of_int (30)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
+                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (40)))))
                                                            (Obj.magic
-                                                              (Pulse_Checker_Prover_ElimExists.elim_exists_pst
+                                                              (prover_iteration
                                                                  preamble
-                                                                 pst2))
+                                                                 pst1))
                                                            (fun uu___2 ->
-                                                              (fun pst3 ->
-                                                                 Obj.magic
-                                                                   (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (227))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (229))
-                                                                    (Prims.of_int (62)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (231))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Util.debug_prover
-                                                                    pst3.Pulse_Checker_Prover_Base.pg
-                                                                    (fun
-                                                                    uu___2 ->
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (229))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (229))
-                                                                    (Prims.of_int (61)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "prims.fst"
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (19))
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (31)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    (Pulse_Syntax_Pure.list_as_vprop
-                                                                    pst3.Pulse_Checker_Prover_Base.remaining_ctxt)))
-                                                                    (fun
-                                                                    uu___3 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    Prims.strcat
-                                                                    "prover: remaining_ctxt after elim exists: "
-                                                                    (Prims.strcat
-                                                                    uu___3
-                                                                    "\n"))))))
-                                                                    (fun
-                                                                    uu___2 ->
-                                                                    (fun
-                                                                    uu___2 ->
-                                                                    if
-                                                                    pst3.Pulse_Checker_Prover_Base.progress
-                                                                    then
+                                                              (fun uu___2 ->
+                                                                 match uu___2
+                                                                 with
+                                                                 | Stepped
+                                                                    pst' ->
                                                                     Obj.magic
                                                                     (prover
                                                                     preamble
-                                                                    pst3)
-                                                                    else
+                                                                    pst')
+                                                                 | NoProgress
+                                                                    ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (234))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (43)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (309))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (40)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (236))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_ElimPure.elim_pure_pst
-                                                                    preamble
-                                                                    pst3))
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    (fun pst4
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (236))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (238))
-                                                                    (Prims.of_int (62)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (239))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Util.debug_prover
-                                                                    pst4.Pulse_Checker_Prover_Base.pg
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (238))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (238))
-                                                                    (Prims.of_int (61)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "prims.fst"
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (19))
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (31)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    (Pulse_Syntax_Pure.list_as_vprop
-                                                                    pst4.Pulse_Checker_Prover_Base.remaining_ctxt)))
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    Prims.strcat
-                                                                    "prover: remaining_ctxt after elim pure: "
-                                                                    (Prims.strcat
-                                                                    uu___5
-                                                                    "\n"))))))
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    (fun
-                                                                    uu___4 ->
-                                                                    if
-                                                                    pst4.Pulse_Checker_Prover_Base.progress
-                                                                    then
-                                                                    Obj.magic
-                                                                    (prover
-                                                                    preamble
-                                                                    pst4)
-                                                                    else
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (241))
-                                                                    (Prims.of_int (29))
-                                                                    (Prims.of_int (241))
-                                                                    (Prims.of_int (82)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (239))
-                                                                    (Prims.of_int (55))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    collect_exists
-                                                                    (Pulse_Typing_Env.push_env
-                                                                    pst4.Pulse_Checker_Prover_Base.pg
-                                                                    pst4.Pulse_Checker_Prover_Base.uvs)
-                                                                    pst4.Pulse_Checker_Prover_Base.unsolved))
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    match uu___6
-                                                                    with
-                                                                    | 
-                                                                    FStar_Pervasives.Mkdtuple3
-                                                                    (exs,
-                                                                    rest, d)
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (243))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (245))
-                                                                    (Prims.of_int (87)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (246))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Util.debug_prover
-                                                                    pst4.Pulse_Checker_Prover_Base.pg
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (245))
-                                                                    (Prims.of_int (47))
-                                                                    (Prims.of_int (245))
-                                                                    (Prims.of_int (86)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (244))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (245))
-                                                                    (Prims.of_int (86)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    (Pulse_Syntax_Pure.list_as_vprop
-                                                                    rest)))
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (244))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (245))
-                                                                    (Prims.of_int (86)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (244))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (245))
-                                                                    (Prims.of_int (86)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (245))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (245))
-                                                                    (Prims.of_int (46)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "FStar.Printf.fst"
-                                                                    (Prims.of_int (122))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (124))
-                                                                    (Prims.of_int (44)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    (Pulse_Syntax_Pure.list_as_vprop
-                                                                    exs)))
-                                                                    (fun
-                                                                    uu___9 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___10
-                                                                    ->
-                                                                    fun x ->
-                                                                    Prims.strcat
-                                                                    (Prims.strcat
-                                                                    "prover: tried to pull exists: exs: "
-                                                                    (Prims.strcat
-                                                                    uu___9
-                                                                    " and rest: "))
-                                                                    (Prims.strcat
-                                                                    x "\n")))))
-                                                                    (fun
-                                                                    uu___9 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___10
-                                                                    ->
-                                                                    uu___9
-                                                                    uu___8))))
-                                                                    uu___8))))
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    if
-                                                                    pst4.Pulse_Checker_Prover_Base.progress
-                                                                    then
-                                                                    Obj.magic
-                                                                    (prover
-                                                                    preamble
-                                                                    pst4)
-                                                                    else
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (248))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (248))
-                                                                    (Prims.of_int (49)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (250))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___9 ->
-                                                                    unsolved_equiv_pst
-                                                                    preamble
-                                                                    pst4
-                                                                    (FStar_List_Tot_Base.op_At
-                                                                    exs rest)
-                                                                    ()))
-                                                                    (fun
-                                                                    uu___9 ->
-                                                                    (fun pst5
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (250))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (252))
-                                                                    (Prims.of_int (56)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (253))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Util.debug_prover
-                                                                    pst5.Pulse_Checker_Prover_Base.pg
-                                                                    (fun
-                                                                    uu___9 ->
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (252))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (252))
-                                                                    (Prims.of_int (55)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "prims.fst"
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (19))
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (31)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    (Pulse_Syntax_Pure.list_as_vprop
-                                                                    pst5.Pulse_Checker_Prover_Base.unsolved)))
-                                                                    (fun
-                                                                    uu___10
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___11
-                                                                    ->
-                                                                    Prims.strcat
-                                                                    "prover: unsolved after pulling exists at the top: "
-                                                                    (Prims.strcat
-                                                                    uu___10
-                                                                    "\n"))))))
-                                                                    (fun
-                                                                    uu___9 ->
-                                                                    (fun
-                                                                    uu___9 ->
-                                                                    if
-                                                                    pst5.Pulse_Checker_Prover_Base.progress
-                                                                    then
-                                                                    Obj.magic
-                                                                    (prover
-                                                                    preamble
-                                                                    pst5)
-                                                                    else
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (257))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (257))
-                                                                    (Prims.of_int (33)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (259))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Explode.explode
-                                                                    preamble
-                                                                    pst5))
-                                                                    (fun
-                                                                    uu___11
-                                                                    ->
-                                                                    (fun pst6
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (259))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (262))
-                                                                    (Prims.of_int (65)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (263))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Util.debug_prover
-                                                                    pst6.Pulse_Checker_Prover_Base.pg
-                                                                    (fun
-                                                                    uu___11
-                                                                    ->
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (262))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (262))
-                                                                    (Prims.of_int (64)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (260))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (262))
-                                                                    (Prims.of_int (64)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    (Pulse_Checker_Prover_Base.op_Array_Access
-                                                                    pst6.Pulse_Checker_Prover_Base.ss
-                                                                    (Pulse_Syntax_Pure.list_as_vprop
-                                                                    pst6.Pulse_Checker_Prover_Base.unsolved))))
-                                                                    (fun
-                                                                    uu___12
-                                                                    ->
-                                                                    (fun
-                                                                    uu___12
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (260))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (262))
-                                                                    (Prims.of_int (64)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (260))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (262))
-                                                                    (Prims.of_int (64)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (261))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (261))
-                                                                    (Prims.of_int (55)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "FStar.Printf.fst"
-                                                                    (Prims.of_int (122))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (124))
-                                                                    (Prims.of_int (44)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    (Pulse_Syntax_Pure.list_as_vprop
-                                                                    pst6.Pulse_Checker_Prover_Base.unsolved)))
-                                                                    (fun
-                                                                    uu___13
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___14
-                                                                    ->
-                                                                    fun x ->
-                                                                    Prims.strcat
-                                                                    (Prims.strcat
-                                                                    "prover: unsolved after exploding: "
-                                                                    (Prims.strcat
-                                                                    uu___13
-                                                                    " /// ("))
-                                                                    (Prims.strcat
-                                                                    x ")\n")))))
-                                                                    (fun
-                                                                    uu___13
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___14
-                                                                    ->
-                                                                    uu___13
-                                                                    uu___12))))
-                                                                    uu___12))))
-                                                                    (fun
-                                                                    uu___11
-                                                                    ->
-                                                                    (fun
-                                                                    uu___11
-                                                                    ->
-                                                                    if
-                                                                    pst6.Pulse_Checker_Prover_Base.progress
-                                                                    then
-                                                                    Obj.magic
-                                                                    (prover
-                                                                    preamble
-                                                                    pst6)
-                                                                    else
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (266))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (266))
-                                                                    (Prims.of_int (39)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (268))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Match.match_syntactic
-                                                                    preamble
-                                                                    pst6))
-                                                                    (fun
-                                                                    uu___13
-                                                                    ->
-                                                                    (fun pst7
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (268))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (270))
-                                                                    (Prims.of_int (44)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (271))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Util.debug_prover
-                                                                    pst7.Pulse_Checker_Prover_Base.pg
-                                                                    (fun
-                                                                    uu___13
-                                                                    ->
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (270))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (270))
-                                                                    (Prims.of_int (43)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "prims.fst"
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (19))
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (31)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Show.show
-                                                                    Pulse_Show.tac_showable_r_term
-                                                                    (Pulse_Syntax_Pure.list_as_vprop
-                                                                    pst7.Pulse_Checker_Prover_Base.unsolved)))
-                                                                    (fun
-                                                                    uu___14
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___15
-                                                                    ->
-                                                                    Prims.strcat
-                                                                    "prover: unsolved after syntactic match: "
-                                                                    (Prims.strcat
-                                                                    uu___14
-                                                                    "\n"))))))
-                                                                    (fun
-                                                                    uu___13
-                                                                    ->
-                                                                    (fun
-                                                                    uu___13
-                                                                    ->
-                                                                    if
-                                                                    pst7.Pulse_Checker_Prover_Base.progress
-                                                                    then
-                                                                    Obj.magic
-                                                                    (prover
-                                                                    preamble
-                                                                    pst7)
-                                                                    else
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (274))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (274))
-                                                                    (Prims.of_int (38)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (275))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Match.match_fastunif
-                                                                    preamble
-                                                                    pst7))
-                                                                    (fun
-                                                                    uu___15
-                                                                    ->
-                                                                    (fun pst8
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (275))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (277))
-                                                                    (Prims.of_int (44)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (278))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Util.debug_prover
-                                                                    pst8.Pulse_Checker_Prover_Base.pg
-                                                                    (fun
-                                                                    uu___15
-                                                                    ->
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (277))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (277))
-                                                                    (Prims.of_int (43)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "prims.fst"
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (19))
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (31)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Show.show
-                                                                    Pulse_Show.tac_showable_r_term
-                                                                    (Pulse_Syntax_Pure.list_as_vprop
-                                                                    pst8.Pulse_Checker_Prover_Base.unsolved)))
-                                                                    (fun
-                                                                    uu___16
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___17
-                                                                    ->
-                                                                    Prims.strcat
-                                                                    "prover: unsolved after fastunif: "
-                                                                    (Prims.strcat
-                                                                    uu___16
-                                                                    "\n"))))))
-                                                                    (fun
-                                                                    uu___15
-                                                                    ->
-                                                                    (fun
-                                                                    uu___15
-                                                                    ->
-                                                                    if
-                                                                    pst8.Pulse_Checker_Prover_Base.progress
-                                                                    then
-                                                                    Obj.magic
-                                                                    (prover
-                                                                    preamble
-                                                                    pst8)
-                                                                    else
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (281))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (281))
-                                                                    (Prims.of_int (40)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (282))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Match.match_fastunif_i
-                                                                    preamble
-                                                                    pst8))
-                                                                    (fun
-                                                                    uu___17
-                                                                    ->
-                                                                    (fun pst9
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (282))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (284))
-                                                                    (Prims.of_int (44)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (285))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Util.debug_prover
-                                                                    pst9.Pulse_Checker_Prover_Base.pg
-                                                                    (fun
-                                                                    uu___17
-                                                                    ->
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (284))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (284))
-                                                                    (Prims.of_int (43)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "prims.fst"
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (19))
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (31)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Show.show
-                                                                    Pulse_Show.tac_showable_r_term
-                                                                    (Pulse_Syntax_Pure.list_as_vprop
-                                                                    pst9.Pulse_Checker_Prover_Base.unsolved)))
-                                                                    (fun
-                                                                    uu___18
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___19
-                                                                    ->
-                                                                    Prims.strcat
-                                                                    "prover: unsolved after fastunif_inst: "
-                                                                    (Prims.strcat
-                                                                    uu___18
-                                                                    "\n"))))))
-                                                                    (fun
-                                                                    uu___17
-                                                                    ->
-                                                                    (fun
-                                                                    uu___17
-                                                                    ->
-                                                                    if
-                                                                    pst9.Pulse_Checker_Prover_Base.progress
-                                                                    then
-                                                                    Obj.magic
-                                                                    (prover
-                                                                    preamble
-                                                                    pst9)
-                                                                    else
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (289))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (289))
-                                                                    (Prims.of_int (34)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (291))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Match.match_full
-                                                                    preamble
-                                                                    pst9))
-                                                                    (fun
-                                                                    uu___19
-                                                                    ->
-                                                                    (fun
-                                                                    pst10 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (291))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (293))
-                                                                    (Prims.of_int (56)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (294))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Checker_Prover_Util.debug_prover
-                                                                    pst10.Pulse_Checker_Prover_Base.pg
-                                                                    (fun
-                                                                    uu___19
-                                                                    ->
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (293))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (293))
-                                                                    (Prims.of_int (55)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "prims.fst"
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (19))
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (31)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Printer.term_to_string
-                                                                    (Pulse_Syntax_Pure.list_as_vprop
-                                                                    pst10.Pulse_Checker_Prover_Base.unsolved)))
-                                                                    (fun
-                                                                    uu___20
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___21
-                                                                    ->
-                                                                    Prims.strcat
-                                                                    "prover: unsolved after full match: "
-                                                                    (Prims.strcat
-                                                                    uu___20
-                                                                    "\n"))))))
-                                                                    (fun
-                                                                    uu___19
-                                                                    ->
-                                                                    (fun
-                                                                    uu___19
-                                                                    ->
-                                                                    if
-                                                                    pst10.Pulse_Checker_Prover_Base.progress
-                                                                    then
-                                                                    Obj.magic
-                                                                    (prover
-                                                                    preamble
-                                                                    pst10)
-                                                                    else
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (296))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (296))
-                                                                    (Prims.of_int (41)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (297))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (intro_any_exists
                                                                     preamble
-                                                                    pst10
+                                                                    pst1
                                                                     prover))
                                                                     (fun
-                                                                    uu___21
+                                                                    uu___3 ->
+                                                                    (fun pst2
                                                                     ->
-                                                                    (fun
-                                                                    pst11 ->
                                                                     if
-                                                                    pst11.Pulse_Checker_Prover_Base.progress
+                                                                    pst2.Pulse_Checker_Prover_Base.progress
                                                                     then
                                                                     Obj.magic
                                                                     (Obj.repr
                                                                     (prover
                                                                     preamble
-                                                                    pst11))
+                                                                    pst2))
                                                                     else
                                                                     Obj.magic
                                                                     (Obj.repr
                                                                     (match 
-                                                                    pst11.Pulse_Checker_Prover_Base.unsolved
+                                                                    pst2.Pulse_Checker_Prover_Base.unsolved
                                                                     with
                                                                     | 
                                                                     [] ->
                                                                     Obj.repr
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___22
-                                                                    -> pst11))
+                                                                    uu___4 ->
+                                                                    pst2))
                                                                     | 
                                                                     hd::unsolved'
                                                                     ->
@@ -2176,75 +1545,70 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (308))
-                                                                    (Prims.of_int (35))
-                                                                    (Prims.of_int (308))
-                                                                    (Prims.of_int (87)))))
+                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (37))
+                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (89)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (301))
-                                                                    (Prims.of_int (22))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
+                                                                    (Prims.of_int (313))
+                                                                    (Prims.of_int (24))
+                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (40)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___22
-                                                                    ->
+                                                                    uu___4 ->
                                                                     collect_pures
                                                                     (Pulse_Typing_Env.push_env
-                                                                    pst11.Pulse_Checker_Prover_Base.pg
-                                                                    pst11.Pulse_Checker_Prover_Base.uvs)
-                                                                    pst11.Pulse_Checker_Prover_Base.unsolved))
+                                                                    pst2.Pulse_Checker_Prover_Base.pg
+                                                                    pst2.Pulse_Checker_Prover_Base.uvs)
+                                                                    pst2.Pulse_Checker_Prover_Base.unsolved))
                                                                     (fun
-                                                                    uu___22
-                                                                    ->
+                                                                    uu___4 ->
                                                                     (fun
-                                                                    uu___22
-                                                                    ->
-                                                                    match uu___22
+                                                                    uu___4 ->
+                                                                    match uu___4
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives.Mkdtuple3
                                                                     (pures,
-                                                                    rest1,
-                                                                    d1) ->
+                                                                    rest, d)
+                                                                    ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (309))
-                                                                    (Prims.of_int (18))
-                                                                    (Prims.of_int (309))
-                                                                    (Prims.of_int (55)))))
+                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (310))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
+                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (40)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___23
-                                                                    ->
+                                                                    uu___5 ->
                                                                     unsolved_equiv_pst
                                                                     preamble
-                                                                    pst11
+                                                                    pst2
                                                                     (FStar_List_Tot_Base.op_At
-                                                                    rest1
+                                                                    rest
                                                                     pures) ()))
                                                                     (fun
-                                                                    uu___23
+                                                                    uu___5 ->
+                                                                    (fun pst3
                                                                     ->
-                                                                    (fun
-                                                                    pst12 ->
                                                                     match 
-                                                                    pst12.Pulse_Checker_Prover_Base.unsolved
+                                                                    pst3.Pulse_Checker_Prover_Base.unsolved
                                                                     with
                                                                     | 
                                                                     [] ->
@@ -2252,8 +1616,8 @@ let rec (prover :
                                                                     (Obj.repr
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___23
-                                                                    -> pst12)))
+                                                                    uu___5 ->
+                                                                    pst3)))
                                                                     | 
                                                                     q::tl ->
                                                                     Obj.magic
@@ -2264,51 +1628,46 @@ let rec (prover :
                                                                     with
                                                                     | 
                                                                     Pulse_Syntax_Pure.Tm_Pure
-                                                                    uu___23
-                                                                    ->
+                                                                    uu___5 ->
                                                                     prove_pures
                                                                     preamble
-                                                                    pst12
+                                                                    pst3
                                                                     | 
-                                                                    uu___23
-                                                                    ->
+                                                                    uu___5 ->
                                                                     FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (318))
-                                                                    (Prims.of_int (28))
-                                                                    (Prims.of_int (318))
-                                                                    (Prims.of_int (92)))))
+                                                                    (Prims.of_int (326))
+                                                                    (Prims.of_int (30))
+                                                                    (Prims.of_int (326))
+                                                                    (Prims.of_int (94)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (318))
-                                                                    (Prims.of_int (95))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
+                                                                    (Prims.of_int (326))
+                                                                    (Prims.of_int (97))
+                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Util.filter
                                                                     (fun
-                                                                    uu___24
-                                                                    ->
+                                                                    uu___6 ->
                                                                     (fun t ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___24
-                                                                    ->
+                                                                    uu___6 ->
                                                                     Prims.op_Negation
                                                                     (Pulse_Syntax_Pure.uu___is_Tm_Pure
                                                                     (Pulse_Syntax_Pure.inspect_term
                                                                     t)))))
-                                                                    uu___24)
-                                                                    pst12.Pulse_Checker_Prover_Base.unsolved))
+                                                                    uu___6)
+                                                                    pst3.Pulse_Checker_Prover_Base.unsolved))
                                                                     (fun
-                                                                    uu___24
-                                                                    ->
+                                                                    uu___6 ->
                                                                     (fun
                                                                     non_pures
                                                                     ->
@@ -2318,38 +1677,35 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (319))
-                                                                    (Prims.of_int (28))
-                                                                    (Prims.of_int (319))
-                                                                    (Prims.of_int (65)))))
+                                                                    (Prims.of_int (327))
+                                                                    (Prims.of_int (30))
+                                                                    (Prims.of_int (327))
+                                                                    (Prims.of_int (67)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (319))
-                                                                    (Prims.of_int (68))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
+                                                                    (Prims.of_int (327))
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Util.map
                                                                     (fun
-                                                                    uu___24
-                                                                    ->
+                                                                    uu___6 ->
                                                                     (fun q1
                                                                     ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___24
-                                                                    ->
+                                                                    uu___6 ->
                                                                     Pulse_Checker_Prover_Base.op_Array_Access
-                                                                    pst12.Pulse_Checker_Prover_Base.ss
+                                                                    pst3.Pulse_Checker_Prover_Base.ss
                                                                     q1)))
-                                                                    uu___24)
+                                                                    uu___6)
                                                                     non_pures))
                                                                     (fun
-                                                                    uu___24
-                                                                    ->
+                                                                    uu___6 ->
                                                                     (fun
                                                                     non_pures1
                                                                     ->
@@ -2359,28 +1715,26 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (320))
-                                                                    (Prims.of_int (33))
-                                                                    (Prims.of_int (320))
-                                                                    (Prims.of_int (43)))))
+                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (35))
+                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (321))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
+                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (40)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___24
-                                                                    ->
+                                                                    uu___6 ->
                                                                     Pulse_Checker_Prover_Base.op_Array_Access
-                                                                    pst12.Pulse_Checker_Prover_Base.ss
+                                                                    pst3.Pulse_Checker_Prover_Base.ss
                                                                     q))
                                                                     (fun
-                                                                    uu___24
-                                                                    ->
+                                                                    uu___6 ->
                                                                     (fun
                                                                     q_norm ->
                                                                     Obj.magic
@@ -2389,29 +1743,27 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (321))
-                                                                    (Prims.of_int (18))
-                                                                    (Prims.of_int (321))
-                                                                    (Prims.of_int (48)))))
+                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (321))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
+                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (check_equiv_emp'
-                                                                    pst12.Pulse_Checker_Prover_Base.pg
+                                                                    pst3.Pulse_Checker_Prover_Base.pg
                                                                     q_norm))
                                                                     (fun
-                                                                    uu___24
-                                                                    ->
+                                                                    uu___6 ->
                                                                     (fun
-                                                                    uu___24
-                                                                    ->
-                                                                    match uu___24
+                                                                    uu___6 ->
+                                                                    match uu___6
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.Some
@@ -2422,70 +1774,68 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (324))
-                                                                    (Prims.of_int (27))
-                                                                    (Prims.of_int (326))
-                                                                    (Prims.of_int (36)))))
+                                                                    (Prims.of_int (332))
+                                                                    (Prims.of_int (29))
+                                                                    (Prims.of_int (334))
+                                                                    (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (328))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (328))
-                                                                    (Prims.of_int (25)))))
+                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (27)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___25
-                                                                    ->
+                                                                    uu___7 ->
                                                                     {
                                                                     Pulse_Checker_Prover_Base.pg
                                                                     =
-                                                                    (pst12.Pulse_Checker_Prover_Base.pg);
+                                                                    (pst3.Pulse_Checker_Prover_Base.pg);
                                                                     Pulse_Checker_Prover_Base.remaining_ctxt
                                                                     =
-                                                                    (pst12.Pulse_Checker_Prover_Base.remaining_ctxt);
+                                                                    (pst3.Pulse_Checker_Prover_Base.remaining_ctxt);
                                                                     Pulse_Checker_Prover_Base.remaining_ctxt_frame_typing
                                                                     = ();
                                                                     Pulse_Checker_Prover_Base.uvs
                                                                     =
-                                                                    (pst12.Pulse_Checker_Prover_Base.uvs);
+                                                                    (pst3.Pulse_Checker_Prover_Base.uvs);
                                                                     Pulse_Checker_Prover_Base.ss
                                                                     =
-                                                                    (pst12.Pulse_Checker_Prover_Base.ss);
+                                                                    (pst3.Pulse_Checker_Prover_Base.ss);
                                                                     Pulse_Checker_Prover_Base.nts
                                                                     =
-                                                                    (pst12.Pulse_Checker_Prover_Base.nts);
+                                                                    (pst3.Pulse_Checker_Prover_Base.nts);
                                                                     Pulse_Checker_Prover_Base.solved
                                                                     =
-                                                                    (pst12.Pulse_Checker_Prover_Base.solved);
+                                                                    (pst3.Pulse_Checker_Prover_Base.solved);
                                                                     Pulse_Checker_Prover_Base.unsolved
                                                                     =
                                                                     unsolved';
                                                                     Pulse_Checker_Prover_Base.k
                                                                     =
-                                                                    (pst12.Pulse_Checker_Prover_Base.k);
+                                                                    (pst3.Pulse_Checker_Prover_Base.k);
                                                                     Pulse_Checker_Prover_Base.goals_inv
                                                                     = ();
                                                                     Pulse_Checker_Prover_Base.solved_inv
                                                                     = ();
                                                                     Pulse_Checker_Prover_Base.progress
                                                                     =
-                                                                    (pst12.Pulse_Checker_Prover_Base.progress);
+                                                                    (pst3.Pulse_Checker_Prover_Base.progress);
                                                                     Pulse_Checker_Prover_Base.allow_ambiguous
                                                                     =
-                                                                    (pst12.Pulse_Checker_Prover_Base.allow_ambiguous)
+                                                                    (pst3.Pulse_Checker_Prover_Base.allow_ambiguous)
                                                                     }))
                                                                     (fun
-                                                                    uu___25
-                                                                    ->
+                                                                    uu___7 ->
                                                                     (fun pst'
                                                                     ->
                                                                     Obj.magic
                                                                     (prover
                                                                     preamble
                                                                     pst'))
-                                                                    uu___25))
+                                                                    uu___7))
                                                                     | 
                                                                     FStar_Pervasives_Native.None
                                                                     ->
@@ -2495,344 +1845,320 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (330))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (340))
-                                                                    (Prims.of_int (28)))))
+                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (344))
-                                                                    (Prims.of_int (38)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (330))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (335))
-                                                                    (Prims.of_int (15)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (330))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (340))
-                                                                    (Prims.of_int (28)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (332))
-                                                                    (Prims.of_int (67)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (330))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (335))
-                                                                    (Prims.of_int (15)))))
+                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (332))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (332))
-                                                                    (Prims.of_int (67)))))
+                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (17)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (331))
-                                                                    (Prims.of_int (16))
-                                                                    (Prims.of_int (332))
-                                                                    (Prims.of_int (67)))))
+                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (30)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (332))
-                                                                    (Prims.of_int (27))
-                                                                    (Prims.of_int (332))
-                                                                    (Prims.of_int (67)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (332))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (332))
-                                                                    (Prims.of_int (67)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (332))
-                                                                    (Prims.of_int (34))
-                                                                    (Prims.of_int (332))
-                                                                    (Prims.of_int (66)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (332))
-                                                                    (Prims.of_int (27))
-                                                                    (Prims.of_int (332))
-                                                                    (Prims.of_int (67)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Pure.canon_vprop_list_print
-                                                                    non_pures1))
-                                                                    (fun
-                                                                    uu___25
-                                                                    ->
-                                                                    (fun
-                                                                    uu___25
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (Pulse_PP.pp
-                                                                    Pulse_PP.printable_term
-                                                                    uu___25))
-                                                                    uu___25)))
-                                                                    (fun
-                                                                    uu___25
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___26
-                                                                    ->
-                                                                    Pulse_PP.indent
-                                                                    uu___25))))
-                                                                    (fun
-                                                                    uu___25
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___26
-                                                                    ->
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    (Pulse_PP.text
-                                                                    "Cannot prove:")
-                                                                    uu___25))))
-                                                                    (fun
-                                                                    uu___25
-                                                                    ->
-                                                                    (fun
-                                                                    uu___25
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (330))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (335))
-                                                                    (Prims.of_int (15)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (330))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (335))
-                                                                    (Prims.of_int (15)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (333))
-                                                                    (Prims.of_int (16))
-                                                                    (Prims.of_int (334))
-                                                                    (Prims.of_int (76)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (330))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (335))
-                                                                    (Prims.of_int (15)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (334))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (334))
-                                                                    (Prims.of_int (76)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (333))
-                                                                    (Prims.of_int (16))
-                                                                    (Prims.of_int (334))
-                                                                    (Prims.of_int (76)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (334))
-                                                                    (Prims.of_int (27))
-                                                                    (Prims.of_int (334))
-                                                                    (Prims.of_int (76)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (334))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (334))
-                                                                    (Prims.of_int (76)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (334))
-                                                                    (Prims.of_int (34))
-                                                                    (Prims.of_int (334))
-                                                                    (Prims.of_int (75)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (334))
-                                                                    (Prims.of_int (27))
-                                                                    (Prims.of_int (334))
-                                                                    (Prims.of_int (76)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_Syntax_Pure.canon_vprop_list_print
-                                                                    pst12.Pulse_Checker_Prover_Base.remaining_ctxt))
-                                                                    (fun
-                                                                    uu___26
-                                                                    ->
-                                                                    (fun
-                                                                    uu___26
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (Pulse_PP.pp
-                                                                    Pulse_PP.printable_term
-                                                                    uu___26))
-                                                                    uu___26)))
-                                                                    (fun
-                                                                    uu___26
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___27
-                                                                    ->
-                                                                    Pulse_PP.indent
-                                                                    uu___26))))
-                                                                    (fun
-                                                                    uu___26
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___27
-                                                                    ->
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    (Pulse_PP.text
-                                                                    "In the context:")
-                                                                    uu___26))))
-                                                                    (fun
-                                                                    uu___26
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___27
-                                                                    ->
-                                                                    [uu___26]))))
-                                                                    (fun
-                                                                    uu___26
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___27
-                                                                    ->
-                                                                    uu___25
-                                                                    ::
-                                                                    uu___26))))
-                                                                    uu___25)))
-                                                                    (fun
-                                                                    uu___25
-                                                                    ->
-                                                                    (fun
-                                                                    uu___25
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (18))
                                                                     (Prims.of_int (340))
-                                                                    (Prims.of_int (28)))))
+                                                                    (Prims.of_int (69)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (330))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (340))
-                                                                    (Prims.of_int (28)))))
+                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (17)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (340))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (69)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (18))
+                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (69)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (29))
+                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (69)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (69)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (36))
+                                                                    (Prims.of_int (340))
                                                                     (Prims.of_int (68)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (335))
-                                                                    (Prims.of_int (18))
                                                                     (Prims.of_int (340))
-                                                                    (Prims.of_int (28)))))
+                                                                    (Prims.of_int (29))
+                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (69)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Syntax_Pure.canon_vprop_list_print
+                                                                    non_pures1))
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.printable_term
+                                                                    uu___7))
+                                                                    uu___7)))
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    Pulse_PP.indent
+                                                                    uu___7))))
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    (Pulse_PP.text
+                                                                    "Cannot prove:")
+                                                                    uu___7))))
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (17)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (17)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (18))
+                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (78)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (17)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (78)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (18))
+                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (78)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (29))
+                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (78)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (78)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (36))
+                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (77)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (29))
+                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (78)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Syntax_Pure.canon_vprop_list_print
+                                                                    pst3.Pulse_Checker_Prover_Base.remaining_ctxt))
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.printable_term
+                                                                    uu___8))
+                                                                    uu___8)))
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    Pulse_PP.indent
+                                                                    uu___8))))
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    (Pulse_PP.text
+                                                                    "In the context:")
+                                                                    uu___8))))
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    [uu___8]))))
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    uu___7 ::
+                                                                    uu___8))))
+                                                                    uu___7)))
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (30)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (30)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (24))
+                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (70)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Prover.fst"
+                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (30)))))
                                                                     (Obj.magic
                                                                     (Pulse_Config.debug_flag
                                                                     "initial_solver_state"))
                                                                     (fun
-                                                                    uu___26
-                                                                    ->
+                                                                    uu___8 ->
                                                                     (fun
-                                                                    uu___26
-                                                                    ->
-                                                                    if
-                                                                    uu___26
+                                                                    uu___8 ->
+                                                                    if uu___8
                                                                     then
                                                                     Obj.magic
                                                                     (Obj.repr
@@ -2841,255 +2167,230 @@ let rec (prover :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (336))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (337))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (335))
-                                                                    (Prims.of_int (74))
-                                                                    (Prims.of_int (340))
-                                                                    (Prims.of_int (19)))))
+                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (76))
+                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (21)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (337))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (337))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (336))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (337))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (337))
-                                                                    (Prims.of_int (31))
-                                                                    (Prims.of_int (337))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (33))
+                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (337))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (337))
-                                                                    (Prims.of_int (50)))))
+                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
                                                                     Pulse_PP.printable_term
                                                                     preamble.Pulse_Checker_Prover_Base.goals))
                                                                     (fun
-                                                                    uu___27
-                                                                    ->
+                                                                    uu___9 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___28
+                                                                    uu___10
                                                                     ->
                                                                     Pulse_PP.indent
-                                                                    uu___27))))
+                                                                    uu___9))))
                                                                     (fun
-                                                                    uu___27
-                                                                    ->
+                                                                    uu___9 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___28
+                                                                    uu___10
                                                                     ->
                                                                     FStar_Pprint.op_Hat_Hat
                                                                     (Pulse_PP.text
                                                                     "The prover was started with goal:")
-                                                                    uu___27))))
+                                                                    uu___9))))
                                                                     (fun
-                                                                    uu___27
-                                                                    ->
+                                                                    uu___9 ->
                                                                     (fun
-                                                                    uu___27
-                                                                    ->
+                                                                    uu___9 ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (335))
-                                                                    (Prims.of_int (74))
-                                                                    (Prims.of_int (340))
-                                                                    (Prims.of_int (19)))))
+                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (76))
+                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (21)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (335))
-                                                                    (Prims.of_int (74))
-                                                                    (Prims.of_int (340))
-                                                                    (Prims.of_int (19)))))
+                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (76))
+                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (21)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (338))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (339))
-                                                                    (Prims.of_int (49)))))
+                                                                    (Prims.of_int (346))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (335))
-                                                                    (Prims.of_int (74))
-                                                                    (Prims.of_int (340))
-                                                                    (Prims.of_int (19)))))
+                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (76))
+                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (21)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (339))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (339))
-                                                                    (Prims.of_int (49)))))
+                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (338))
-                                                                    (Prims.of_int (20))
-                                                                    (Prims.of_int (339))
-                                                                    (Prims.of_int (49)))))
+                                                                    (Prims.of_int (346))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (51)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (339))
-                                                                    (Prims.of_int (31))
-                                                                    (Prims.of_int (339))
-                                                                    (Prims.of_int (49)))))
+                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (33))
+                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (339))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (339))
-                                                                    (Prims.of_int (49)))))
+                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (51)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
                                                                     Pulse_PP.printable_term
                                                                     preamble.Pulse_Checker_Prover_Base.ctxt))
                                                                     (fun
-                                                                    uu___28
+                                                                    uu___10
                                                                     ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___29
+                                                                    uu___11
                                                                     ->
                                                                     Pulse_PP.indent
-                                                                    uu___28))))
+                                                                    uu___10))))
                                                                     (fun
-                                                                    uu___28
+                                                                    uu___10
                                                                     ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___29
+                                                                    uu___11
                                                                     ->
                                                                     FStar_Pprint.op_Hat_Hat
                                                                     (Pulse_PP.text
                                                                     "and initial context:")
-                                                                    uu___28))))
+                                                                    uu___10))))
                                                                     (fun
-                                                                    uu___28
+                                                                    uu___10
                                                                     ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___29
+                                                                    uu___11
                                                                     ->
-                                                                    [uu___28]))))
+                                                                    [uu___10]))))
                                                                     (fun
-                                                                    uu___28
+                                                                    uu___10
                                                                     ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___29
-                                                                    ->
-                                                                    uu___27
+                                                                    uu___11
+                                                                    -> uu___9
                                                                     ::
-                                                                    uu___28))))
-                                                                    uu___27)))
+                                                                    uu___10))))
+                                                                    uu___9)))
                                                                     else
                                                                     Obj.magic
                                                                     (Obj.repr
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___28
+                                                                    uu___10
                                                                     -> []))))
-                                                                    uu___26)))
+                                                                    uu___8)))
                                                                     (fun
-                                                                    uu___26
-                                                                    ->
+                                                                    uu___8 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___27
-                                                                    ->
+                                                                    uu___9 ->
                                                                     FStar_List_Tot_Base.op_At
-                                                                    uu___25
-                                                                    uu___26))))
-                                                                    uu___25)))
+                                                                    uu___7
+                                                                    uu___8))))
+                                                                    uu___7)))
                                                                     (fun
-                                                                    uu___25
-                                                                    ->
+                                                                    uu___7 ->
                                                                     (fun msg
                                                                     ->
                                                                     Obj.magic
                                                                     (Pulse_Typing_Env.fail_doc
-                                                                    pst12.Pulse_Checker_Prover_Base.pg
+                                                                    pst3.Pulse_Checker_Prover_Base.pg
                                                                     FStar_Pervasives_Native.None
                                                                     msg))
-                                                                    uu___25)))
-                                                                    uu___24)))
-                                                                    uu___24)))
-                                                                    uu___24)))
-                                                                    uu___24))))
-                                                                    uu___23)))
-                                                                    uu___22)))))
-                                                                    uu___21)))
-                                                                    uu___19)))
-                                                                    uu___19)))
-                                                                    uu___17)))
-                                                                    uu___17)))
-                                                                    uu___15)))
-                                                                    uu___15)))
-                                                                    uu___13)))
-                                                                    uu___13)))
-                                                                    uu___11)))
-                                                                    uu___11)))
-                                                                    uu___9)))
-                                                                    uu___9)))
                                                                     uu___7)))
                                                                     uu___6)))
-                                                                    uu___4)))
-                                                                    uu___4)))
-                                                                    uu___2)))
+                                                                    uu___6)))
+                                                                    uu___6)))
+                                                                    uu___6))))
+                                                                    uu___5)))
+                                                                    uu___4)))))
+                                                                    uu___3)))
                                                                 uu___2)))
-                                                     uu___2)))) uu___1)))
+                                                     uu___2))) uu___2))))
                         uu___1))) uu___)
 let rec (get_q_at_hd :
   Pulse_Typing_Env.env ->
@@ -3137,13 +2438,13 @@ let (prove :
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                           (Prims.of_int (370)) (Prims.of_int (2))
-                           (Prims.of_int (372)) (Prims.of_int (55)))))
+                           (Prims.of_int (378)) (Prims.of_int (2))
+                           (Prims.of_int (380)) (Prims.of_int (55)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                           (Prims.of_int (372)) (Prims.of_int (56))
-                           (Prims.of_int (464)) (Prims.of_int (126)))))
+                           (Prims.of_int (380)) (Prims.of_int (56))
+                           (Prims.of_int (472)) (Prims.of_int (126)))))
                   (Obj.magic
                      (Pulse_Checker_Prover_Util.debug_prover g
                         (fun uu___ ->
@@ -3152,16 +2453,16 @@ let (prove :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Prover.fst"
-                                      (Prims.of_int (372))
+                                      (Prims.of_int (380))
                                       (Prims.of_int (30))
-                                      (Prims.of_int (372))
+                                      (Prims.of_int (380))
                                       (Prims.of_int (54)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Prover.fst"
-                                      (Prims.of_int (371)) (Prims.of_int (4))
-                                      (Prims.of_int (372))
+                                      (Prims.of_int (379)) (Prims.of_int (4))
+                                      (Prims.of_int (380))
                                       (Prims.of_int (54)))))
                              (Obj.magic
                                 (Pulse_Syntax_Printer.term_to_string goals))
@@ -3173,17 +2474,17 @@ let (prove :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Prover.fst"
-                                                 (Prims.of_int (371))
+                                                 (Prims.of_int (379))
                                                  (Prims.of_int (4))
-                                                 (Prims.of_int (372))
+                                                 (Prims.of_int (380))
                                                  (Prims.of_int (54)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Prover.fst"
-                                                 (Prims.of_int (371))
+                                                 (Prims.of_int (379))
                                                  (Prims.of_int (4))
-                                                 (Prims.of_int (372))
+                                                 (Prims.of_int (380))
                                                  (Prims.of_int (54)))))
                                         (Obj.magic
                                            (FStar_Tactics_Effect.tac_bind
@@ -3191,9 +2492,9 @@ let (prove :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.Prover.fst"
-                                                       (Prims.of_int (372))
+                                                       (Prims.of_int (380))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (372))
+                                                       (Prims.of_int (380))
                                                        (Prims.of_int (29)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
@@ -3230,17 +2531,17 @@ let (prove :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Prover.fst"
-                                      (Prims.of_int (374))
+                                      (Prims.of_int (382))
                                       (Prims.of_int (15))
-                                      (Prims.of_int (374))
+                                      (Prims.of_int (382))
                                       (Prims.of_int (33)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Prover.fst"
-                                      (Prims.of_int (389))
+                                      (Prims.of_int (397))
                                       (Prims.of_int (75))
-                                      (Prims.of_int (464))
+                                      (Prims.of_int (472))
                                       (Prims.of_int (126)))))
                              (FStar_Tactics_Effect.lift_div_tac
                                 (fun uu___1 ->
@@ -3253,17 +2554,17 @@ let (prove :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Prover.fst"
-                                                 (Prims.of_int (391))
+                                                 (Prims.of_int (399))
                                                  (Prims.of_int (6))
-                                                 (Prims.of_int (395))
+                                                 (Prims.of_int (403))
                                                  (Prims.of_int (12)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Prover.fst"
-                                                 (Prims.of_int (398))
+                                                 (Prims.of_int (406))
                                                  (Prims.of_int (43))
-                                                 (Prims.of_int (464))
+                                                 (Prims.of_int (472))
                                                  (Prims.of_int (126)))))
                                         (FStar_Tactics_Effect.lift_div_tac
                                            (fun uu___1 ->
@@ -3287,17 +2588,17 @@ let (prove :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Checker.Prover.fst"
-                                                            (Prims.of_int (400))
+                                                            (Prims.of_int (408))
                                                             (Prims.of_int (6))
-                                                            (Prims.of_int (412))
+                                                            (Prims.of_int (420))
                                                             (Prims.of_int (40)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Checker.Prover.fst"
-                                                            (Prims.of_int (413))
+                                                            (Prims.of_int (421))
                                                             (Prims.of_int (8))
-                                                            (Prims.of_int (464))
+                                                            (Prims.of_int (472))
                                                             (Prims.of_int (126)))))
                                                    (FStar_Tactics_Effect.lift_div_tac
                                                       (fun uu___1 ->
@@ -3364,18 +2665,18 @@ let (prove :
                                                                     (
                                                                     FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (423))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (423))
                                                                     (Prims.of_int (25)))))
                                                               (FStar_Sealed.seal
                                                                  (Obj.magic
                                                                     (
                                                                     FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (423))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (464))
+                                                                    (Prims.of_int (472))
                                                                     (Prims.of_int (126)))))
                                                               (Obj.magic
                                                                  (prover
@@ -3389,17 +2690,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (431))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (445))
+                                                                    (Prims.of_int (453))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (423))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (464))
+                                                                    (Prims.of_int (472))
                                                                     (Prims.of_int (126)))))
                                                                     (match 
                                                                     pst.Pulse_Checker_Prover_Base.nts
@@ -3423,17 +2724,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (434))
+                                                                    (Prims.of_int (442))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (434))
+                                                                    (Prims.of_int (442))
                                                                     (Prims.of_int (56)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (435))
+                                                                    (Prims.of_int (443))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (445))
+                                                                    (Prims.of_int (453))
                                                                     (Prims.of_int (24)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Prover_Substs.ss_to_nt_substs
@@ -3455,17 +2756,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3473,17 +2774,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3491,17 +2792,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (439))
+                                                                    (Prims.of_int (447))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (439))
+                                                                    (Prims.of_int (447))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3509,17 +2810,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (439))
+                                                                    (Prims.of_int (447))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (439))
+                                                                    (Prims.of_int (447))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (439))
+                                                                    (Prims.of_int (447))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (439))
+                                                                    (Prims.of_int (447))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -3546,17 +2847,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3564,17 +2865,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (448))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (448))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3582,17 +2883,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (448))
                                                                     (Prims.of_int (42))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (448))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (448))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (448))
                                                                     (Prims.of_int (54)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -3619,17 +2920,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3637,17 +2938,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (441))
+                                                                    (Prims.of_int (449))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (441))
+                                                                    (Prims.of_int (449))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3655,17 +2956,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (441))
+                                                                    (Prims.of_int (449))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (441))
+                                                                    (Prims.of_int (449))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (441))
+                                                                    (Prims.of_int (449))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (441))
+                                                                    (Prims.of_int (449))
                                                                     (Prims.of_int (52)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -3692,17 +2993,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3710,17 +3011,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (442))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (442))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3728,17 +3029,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (442))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (53))
-                                                                    (Prims.of_int (442))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (442))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (442))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (76)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -3766,17 +3067,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3784,17 +3085,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (443))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (443))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (64)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3802,17 +3103,17 @@ let (prove :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (443))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (47))
-                                                                    (Prims.of_int (443))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (64)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (443))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (443))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (64)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -4007,13 +3308,13 @@ let (try_frame_pre_uvs :
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                           (Prims.of_int (493)) (Prims.of_int (22))
-                           (Prims.of_int (493)) (Prims.of_int (23)))))
+                           (Prims.of_int (501)) (Prims.of_int (22))
+                           (Prims.of_int (501)) (Prims.of_int (23)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                           (Prims.of_int (491)) (Prims.of_int (42))
-                           (Prims.of_int (564)) (Prims.of_int (88)))))
+                           (Prims.of_int (499)) (Prims.of_int (42))
+                           (Prims.of_int (572)) (Prims.of_int (88)))))
                   (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> d))
                   (fun uu___ ->
                      (fun uu___ ->
@@ -4025,17 +3326,17 @@ let (try_frame_pre_uvs :
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Checker.Prover.fst"
-                                          (Prims.of_int (495))
+                                          (Prims.of_int (503))
                                           (Prims.of_int (10))
-                                          (Prims.of_int (495))
+                                          (Prims.of_int (503))
                                           (Prims.of_int (48)))))
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Checker.Prover.fst"
-                                          (Prims.of_int (495))
+                                          (Prims.of_int (503))
                                           (Prims.of_int (51))
-                                          (Prims.of_int (564))
+                                          (Prims.of_int (572))
                                           (Prims.of_int (88)))))
                                  (FStar_Tactics_Effect.lift_div_tac
                                     (fun uu___1 ->
@@ -4050,17 +3351,17 @@ let (try_frame_pre_uvs :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Checker.Prover.fst"
-                                                     (Prims.of_int (498))
+                                                     (Prims.of_int (506))
                                                      (Prims.of_int (4))
-                                                     (Prims.of_int (498))
+                                                     (Prims.of_int (506))
                                                      (Prims.of_int (75)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Checker.Prover.fst"
-                                                     (Prims.of_int (495))
+                                                     (Prims.of_int (503))
                                                      (Prims.of_int (51))
-                                                     (Prims.of_int (564))
+                                                     (Prims.of_int (572))
                                                      (Prims.of_int (88)))))
                                             (Obj.magic
                                                (prove allow_ambiguous g1 ctxt
@@ -4082,17 +3383,17 @@ let (try_frame_pre_uvs :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (502))
+                                                                    (Prims.of_int (510))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (502))
+                                                                    (Prims.of_int (510))
                                                                     (Prims.of_int (49)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (504))
+                                                                    (Prims.of_int (512))
                                                                     (Prims.of_int (82))
-                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (572))
                                                                     (Prims.of_int (88)))))
                                                            (FStar_Tactics_Effect.lift_div_tac
                                                               (fun uu___2 ->
@@ -4107,17 +3408,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (505))
+                                                                    (Prims.of_int (513))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (505))
+                                                                    (Prims.of_int (513))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (505))
+                                                                    (Prims.of_int (513))
                                                                     (Prims.of_int (38))
-                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (572))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4134,17 +3435,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (506))
+                                                                    (Prims.of_int (514))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (506))
+                                                                    (Prims.of_int (514))
                                                                     (Prims.of_int (32)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (506))
+                                                                    (Prims.of_int (514))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (572))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4161,17 +3462,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (508))
-                                                                    (Prims.of_int (28))
                                                                     (Prims.of_int (516))
+                                                                    (Prims.of_int (28))
+                                                                    (Prims.of_int (524))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (516))
+                                                                    (Prims.of_int (524))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (572))
                                                                     (Prims.of_int (88)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4179,17 +3480,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (509))
+                                                                    (Prims.of_int (517))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (509))
+                                                                    (Prims.of_int (517))
                                                                     (Prims.of_int (69)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (510))
+                                                                    (Prims.of_int (518))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (516))
+                                                                    (Prims.of_int (524))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4214,17 +3515,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (513))
+                                                                    (Prims.of_int (521))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (515))
+                                                                    (Prims.of_int (523))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (512))
+                                                                    (Prims.of_int (520))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (515))
+                                                                    (Prims.of_int (523))
                                                                     (Prims.of_int (34)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4232,17 +3533,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (515))
+                                                                    (Prims.of_int (523))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (515))
+                                                                    (Prims.of_int (523))
                                                                     (Prims.of_int (33)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (513))
+                                                                    (Prims.of_int (521))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (515))
+                                                                    (Prims.of_int (523))
                                                                     (Prims.of_int (34)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
@@ -4257,17 +3558,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (513))
+                                                                    (Prims.of_int (521))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (515))
+                                                                    (Prims.of_int (523))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (513))
+                                                                    (Prims.of_int (521))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (515))
+                                                                    (Prims.of_int (523))
                                                                     (Prims.of_int (34)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4275,9 +3576,9 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (514))
+                                                                    (Prims.of_int (522))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (514))
+                                                                    (Prims.of_int (522))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -4344,17 +3645,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (521))
+                                                                    (Prims.of_int (529))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (521))
+                                                                    (Prims.of_int (529))
                                                                     (Prims.of_int (22)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (521))
+                                                                    (Prims.of_int (529))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (572))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4371,17 +3672,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (522))
+                                                                    (Prims.of_int (530))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (522))
+                                                                    (Prims.of_int (530))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (522))
+                                                                    (Prims.of_int (530))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (572))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4399,17 +3700,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (524))
+                                                                    (Prims.of_int (532))
                                                                     (Prims.of_int (82))
-                                                                    (Prims.of_int (524))
+                                                                    (Prims.of_int (532))
                                                                     (Prims.of_int (102)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (524))
+                                                                    (Prims.of_int (532))
                                                                     (Prims.of_int (105))
-                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (572))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4428,17 +3729,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (526))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (526))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (18)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (526))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (572))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4454,17 +3755,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (527))
+                                                                    (Prims.of_int (535))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (527))
+                                                                    (Prims.of_int (535))
                                                                     (Prims.of_int (21)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (527))
+                                                                    (Prims.of_int (535))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (572))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4481,17 +3782,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (528))
+                                                                    (Prims.of_int (536))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (528))
+                                                                    (Prims.of_int (536))
                                                                     (Prims.of_int (42)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (529))
+                                                                    (Prims.of_int (537))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (572))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4510,17 +3811,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (530))
+                                                                    (Prims.of_int (538))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (530))
+                                                                    (Prims.of_int (538))
                                                                     (Prims.of_int (75)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (530))
+                                                                    (Prims.of_int (538))
                                                                     (Prims.of_int (78))
-                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (572))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4542,17 +3843,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (532))
+                                                                    (Prims.of_int (540))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (532))
+                                                                    (Prims.of_int (540))
                                                                     (Prims.of_int (73)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (532))
+                                                                    (Prims.of_int (540))
                                                                     (Prims.of_int (76))
-                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (572))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4572,17 +3873,17 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (537))
+                                                                    (Prims.of_int (545))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (537))
+                                                                    (Prims.of_int (545))
                                                                     (Prims.of_int (104)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (544))
+                                                                    (Prims.of_int (552))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (564))
+                                                                    (Prims.of_int (572))
                                                                     (Prims.of_int (88)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.continuation_elaborator_with_bind
@@ -4678,13 +3979,13 @@ let (try_frame_pre :
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                         (Prims.of_int (575)) (Prims.of_int (12))
-                         (Prims.of_int (575)) (Prims.of_int (32)))))
+                         (Prims.of_int (583)) (Prims.of_int (12))
+                         (Prims.of_int (583)) (Prims.of_int (32)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                         (Prims.of_int (577)) (Prims.of_int (2))
-                         (Prims.of_int (577)) (Prims.of_int (64)))))
+                         (Prims.of_int (585)) (Prims.of_int (2))
+                         (Prims.of_int (585)) (Prims.of_int (64)))))
                 (FStar_Tactics_Effect.lift_div_tac
                    (fun uu___ ->
                       Pulse_Typing_Env.mk_env (Pulse_Typing_Env.fstar_env g)))
@@ -4711,13 +4012,13 @@ let (prove_post_hint :
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                       (Prims.of_int (586)) (Prims.of_int (10))
-                       (Prims.of_int (586)) (Prims.of_int (46)))))
+                       (Prims.of_int (594)) (Prims.of_int (10))
+                       (Prims.of_int (594)) (Prims.of_int (46)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Prover.fst"
-                       (Prims.of_int (588)) (Prims.of_int (2))
-                       (Prims.of_int (641)) (Prims.of_int (99)))))
+                       (Prims.of_int (596)) (Prims.of_int (2))
+                       (Prims.of_int (649)) (Prims.of_int (99)))))
               (FStar_Tactics_Effect.lift_div_tac
                  (fun uu___ ->
                     Pulse_Typing_Env.push_context g "prove_post_hint" rng))
@@ -4737,17 +4038,17 @@ let (prove_post_hint :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Prover.fst"
-                                         (Prims.of_int (591))
+                                         (Prims.of_int (599))
                                          (Prims.of_int (79))
-                                         (Prims.of_int (591))
+                                         (Prims.of_int (599))
                                          (Prims.of_int (80)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "Pulse.Checker.Prover.fst"
-                                         (Prims.of_int (590))
+                                         (Prims.of_int (598))
                                          (Prims.of_int (21))
-                                         (Prims.of_int (641))
+                                         (Prims.of_int (649))
                                          (Prims.of_int (99)))))
                                 (FStar_Tactics_Effect.lift_div_tac
                                    (fun uu___ -> r))
@@ -4766,17 +4067,17 @@ let (prove_post_hint :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.fst"
-                                                        (Prims.of_int (593))
+                                                        (Prims.of_int (601))
                                                         (Prims.of_int (17))
-                                                        (Prims.of_int (593))
+                                                        (Prims.of_int (601))
                                                         (Prims.of_int (44)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Prover.fst"
-                                                        (Prims.of_int (593))
+                                                        (Prims.of_int (601))
                                                         (Prims.of_int (47))
-                                                        (Prims.of_int (641))
+                                                        (Prims.of_int (649))
                                                         (Prims.of_int (99)))))
                                                (FStar_Tactics_Effect.lift_div_tac
                                                   (fun uu___1 ->
@@ -4790,17 +4091,17 @@ let (prove_post_hint :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Prover.fst"
-                                                                   (Prims.of_int (594))
+                                                                   (Prims.of_int (602))
                                                                    (Prims.of_int (27))
-                                                                   (Prims.of_int (594))
+                                                                   (Prims.of_int (602))
                                                                    (Prims.of_int (66)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "Pulse.Checker.Prover.fst"
-                                                                   (Prims.of_int (597))
+                                                                   (Prims.of_int (605))
                                                                    (Prims.of_int (4))
-                                                                   (Prims.of_int (641))
+                                                                   (Prims.of_int (649))
                                                                    (Prims.of_int (99)))))
                                                           (FStar_Tactics_Effect.lift_div_tac
                                                              (fun uu___1 ->
@@ -4826,17 +4127,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (599))
+                                                                    (Prims.of_int (607))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (605))
+                                                                    (Prims.of_int (613))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (599))
+                                                                    (Prims.of_int (607))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (605))
+                                                                    (Prims.of_int (613))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4844,17 +4145,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (599))
+                                                                    (Prims.of_int (607))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (605))
+                                                                    (Prims.of_int (613))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (599))
+                                                                    (Prims.of_int (607))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (605))
+                                                                    (Prims.of_int (613))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4862,17 +4163,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (601))
+                                                                    (Prims.of_int (609))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (604))
+                                                                    (Prims.of_int (612))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (599))
+                                                                    (Prims.of_int (607))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (605))
+                                                                    (Prims.of_int (613))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4880,17 +4181,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (602))
+                                                                    (Prims.of_int (610))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (604))
+                                                                    (Prims.of_int (612))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (601))
+                                                                    (Prims.of_int (609))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (604))
+                                                                    (Prims.of_int (612))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4898,17 +4199,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (602))
+                                                                    (Prims.of_int (610))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (602))
+                                                                    (Prims.of_int (610))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (602))
+                                                                    (Prims.of_int (610))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (604))
+                                                                    (Prims.of_int (612))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4916,17 +4217,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (602))
+                                                                    (Prims.of_int (610))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (602))
+                                                                    (Prims.of_int (610))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (602))
+                                                                    (Prims.of_int (610))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (602))
+                                                                    (Prims.of_int (610))
                                                                     (Prims.of_int (24)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -4949,17 +4250,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (603))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (604))
+                                                                    (Prims.of_int (612))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (602))
+                                                                    (Prims.of_int (610))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (604))
+                                                                    (Prims.of_int (612))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4967,17 +4268,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (604))
+                                                                    (Prims.of_int (612))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (604))
+                                                                    (Prims.of_int (612))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (603))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (604))
+                                                                    (Prims.of_int (612))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4985,17 +4286,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (604))
+                                                                    (Prims.of_int (612))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (604))
+                                                                    (Prims.of_int (612))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (604))
+                                                                    (Prims.of_int (612))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (604))
+                                                                    (Prims.of_int (612))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -5088,17 +4389,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (610))
+                                                                    (Prims.of_int (618))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (610))
+                                                                    (Prims.of_int (618))
                                                                     (Prims.of_int (99)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (608))
+                                                                    (Prims.of_int (616))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (641))
+                                                                    (Prims.of_int (649))
                                                                     (Prims.of_int (99)))))
                                                                     (Obj.magic
                                                                     (prove
@@ -5128,17 +4429,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (615))
+                                                                    (Prims.of_int (623))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (615))
+                                                                    (Prims.of_int (623))
                                                                     (Prims.of_int (27)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (617))
+                                                                    (Prims.of_int (625))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (641))
+                                                                    (Prims.of_int (649))
                                                                     (Prims.of_int (99)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -5156,17 +4457,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (617))
+                                                                    (Prims.of_int (625))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (617))
+                                                                    (Prims.of_int (625))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (617))
+                                                                    (Prims.of_int (625))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (641))
+                                                                    (Prims.of_int (649))
                                                                     (Prims.of_int (99)))))
                                                                     (Obj.magic
                                                                     (check_equiv_emp'
@@ -5188,17 +4489,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (619))
-                                                                    (Prims.of_int (30))
                                                                     (Prims.of_int (627))
+                                                                    (Prims.of_int (30))
+                                                                    (Prims.of_int (635))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (619))
+                                                                    (Prims.of_int (627))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (627))
+                                                                    (Prims.of_int (635))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -5206,17 +4507,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (619))
-                                                                    (Prims.of_int (30))
                                                                     (Prims.of_int (627))
+                                                                    (Prims.of_int (30))
+                                                                    (Prims.of_int (635))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (619))
-                                                                    (Prims.of_int (30))
                                                                     (Prims.of_int (627))
+                                                                    (Prims.of_int (30))
+                                                                    (Prims.of_int (635))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -5224,17 +4525,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (621))
+                                                                    (Prims.of_int (629))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (622))
+                                                                    (Prims.of_int (630))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (619))
-                                                                    (Prims.of_int (30))
                                                                     (Prims.of_int (627))
+                                                                    (Prims.of_int (30))
+                                                                    (Prims.of_int (635))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -5242,17 +4543,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (622))
+                                                                    (Prims.of_int (630))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (622))
+                                                                    (Prims.of_int (630))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (621))
+                                                                    (Prims.of_int (629))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (622))
+                                                                    (Prims.of_int (630))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -5260,17 +4561,17 @@ let (prove_post_hint :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (622))
+                                                                    (Prims.of_int (630))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (622))
+                                                                    (Prims.of_int (630))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (622))
+                                                                    (Prims.of_int (630))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (622))
+                                                                    (Prims.of_int (630))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_doc

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_ElimExists.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_ElimExists.ml
@@ -139,108 +139,132 @@ let (elim_exists_pst :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Prover.ElimExists.fst"
-                 (Prims.of_int (79)) (Prims.of_int (4)) (Prims.of_int (84))
-                 (Prims.of_int (13)))))
+                 (Prims.of_int (80)) (Prims.of_int (13)) (Prims.of_int (80))
+                 (Prims.of_int (89)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Prover.ElimExists.fst"
-                 (Prims.of_int (76)) (Prims.of_int (74)) (Prims.of_int (115))
+                 (Prims.of_int (80)) (Prims.of_int (92)) (Prims.of_int (120))
                  (Prims.of_int (3)))))
-        (Obj.magic
-           (elim_exists_frame pst.Pulse_Checker_Prover_Base.pg
-              (Pulse_Syntax_Pure.list_as_vprop
-                 pst.Pulse_Checker_Prover_Base.remaining_ctxt)
-              (Pulse_Checker_Prover_Base.op_Star
-                 preamble.Pulse_Checker_Prover_Base.frame
-                 (Pulse_Checker_Prover_Base.op_Array_Access
-                    pst.Pulse_Checker_Prover_Base.ss
-                    pst.Pulse_Checker_Prover_Base.solved)) ()
-              pst.Pulse_Checker_Prover_Base.uvs))
+        (FStar_Tactics_Effect.lift_div_tac
+           (fun uu___ ->
+              FStar_List_Tot_Base.existsb
+                (fun t ->
+                   Pulse_Syntax_Pure.uu___is_Tm_ExistsSL
+                     (Pulse_Syntax_Pure.inspect_term t))
+                pst.Pulse_Checker_Prover_Base.remaining_ctxt))
         (fun uu___ ->
-           FStar_Tactics_Effect.lift_div_tac
-             (fun uu___1 ->
-                match uu___ with
-                | FStar_Pervasives.Mkdtuple4 (g', remaining_ctxt', ty, k) ->
-                    {
-                      Pulse_Checker_Prover_Base.pg = g';
-                      Pulse_Checker_Prover_Base.remaining_ctxt =
-                        (Pulse_Syntax_Pure.vprop_as_list remaining_ctxt');
-                      Pulse_Checker_Prover_Base.remaining_ctxt_frame_typing =
-                        ();
-                      Pulse_Checker_Prover_Base.uvs =
-                        (pst.Pulse_Checker_Prover_Base.uvs);
-                      Pulse_Checker_Prover_Base.ss =
-                        (pst.Pulse_Checker_Prover_Base.ss);
-                      Pulse_Checker_Prover_Base.nts =
-                        FStar_Pervasives_Native.None;
-                      Pulse_Checker_Prover_Base.solved =
-                        (pst.Pulse_Checker_Prover_Base.solved);
-                      Pulse_Checker_Prover_Base.unsolved =
-                        (pst.Pulse_Checker_Prover_Base.unsolved);
-                      Pulse_Checker_Prover_Base.k =
-                        (Pulse_Checker_Base.k_elab_trans
-                           preamble.Pulse_Checker_Prover_Base.g0
-                           (Pulse_Checker_Prover_Base.__proj__Mkprover_state__item__pg
-                              preamble pst) g'
-                           (Pulse_Checker_Prover_Base.op_Star
-                              preamble.Pulse_Checker_Prover_Base.ctxt
-                              preamble.Pulse_Checker_Prover_Base.frame)
-                           (Pulse_Checker_Prover_Base.op_Star
-                              (Pulse_Checker_Prover_Base.op_Star
-                                 (Pulse_Syntax_Pure.list_as_vprop
-                                    (Pulse_Checker_Prover_Base.__proj__Mkprover_state__item__remaining_ctxt
-                                       preamble pst))
-                                 preamble.Pulse_Checker_Prover_Base.frame)
-                              (Pulse_Checker_Prover_Base.op_Array_Access
-                                 (Pulse_Checker_Prover_Base.__proj__Mkprover_state__item__ss
-                                    preamble pst)
-                                 (Pulse_Checker_Prover_Base.__proj__Mkprover_state__item__solved
-                                    preamble pst)))
-                           (Pulse_Checker_Prover_Base.op_Star
-                              (Pulse_Checker_Prover_Base.op_Star
-                                 remaining_ctxt'
-                                 preamble.Pulse_Checker_Prover_Base.frame)
-                              (Pulse_Checker_Prover_Base.op_Array_Access
-                                 pst.Pulse_Checker_Prover_Base.ss
-                                 pst.Pulse_Checker_Prover_Base.solved))
-                           pst.Pulse_Checker_Prover_Base.k
-                           (Pulse_Checker_Base.k_elab_equiv
-                              pst.Pulse_Checker_Prover_Base.pg g'
-                              (Pulse_Checker_Prover_Base.op_Star
-                                 (Pulse_Syntax_Pure.list_as_vprop
-                                    pst.Pulse_Checker_Prover_Base.remaining_ctxt)
-                                 (Pulse_Checker_Prover_Base.op_Star
-                                    preamble.Pulse_Checker_Prover_Base.frame
-                                    (Pulse_Checker_Prover_Base.op_Array_Access
-                                       pst.Pulse_Checker_Prover_Base.ss
-                                       pst.Pulse_Checker_Prover_Base.solved)))
-                              (Pulse_Checker_Prover_Base.op_Star
-                                 (Pulse_Checker_Prover_Base.op_Star
-                                    (Pulse_Syntax_Pure.list_as_vprop
-                                       pst.Pulse_Checker_Prover_Base.remaining_ctxt)
-                                    preamble.Pulse_Checker_Prover_Base.frame)
-                                 (Pulse_Checker_Prover_Base.op_Array_Access
-                                    pst.Pulse_Checker_Prover_Base.ss
-                                    pst.Pulse_Checker_Prover_Base.solved))
-                              (Pulse_Checker_Prover_Base.op_Star
-                                 remaining_ctxt'
-                                 (Pulse_Checker_Prover_Base.op_Star
-                                    preamble.Pulse_Checker_Prover_Base.frame
-                                    (Pulse_Checker_Prover_Base.op_Array_Access
-                                       pst.Pulse_Checker_Prover_Base.ss
-                                       pst.Pulse_Checker_Prover_Base.solved)))
-                              (Pulse_Checker_Prover_Base.op_Star
-                                 (Pulse_Checker_Prover_Base.op_Star
-                                    remaining_ctxt'
-                                    preamble.Pulse_Checker_Prover_Base.frame)
-                                 (Pulse_Checker_Prover_Base.op_Array_Access
-                                    pst.Pulse_Checker_Prover_Base.ss
-                                    pst.Pulse_Checker_Prover_Base.solved)) k
-                              () ()));
-                      Pulse_Checker_Prover_Base.goals_inv = ();
-                      Pulse_Checker_Prover_Base.solved_inv = ();
-                      Pulse_Checker_Prover_Base.progress =
-                        (pst.Pulse_Checker_Prover_Base.progress);
-                      Pulse_Checker_Prover_Base.allow_ambiguous =
-                        (pst.Pulse_Checker_Prover_Base.allow_ambiguous)
-                    }))
+           (fun prog ->
+              Obj.magic
+                (FStar_Tactics_Effect.tac_bind
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range
+                            "Pulse.Checker.Prover.ElimExists.fst"
+                            (Prims.of_int (83)) (Prims.of_int (4))
+                            (Prims.of_int (88)) (Prims.of_int (13)))))
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range
+                            "Pulse.Checker.Prover.ElimExists.fst"
+                            (Prims.of_int (80)) (Prims.of_int (92))
+                            (Prims.of_int (120)) (Prims.of_int (3)))))
+                   (Obj.magic
+                      (elim_exists_frame pst.Pulse_Checker_Prover_Base.pg
+                         (Pulse_Syntax_Pure.list_as_vprop
+                            pst.Pulse_Checker_Prover_Base.remaining_ctxt)
+                         (Pulse_Checker_Prover_Base.op_Star
+                            preamble.Pulse_Checker_Prover_Base.frame
+                            (Pulse_Checker_Prover_Base.op_Array_Access
+                               pst.Pulse_Checker_Prover_Base.ss
+                               pst.Pulse_Checker_Prover_Base.solved)) ()
+                         pst.Pulse_Checker_Prover_Base.uvs))
+                   (fun uu___ ->
+                      FStar_Tactics_Effect.lift_div_tac
+                        (fun uu___1 ->
+                           match uu___ with
+                           | FStar_Pervasives.Mkdtuple4
+                               (g', remaining_ctxt', ty, k) ->
+                               {
+                                 Pulse_Checker_Prover_Base.pg = g';
+                                 Pulse_Checker_Prover_Base.remaining_ctxt =
+                                   (Pulse_Syntax_Pure.vprop_as_list
+                                      remaining_ctxt');
+                                 Pulse_Checker_Prover_Base.remaining_ctxt_frame_typing
+                                   = ();
+                                 Pulse_Checker_Prover_Base.uvs =
+                                   (pst.Pulse_Checker_Prover_Base.uvs);
+                                 Pulse_Checker_Prover_Base.ss =
+                                   (pst.Pulse_Checker_Prover_Base.ss);
+                                 Pulse_Checker_Prover_Base.nts =
+                                   FStar_Pervasives_Native.None;
+                                 Pulse_Checker_Prover_Base.solved =
+                                   (pst.Pulse_Checker_Prover_Base.solved);
+                                 Pulse_Checker_Prover_Base.unsolved =
+                                   (pst.Pulse_Checker_Prover_Base.unsolved);
+                                 Pulse_Checker_Prover_Base.k =
+                                   (Pulse_Checker_Base.k_elab_trans
+                                      preamble.Pulse_Checker_Prover_Base.g0
+                                      (Pulse_Checker_Prover_Base.__proj__Mkprover_state__item__pg
+                                         preamble pst) g'
+                                      (Pulse_Checker_Prover_Base.op_Star
+                                         preamble.Pulse_Checker_Prover_Base.ctxt
+                                         preamble.Pulse_Checker_Prover_Base.frame)
+                                      (Pulse_Checker_Prover_Base.op_Star
+                                         (Pulse_Checker_Prover_Base.op_Star
+                                            (Pulse_Syntax_Pure.list_as_vprop
+                                               (Pulse_Checker_Prover_Base.__proj__Mkprover_state__item__remaining_ctxt
+                                                  preamble pst))
+                                            preamble.Pulse_Checker_Prover_Base.frame)
+                                         (Pulse_Checker_Prover_Base.op_Array_Access
+                                            (Pulse_Checker_Prover_Base.__proj__Mkprover_state__item__ss
+                                               preamble pst)
+                                            (Pulse_Checker_Prover_Base.__proj__Mkprover_state__item__solved
+                                               preamble pst)))
+                                      (Pulse_Checker_Prover_Base.op_Star
+                                         (Pulse_Checker_Prover_Base.op_Star
+                                            remaining_ctxt'
+                                            preamble.Pulse_Checker_Prover_Base.frame)
+                                         (Pulse_Checker_Prover_Base.op_Array_Access
+                                            pst.Pulse_Checker_Prover_Base.ss
+                                            pst.Pulse_Checker_Prover_Base.solved))
+                                      pst.Pulse_Checker_Prover_Base.k
+                                      (Pulse_Checker_Base.k_elab_equiv
+                                         pst.Pulse_Checker_Prover_Base.pg g'
+                                         (Pulse_Checker_Prover_Base.op_Star
+                                            (Pulse_Syntax_Pure.list_as_vprop
+                                               pst.Pulse_Checker_Prover_Base.remaining_ctxt)
+                                            (Pulse_Checker_Prover_Base.op_Star
+                                               preamble.Pulse_Checker_Prover_Base.frame
+                                               (Pulse_Checker_Prover_Base.op_Array_Access
+                                                  pst.Pulse_Checker_Prover_Base.ss
+                                                  pst.Pulse_Checker_Prover_Base.solved)))
+                                         (Pulse_Checker_Prover_Base.op_Star
+                                            (Pulse_Checker_Prover_Base.op_Star
+                                               (Pulse_Syntax_Pure.list_as_vprop
+                                                  pst.Pulse_Checker_Prover_Base.remaining_ctxt)
+                                               preamble.Pulse_Checker_Prover_Base.frame)
+                                            (Pulse_Checker_Prover_Base.op_Array_Access
+                                               pst.Pulse_Checker_Prover_Base.ss
+                                               pst.Pulse_Checker_Prover_Base.solved))
+                                         (Pulse_Checker_Prover_Base.op_Star
+                                            remaining_ctxt'
+                                            (Pulse_Checker_Prover_Base.op_Star
+                                               preamble.Pulse_Checker_Prover_Base.frame
+                                               (Pulse_Checker_Prover_Base.op_Array_Access
+                                                  pst.Pulse_Checker_Prover_Base.ss
+                                                  pst.Pulse_Checker_Prover_Base.solved)))
+                                         (Pulse_Checker_Prover_Base.op_Star
+                                            (Pulse_Checker_Prover_Base.op_Star
+                                               remaining_ctxt'
+                                               preamble.Pulse_Checker_Prover_Base.frame)
+                                            (Pulse_Checker_Prover_Base.op_Array_Access
+                                               pst.Pulse_Checker_Prover_Base.ss
+                                               pst.Pulse_Checker_Prover_Base.solved))
+                                         k () ()));
+                                 Pulse_Checker_Prover_Base.goals_inv = ();
+                                 Pulse_Checker_Prover_Base.solved_inv = ();
+                                 Pulse_Checker_Prover_Base.progress = prog;
+                                 Pulse_Checker_Prover_Base.allow_ambiguous =
+                                   (pst.Pulse_Checker_Prover_Base.allow_ambiguous)
+                               })))) uu___)

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_Explode.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_Explode.ml
@@ -60,102 +60,87 @@ let (explode1 :
 let rec (explode_aux :
   Pulse_Checker_Prover_Base.preamble ->
     unit Pulse_Checker_Prover_Base.prover_state ->
-      Pulse_Syntax_Base.vprop Prims.list ->
+      Prims.bool ->
         Pulse_Syntax_Base.vprop Prims.list ->
-          (Pulse_Syntax_Base.vprop Prims.list, unit)
-            FStar_Tactics_Effect.tac_repr)
+          Pulse_Syntax_Base.vprop Prims.list ->
+            ((Pulse_Syntax_Base.vprop Prims.list * Prims.bool), unit)
+              FStar_Tactics_Effect.tac_repr)
   =
-  fun uu___3 ->
-    fun uu___2 ->
-      fun uu___1 ->
-        fun uu___ ->
-          (fun preamble ->
-             fun pst ->
-               fun acc ->
-                 fun todo ->
-                   match todo with
-                   | [] ->
-                       Obj.magic
-                         (Obj.repr
-                            (FStar_Tactics_Effect.lift_div_tac
-                               (fun uu___ -> acc)))
-                   | q::qs ->
-                       Obj.magic
-                         (Obj.repr
-                            (FStar_Tactics_Effect.tac_bind
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "Pulse.Checker.Prover.Explode.fst"
-                                        (Prims.of_int (76))
-                                        (Prims.of_int (14))
-                                        (Prims.of_int (76))
-                                        (Prims.of_int (84)))))
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "Pulse.Checker.Prover.Explode.fst"
-                                        (Prims.of_int (77))
-                                        (Prims.of_int (4))
-                                        (Prims.of_int (77))
-                                        (Prims.of_int (26)))))
-                               (Obj.magic
-                                  (FStar_Tactics_Effect.tac_bind
-                                     (FStar_Sealed.seal
-                                        (Obj.magic
-                                           (FStar_Range.mk_range
-                                              "Pulse.Checker.Prover.Explode.fst"
-                                              (Prims.of_int (76))
-                                              (Prims.of_int (20))
-                                              (Prims.of_int (76))
-                                              (Prims.of_int (84)))))
-                                     (FStar_Sealed.seal
-                                        (Obj.magic
-                                           (FStar_Range.mk_range
-                                              "Pulse.Checker.Prover.Explode.fst"
-                                              (Prims.of_int (76))
-                                              (Prims.of_int (14))
-                                              (Prims.of_int (76))
-                                              (Prims.of_int (84)))))
-                                     (Obj.magic
-                                        (FStar_Tactics_Effect.tac_bind
-                                           (FStar_Sealed.seal
-                                              (Obj.magic
-                                                 (FStar_Range.mk_range
-                                                    "Pulse.Checker.Prover.Explode.fst"
-                                                    (Prims.of_int (76))
-                                                    (Prims.of_int (27))
-                                                    (Prims.of_int (76))
-                                                    (Prims.of_int (41)))))
-                                           (FStar_Sealed.seal
-                                              (Obj.magic
-                                                 (FStar_Range.mk_range
-                                                    "Pulse.Checker.Prover.Explode.fst"
-                                                    (Prims.of_int (76))
-                                                    (Prims.of_int (20))
-                                                    (Prims.of_int (76))
-                                                    (Prims.of_int (84)))))
-                                           (Obj.magic
-                                              (explode1 preamble pst q))
-                                           (fun uu___ ->
-                                              FStar_Tactics_Effect.lift_div_tac
-                                                (fun uu___1 ->
-                                                   match uu___ with
-                                                   | FStar_Pervasives_Native.Some
-                                                       (Prims.Mkdtuple2
-                                                       (qs1, uu___2)) -> qs1
-                                                   | FStar_Pervasives_Native.None
-                                                       -> [q]))))
-                                     (fun uu___ ->
-                                        FStar_Tactics_Effect.lift_div_tac
-                                          (fun uu___1 ->
-                                             FStar_List_Tot_Base.append acc
-                                               uu___))))
-                               (fun uu___ ->
-                                  (fun acc1 ->
-                                     Obj.magic
-                                       (explode_aux preamble pst acc1 qs))
-                                    uu___)))) uu___3 uu___2 uu___1 uu___
+  fun uu___4 ->
+    fun uu___3 ->
+      fun uu___2 ->
+        fun uu___1 ->
+          fun uu___ ->
+            (fun preamble ->
+               fun pst ->
+                 fun prog ->
+                   fun acc ->
+                     fun todo ->
+                       match todo with
+                       | [] ->
+                           Obj.magic
+                             (Obj.repr
+                                (FStar_Tactics_Effect.lift_div_tac
+                                   (fun uu___ -> (acc, prog))))
+                       | q::qs ->
+                           Obj.magic
+                             (Obj.repr
+                                (FStar_Tactics_Effect.tac_bind
+                                   (FStar_Sealed.seal
+                                      (Obj.magic
+                                         (FStar_Range.mk_range
+                                            "Pulse.Checker.Prover.Explode.fst"
+                                            (Prims.of_int (78))
+                                            (Prims.of_int (6))
+                                            (Prims.of_int (80))
+                                            (Prims.of_int (26)))))
+                                   (FStar_Sealed.seal
+                                      (Obj.magic
+                                         (FStar_Range.mk_range
+                                            "Pulse.Checker.Prover.Explode.fst"
+                                            (Prims.of_int (76))
+                                            (Prims.of_int (12))
+                                            (Prims.of_int (82))
+                                            (Prims.of_int (51)))))
+                                   (Obj.magic
+                                      (FStar_Tactics_Effect.tac_bind
+                                         (FStar_Sealed.seal
+                                            (Obj.magic
+                                               (FStar_Range.mk_range
+                                                  "Pulse.Checker.Prover.Explode.fst"
+                                                  (Prims.of_int (78))
+                                                  (Prims.of_int (12))
+                                                  (Prims.of_int (78))
+                                                  (Prims.of_int (26)))))
+                                         (FStar_Sealed.seal
+                                            (Obj.magic
+                                               (FStar_Range.mk_range
+                                                  "Pulse.Checker.Prover.Explode.fst"
+                                                  (Prims.of_int (78))
+                                                  (Prims.of_int (6))
+                                                  (Prims.of_int (80))
+                                                  (Prims.of_int (26)))))
+                                         (Obj.magic (explode1 preamble pst q))
+                                         (fun uu___ ->
+                                            FStar_Tactics_Effect.lift_div_tac
+                                              (fun uu___1 ->
+                                                 match uu___ with
+                                                 | FStar_Pervasives_Native.Some
+                                                     (Prims.Mkdtuple2
+                                                     (qs1, uu___2)) ->
+                                                     (qs1, true)
+                                                 | FStar_Pervasives_Native.None
+                                                     -> ([q], false)))))
+                                   (fun uu___ ->
+                                      (fun uu___ ->
+                                         match uu___ with
+                                         | (acc', prog') ->
+                                             Obj.magic
+                                               (explode_aux preamble pst
+                                                  (prog || prog')
+                                                  (FStar_List_Tot_Base.append
+                                                     acc acc') qs)) uu___))))
+              uu___4 uu___3 uu___2 uu___1 uu___
 let (explode :
   Pulse_Checker_Prover_Base.preamble ->
     unit Pulse_Checker_Prover_Base.prover_state ->
@@ -168,60 +153,67 @@ let (explode :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Prover.Explode.fst"
-                 (Prims.of_int (83)) (Prims.of_int (23)) (Prims.of_int (83))
-                 (Prims.of_int (60)))))
+                 (Prims.of_int (88)) (Prims.of_int (27)) (Prims.of_int (88))
+                 (Prims.of_int (70)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Prover.Explode.fst"
-                 (Prims.of_int (83)) (Prims.of_int (63)) (Prims.of_int (91))
+                 (Prims.of_int (87)) Prims.int_one (Prims.of_int (97))
                  (Prims.of_int (3)))))
         (Obj.magic
-           (explode_aux preamble pst []
+           (explode_aux preamble pst false []
               pst.Pulse_Checker_Prover_Base.remaining_ctxt))
         (fun uu___ ->
-           (fun remaining_ctxt ->
-              Obj.magic
-                (FStar_Tactics_Effect.tac_bind
-                   (FStar_Sealed.seal
-                      (Obj.magic
-                         (FStar_Range.mk_range
-                            "Pulse.Checker.Prover.Explode.fst"
-                            (Prims.of_int (84)) (Prims.of_int (18))
-                            (Prims.of_int (84)) (Prims.of_int (49)))))
-                   (FStar_Sealed.seal
-                      (Obj.magic
-                         (FStar_Range.mk_range
-                            "Pulse.Checker.Prover.Explode.fst"
-                            (Prims.of_int (85)) (Prims.of_int (4))
-                            (Prims.of_int (90)) (Prims.of_int (25)))))
-                   (Obj.magic
-                      (explode_aux preamble pst []
-                         pst.Pulse_Checker_Prover_Base.unsolved))
-                   (fun unsolved' ->
-                      FStar_Tactics_Effect.lift_div_tac
-                        (fun uu___ ->
-                           {
-                             Pulse_Checker_Prover_Base.pg =
-                               (pst.Pulse_Checker_Prover_Base.pg);
-                             Pulse_Checker_Prover_Base.remaining_ctxt =
-                               remaining_ctxt;
-                             Pulse_Checker_Prover_Base.remaining_ctxt_frame_typing
-                               = ();
-                             Pulse_Checker_Prover_Base.uvs =
-                               (pst.Pulse_Checker_Prover_Base.uvs);
-                             Pulse_Checker_Prover_Base.ss =
-                               (pst.Pulse_Checker_Prover_Base.ss);
-                             Pulse_Checker_Prover_Base.nts =
-                               (pst.Pulse_Checker_Prover_Base.nts);
-                             Pulse_Checker_Prover_Base.solved =
-                               (pst.Pulse_Checker_Prover_Base.solved);
-                             Pulse_Checker_Prover_Base.unsolved = unsolved';
-                             Pulse_Checker_Prover_Base.k =
-                               (pst.Pulse_Checker_Prover_Base.k);
-                             Pulse_Checker_Prover_Base.goals_inv = ();
-                             Pulse_Checker_Prover_Base.solved_inv = ();
-                             Pulse_Checker_Prover_Base.progress =
-                               (pst.Pulse_Checker_Prover_Base.progress);
-                             Pulse_Checker_Prover_Base.allow_ambiguous =
-                               (pst.Pulse_Checker_Prover_Base.allow_ambiguous)
-                           })))) uu___)
+           (fun uu___ ->
+              match uu___ with
+              | (remaining_ctxt, p1) ->
+                  Obj.magic
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range
+                                "Pulse.Checker.Prover.Explode.fst"
+                                (Prims.of_int (89)) (Prims.of_int (22))
+                                (Prims.of_int (89)) (Prims.of_int (59)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range
+                                "Pulse.Checker.Prover.Explode.fst"
+                                (Prims.of_int (88)) (Prims.of_int (73))
+                                (Prims.of_int (97)) (Prims.of_int (3)))))
+                       (Obj.magic
+                          (explode_aux preamble pst false []
+                             pst.Pulse_Checker_Prover_Base.unsolved))
+                       (fun uu___1 ->
+                          FStar_Tactics_Effect.lift_div_tac
+                            (fun uu___2 ->
+                               match uu___1 with
+                               | (unsolved', p2) ->
+                                   {
+                                     Pulse_Checker_Prover_Base.pg =
+                                       (pst.Pulse_Checker_Prover_Base.pg);
+                                     Pulse_Checker_Prover_Base.remaining_ctxt
+                                       = remaining_ctxt;
+                                     Pulse_Checker_Prover_Base.remaining_ctxt_frame_typing
+                                       = ();
+                                     Pulse_Checker_Prover_Base.uvs =
+                                       (pst.Pulse_Checker_Prover_Base.uvs);
+                                     Pulse_Checker_Prover_Base.ss =
+                                       (pst.Pulse_Checker_Prover_Base.ss);
+                                     Pulse_Checker_Prover_Base.nts =
+                                       (pst.Pulse_Checker_Prover_Base.nts);
+                                     Pulse_Checker_Prover_Base.solved =
+                                       (pst.Pulse_Checker_Prover_Base.solved);
+                                     Pulse_Checker_Prover_Base.unsolved =
+                                       unsolved';
+                                     Pulse_Checker_Prover_Base.k =
+                                       (pst.Pulse_Checker_Prover_Base.k);
+                                     Pulse_Checker_Prover_Base.goals_inv = ();
+                                     Pulse_Checker_Prover_Base.solved_inv =
+                                       ();
+                                     Pulse_Checker_Prover_Base.progress =
+                                       (p1 || p2);
+                                     Pulse_Checker_Prover_Base.allow_ambiguous
+                                       =
+                                       (pst.Pulse_Checker_Prover_Base.allow_ambiguous)
+                                   })))) uu___)


### PR DESCRIPTION
Now all passes are just registered into a list, which makes it easy to extend them.
```fstar
  res_advance <| prover_iteration_loop pst [
    // P "elim_pure_pst"     ElimPure.elim_pure_pst;
    P "elim_exists"       ElimExists.elim_exists_pst;
    P "collect_exists"    prover_pass_collect_exists;
    P "explode"           Explode.explode;
    P "match_syntactic"   Match.match_syntactic;
    P "match_fastunif"    Match.match_fastunif;
    P "match_fastunif_i"  Match.match_fastunif_i;
    P "match_full"        Match.match_full;
  ]
```