### PR TITLE
ExtractPulse.fst: support read/write for Box

### DIFF
--- a/src/extraction/ExtractPulse.fst
+++ b/src/extraction/ExtractPulse.fst
@@ -25,7 +25,8 @@ let pulse_translate_type_without_decay : translate_type_without_decay_t = fun en
     (let p = Syntax.string_of_mlpath p in
      p = "Pulse.Lib.Reference.ref" ||
      p = "Pulse.Lib.Array.Core.array" ||
-     p = "Pulse.Lib.Vec.vec")
+     p = "Pulse.Lib.Vec.vec" ||
+     p = "Pulse.Lib.Box.box")
     ->
       TBuf (translate_type_without_decay env arg)
 
@@ -75,12 +76,14 @@ let pulse_translate_expr : translate_expr_t = fun env e ->
 
   | MLE_App({expr=MLE_App({expr=MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ e ])}, [_v])}, [_perm])
   | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ e; _v; _perm ])
-    when string_of_mlpath p = "Pulse.Lib.Reference.op_Bang" ->
+    when string_of_mlpath p = "Pulse.Lib.Reference.op_Bang"
+      || string_of_mlpath p = "Pulse.Lib.Box.op_Bang" ->
     EBufRead (translate_expr env e, EQualified (["C"], "_zero_for_deref"))
 
   | MLE_App ({expr=MLE_App({expr=MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ e1 ])}, [e2])}, [_e3])
   | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ e1; e2; _e3 ])
-    when string_of_mlpath p = "Pulse.Lib.Reference.op_Colon_Equals" ->
+    when string_of_mlpath p = "Pulse.Lib.Reference.op_Colon_Equals"
+      || string_of_mlpath p = "Pulse.Lib.Box.op_Colon_Equals" ->
     EBufWrite (translate_expr env e1, EQualified (["C"], "_zero_for_deref"), translate_expr env e2)
 
   (* Pulse arrays *)

--- a/src/ocaml/plugin/generated/ExtractPulse.ml
+++ b/src/ocaml/plugin/generated/ExtractPulse.ml
@@ -6,9 +6,10 @@ let (pulse_translate_type_without_decay :
       match t with
       | FStar_Extraction_ML_Syntax.MLTY_Named (arg::[], p) when
           let p1 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          ((p1 = "Pulse.Lib.Reference.ref") ||
-             (p1 = "Pulse.Lib.Array.Core.array"))
-            || (p1 = "Pulse.Lib.Vec.vec")
+          (((p1 = "Pulse.Lib.Reference.ref") ||
+              (p1 = "Pulse.Lib.Array.Core.array"))
+             || (p1 = "Pulse.Lib.Vec.vec"))
+            || (p1 = "Pulse.Lib.Box.box")
           ->
           let uu___ =
             FStar_Extraction_Krml.translate_type_without_decay env arg in
@@ -173,8 +174,11 @@ let (pulse_translate_expr : FStar_Extraction_Krml.translate_expr_t) =
               FStar_Extraction_ML_Syntax.loc = uu___9;_},
             _perm::[])
            when
-           let uu___10 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu___10 = "Pulse.Lib.Reference.op_Bang" ->
+           (let uu___10 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+            uu___10 = "Pulse.Lib.Reference.op_Bang") ||
+             (let uu___10 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___10 = "Pulse.Lib.Box.op_Bang")
+           ->
            let uu___10 =
              let uu___11 = FStar_Extraction_Krml.translate_expr env e2 in
              (uu___11,
@@ -194,8 +198,11 @@ let (pulse_translate_expr : FStar_Extraction_Krml.translate_expr_t) =
               FStar_Extraction_ML_Syntax.loc = uu___5;_},
             e2::_v::_perm::[])
            when
-           let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu___6 = "Pulse.Lib.Reference.op_Bang" ->
+           (let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+            uu___6 = "Pulse.Lib.Reference.op_Bang") ||
+             (let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___6 = "Pulse.Lib.Box.op_Bang")
+           ->
            let uu___6 =
              let uu___7 = FStar_Extraction_Krml.translate_expr env e2 in
              (uu___7,
@@ -227,8 +234,11 @@ let (pulse_translate_expr : FStar_Extraction_Krml.translate_expr_t) =
               FStar_Extraction_ML_Syntax.loc = uu___9;_},
             _e3::[])
            when
-           let uu___10 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu___10 = "Pulse.Lib.Reference.op_Colon_Equals" ->
+           (let uu___10 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+            uu___10 = "Pulse.Lib.Reference.op_Colon_Equals") ||
+             (let uu___10 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___10 = "Pulse.Lib.Box.op_Colon_Equals")
+           ->
            let uu___10 =
              let uu___11 = FStar_Extraction_Krml.translate_expr env e11 in
              let uu___12 = FStar_Extraction_Krml.translate_expr env e2 in
@@ -250,8 +260,11 @@ let (pulse_translate_expr : FStar_Extraction_Krml.translate_expr_t) =
               FStar_Extraction_ML_Syntax.loc = uu___5;_},
             e11::e2::_e3::[])
            when
-           let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-           uu___6 = "Pulse.Lib.Reference.op_Colon_Equals" ->
+           (let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+            uu___6 = "Pulse.Lib.Reference.op_Colon_Equals") ||
+             (let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___6 = "Pulse.Lib.Box.op_Colon_Equals")
+           ->
            let uu___6 =
              let uu___7 = FStar_Extraction_Krml.translate_expr env e11 in
              let uu___8 = FStar_Extraction_Krml.translate_expr env e2 in


### PR DESCRIPTION
I noticed `(!)` and `(:=)` fail to extract for Box. I think the idea is turn them into references and use the reference ops, but these are still there and usable in the module. If they are, they should probably extract like this?

Or, we can remove them too.