### PR TITLE
Extraction nits

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -71,8 +71,7 @@ boot:
 	+$(MAKE) build
 
 .PHONY: boot-checker
-boot-checker:
-	+$(MAKE) extract-syntax-extension extract-checker
+boot-checker: extract-ocaml
 	+$(MAKE) build-ocaml
 
 .PHONY: clean-snapshot

--- a/src/extraction/Extraction.fst.config.json
+++ b/src/extraction/Extraction.fst.config.json
@@ -11,6 +11,7 @@
     ".",
     "${FSTAR_HOME}/src/basic",
     "${FSTAR_HOME}/src/class",
+    "${FSTAR_HOME}/src/data",
     "${FSTAR_HOME}/src/extraction",
     "${FSTAR_HOME}/src/fstar",
     "${FSTAR_HOME}/src/parser",


### PR DESCRIPTION
- Fix `make boot-checker` rule to also bootstrap extraction
- Fix config.json file (was missing src/data from F*)