### PR TITLE
Fix ensures annotations on with_invariants

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.CancellableInvariant.fst
+++ b/lib/pulse/lib/Pulse.Lib.CancellableInvariant.fst
@@ -161,7 +161,7 @@ fn cancel (#v:slprop) (c:cinv)
 {
   with_invariants (iname_of c)
     returns _:unit
-    ensures inv (iname_of c) (cinv_vp c v) ** v
+    ensures cinv_vp c v ** v
     opens [iname_of c] {
     cancel_ c
   };

--- a/lib/pulse/lib/Pulse.Lib.ConditionVarWithCodes.fst
+++ b/lib/pulse/lib/Pulse.Lib.ConditionVarWithCodes.fst
@@ -313,7 +313,7 @@ ensures emp
   unfold cvar;
   with_invariants b.i 
   returns u:unit
-  ensures inv b.i (cvar_inv b.core p) ** emp
+  ensures cvar_inv b.core p ** emp
   {
     unfold cvar_inv;
     Box.gather b.core.r;
@@ -520,7 +520,7 @@ ensures q
   let res : bool =
     with_invariants b.i
     returns res:bool
-    ensures inv b.i (cvar_inv b.core pp) **
+    ensures cvar_inv b.core pp **
             (cond res q (big_ghost_pcm_pts_to b.core.gref (singleton i #0.5R code)))
     {
       unfold cvar_inv;
@@ -758,7 +758,7 @@ opens [b.i]
   unfold cvar;
   with_invariants b.i
   returns u:unit
-  ensures inv b.i (cvar_inv b.core (reveal p)) **
+  ensures cvar_inv b.core (reveal p) **
          (exists* j k.
             big_ghost_pcm_pts_to b.core.gref (singleton j #0.5R cq.c) **
             big_ghost_pcm_pts_to b.core.gref (singleton k #0.5R cr.c))

--- a/lib/pulse/lib/Pulse.Lib.FlippableInv.fst
+++ b/lib/pulse/lib/Pulse.Lib.FlippableInv.fst
@@ -70,7 +70,7 @@ fn flip_on (#p:slprop) (fi:finv p)
   unfold off;
   with_invariants fi.i
     returns _:unit
-    ensures inv fi.i (finv_p p fi.r) **
+    ensures finv_p p fi.r **
             GR.pts_to fi.r #0.5R true
     opens [fi.i]
   {
@@ -97,7 +97,7 @@ fn flip_off (#p:slprop) (fi : finv p)
   unfold on;
   with_invariants fi.i
     returns _:unit
-    ensures inv fi.i (finv_p p fi.r) **
+    ensures finv_p p fi.r **
             GR.pts_to fi.r #0.5R false ** p
     opens [fi.i]
   {

--- a/lib/pulse/lib/Pulse.Lib.SpinLock.fst
+++ b/lib/pulse/lib/Pulse.Lib.SpinLock.fst
@@ -80,7 +80,7 @@ fn rec acquire (#v:slprop) (#p:perm) (l:lock)
   let b =
     with_invariants (CInv.iname_of l.i)
       returns b:bool
-      ensures inv (CInv.iname_of l.i) (cinv_vp l.i (lock_inv l.r l.gr v)) **
+      ensures cinv_vp l.i (lock_inv l.r l.gr v) **
               active l.i p **
               (if b then v ** GR.pts_to l.gr #0.5R 1ul else emp) {
       unpack_cinv_vp l.i;
@@ -142,7 +142,7 @@ fn release (#v:slprop) (#p:perm) (l:lock)
 
   with_invariants (CInv.iname_of l.i)
     returns _:unit
-    ensures inv (CInv.iname_of l.i) (cinv_vp l.i (lock_inv l.r l.gr v)) **
+    ensures cinv_vp l.i (lock_inv l.r l.gr v) **
             active l.i p {
     unpack_cinv_vp l.i;
     unfold (lock_inv l.r l.gr v);

--- a/lib/pulse/lib/Pulse.Lib.SpinLockToken.fst
+++ b/lib/pulse/lib/Pulse.Lib.SpinLockToken.fst
@@ -59,7 +59,7 @@ fn lock_alive (#v:slprop) (l:lock v)
   T.recall l.t2;
   with_invariants l.i
     returns _:unit
-    ensures inv l.i (exists* (p:perm). L.lock_active #p l.l) **
+    ensures (exists* (p:perm). L.lock_active #p l.l) **
             (exists* (p:perm). L.lock_active #p l.l) {
     L.share_lock_active l.l
   };

--- a/lib/pulse/lib/pledge/Pulse.Lib.InvList.fst
+++ b/lib/pulse/lib/pledge/Pulse.Lib.InvList.fst
@@ -96,7 +96,7 @@ fn rec with_invlist (#a:Type0) (#pre : slprop) (#post : a -> slprop)
       rewrite (invlist_inv is) as (inv (snd h) (fst h) ** invlist_inv t);
       let r = with_invariants (snd h)
         returns v:a
-        ensures inv (snd h) (fst h) ** invlist_inv t ** post v
+        ensures fst h ** invlist_inv t ** post v
         opens (invlist_names t @@ [snd h]) {
         let fw : (unit -> stt_ghost a emp_inames
                             (invlist_v t ** (fst h ** pre))

--- a/share/pulse/examples/Invariant.fst
+++ b/share/pulse/examples/Invariant.fst
@@ -100,7 +100,7 @@ fn test2 ()
   let i = new_invariant (exists* v. pts_to r v);
   with_invariants i
     returns _:unit
-    ensures inv i (exists* v. pts_to r v)
+    ensures (exists* v. pts_to r v)
     opens (add_inv emp_inames i) {
       atomic_write_int r 1;
   };
@@ -206,7 +206,7 @@ fn t2 ()
   let j = new_invariant emp;
   with_invariants j 
     returns _:unit
-    ensures inv j emp {
+    ensures emp {
     ()
   };
   drop_ (inv j _);
@@ -229,7 +229,7 @@ fn test_returns0 (i:iname) (b:bool)
   unfold folded_inv i;
   with_invariants i
     returns _:unit
-    ensures inv i p ** q {
+    ensures p ** q {
     if b {
       p_to_q ()
     } else {
@@ -250,7 +250,7 @@ fn test_returns1 (i:iname)
   unfold folded_inv i;
   with_invariants i
     returns _:unit
-    ensures inv i p ** q {
+    ensures p ** q {
     ghost_p_to_q ()
   };
   fold folded_inv i

--- a/share/pulse/examples/PulseCorePaper.S2.Lock.fst
+++ b/share/pulse/examples/PulseCorePaper.S2.Lock.fst
@@ -53,7 +53,7 @@ ensures protects l p
   with_invariants l.i
     //requires inv l.i (lock_inv l.r p) ** p  //we be nice to add this optionally
     returns _ : unit //would be nice to avoid this
-    ensures inv l.i (lock_inv l.r p)
+    ensures lock_inv l.r p
     opens (add_inv emp_inames l.i) //would be nice to have better syntax for sets
   { 
     unfold lock_inv; drop_ (maybe _ _);
@@ -73,7 +73,7 @@ ensures protects l p ** p
   unfold protects;
   let b = with_invariants l.i
     returns b:bool //can we avoid annotating this?
-    ensures inv l.i (lock_inv l.r p) ** maybe b p //and this?
+    ensures lock_inv l.r p ** maybe b p //and this?
   { unfold lock_inv;
     let b = cas_box l.r 0ul 1ul;
     if b {

--- a/share/pulse/examples/bug-reports/Bug.Invariants.fst
+++ b/share/pulse/examples/bug-reports/Bug.Invariants.fst
@@ -128,7 +128,7 @@ ensures inv i (pts_to x 0ul) ** pts_to y 0ul
     let n = 
         with_invariants i
         returns r:U32.t
-        ensures inv i (pts_to x 0ul) ** pure (r == 0ul) ** pts_to y 'w
+        ensures pts_to x 0ul ** pure (r == 0ul) ** pts_to y 'w
         opens (add_inv emp_inames i) {
             read_atomic x
         };

--- a/share/pulse/examples/by-example/ParallelIncrement.fst
+++ b/share/pulse/examples/by-example/ParallelIncrement.fst
@@ -332,7 +332,7 @@ ensures inv l invp ** qpred ('i + 1)
     let next = 
       with_invariants l
       returns b1:bool
-      ensures inv l invp 
+      ensures invp 
           ** cond b1 (qpred 'i) (qpred ('i + 1))
           ** pts_to continue true
       {

--- a/share/pulse/examples/by-example/PulseTutorial.ParallelIncrement.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.ParallelIncrement.fst
@@ -356,7 +356,7 @@ ensures inv (C.iname_of c) (C.cinv_vp c (exists* v. pts_to x v ** refine v)) ** 
     let next = 
       with_invariants (C.iname_of c)
       returns b1:bool
-      ensures inv (C.iname_of c) (C.cinv_vp c (exists* v. pts_to x v ** refine v))
+      ensures C.cinv_vp c (exists* v. pts_to x v ** refine v)
           ** cond b1 (aspec 'i) (aspec ('i + 1))
           ** pts_to continue true
           ** C.active c p

--- a/share/pulse/examples/by-example/PulseTutorial.SpinLock.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.SpinLock.fst
@@ -82,7 +82,7 @@ ensures lock_alive l p ** p
   let b = 
     with_invariants l.i
       returns b:bool
-      ensures inv l.i (lock_inv l.r p) ** maybe b p
+      ensures lock_inv l.r p ** maybe b p
       opens (add_inv emp_inames l.i) {
       unfold lock_inv;
       let b = cas_box l.r 0ul 1ul;
@@ -118,7 +118,7 @@ ensures lock_alive l p
   unfold lock_alive;
   with_invariants l.i
     returns _:unit
-    ensures inv l.i (lock_inv l.r p)
+    ensures lock_inv l.r p
     opens (add_inv emp_inames l.i) {
     unfold lock_inv;
     write_atomic_box l.r 0ul;

--- a/src/checker/Pulse.Checker.Base.fsti
+++ b/src/checker/Pulse.Checker.Base.fsti
@@ -61,7 +61,10 @@ val intro_post_hint
   (effect_annot:effect_annot)
   (ret_ty:option term)
   (post:term)
-  : T.Tac (h:post_hint_for_env g {effect_annot_labels_match h.effect_annot effect_annot})
+  : T.Tac (h:post_hint_for_env g {
+      h.g == g /\
+      effect_annot_labels_match h.effect_annot effect_annot
+    })
 
 val post_hint_from_comp_typing (#g:env) (#c:comp_st) (ct:comp_typing_u g c)
   : post_hint_for_env g

--- a/src/ocaml/plugin/generated/Pulse_Checker_WithInv.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_WithInv.ml
@@ -661,17 +661,17 @@ let rec (withinv_post :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.WithInv.fst"
-                                                         (Prims.of_int (209))
+                                                         (Prims.of_int (213))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (209))
+                                                         (Prims.of_int (213))
                                                          (Prims.of_int (72)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.WithInv.fst"
-                                                         (Prims.of_int (211))
+                                                         (Prims.of_int (215))
                                                          (Prims.of_int (11))
-                                                         (Prims.of_int (219))
+                                                         (Prims.of_int (223))
                                                          (Prims.of_int (16)))))
                                                 (Obj.magic
                                                    (withinv_post g p i l ()
@@ -701,17 +701,17 @@ let rec (withinv_post :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (219))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (219))
                                                                     (Prims.of_int (78)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (216))
+                                                                    (Prims.of_int (220))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (218))
+                                                                    (Prims.of_int (222))
                                                                     (Prims.of_int (29)))))
                                                                   (Obj.magic
                                                                     (withinv_post
@@ -768,13 +768,13 @@ let (check :
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.WithInv.fst"
-                           (Prims.of_int (234)) (Prims.of_int (47))
-                           (Prims.of_int (234)) (Prims.of_int (53)))))
+                           (Prims.of_int (238)) (Prims.of_int (47))
+                           (Prims.of_int (238)) (Prims.of_int (53)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.WithInv.fst"
-                           (Prims.of_int (234)) Prims.int_one
-                           (Prims.of_int (460)) (Prims.of_int (57)))))
+                           (Prims.of_int (238)) Prims.int_one
+                           (Prims.of_int (466)) (Prims.of_int (57)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ -> t.Pulse_Syntax_Base.term1))
                   (fun uu___ ->
@@ -791,17 +791,17 @@ let (check :
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Checker.WithInv.fst"
-                                          (Prims.of_int (235))
+                                          (Prims.of_int (239))
                                           (Prims.of_int (19))
-                                          (Prims.of_int (235))
+                                          (Prims.of_int (239))
                                           (Prims.of_int (46)))))
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Checker.WithInv.fst"
-                                          (Prims.of_int (234))
+                                          (Prims.of_int (238))
                                           (Prims.of_int (56))
-                                          (Prims.of_int (460))
+                                          (Prims.of_int (466))
                                           (Prims.of_int (57)))))
                                  (Obj.magic
                                     (Pulse_Checker_Pure.check_tot_term g i
@@ -816,17 +816,17 @@ let (check :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.WithInv.fst"
-                                                         (Prims.of_int (236))
+                                                         (Prims.of_int (240))
                                                          (Prims.of_int (16))
-                                                         (Prims.of_int (236))
+                                                         (Prims.of_int (240))
                                                          (Prims.of_int (50)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.WithInv.fst"
-                                                         (Prims.of_int (236))
+                                                         (Prims.of_int (240))
                                                          (Prims.of_int (53))
-                                                         (Prims.of_int (460))
+                                                         (Prims.of_int (466))
                                                          (Prims.of_int (57)))))
                                                 (FStar_Tactics_Effect.lift_div_tac
                                                    (fun uu___3 ->
@@ -840,17 +840,17 @@ let (check :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (33)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                            (Obj.magic
                                                               (find_inv g pre
@@ -863,17 +863,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (238))
-                                                                    (Prims.of_int (2))
                                                                     (Prims.of_int (242))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (if
                                                                     FStar_Pervasives_Native.uu___is_None
@@ -886,17 +886,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (239))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (239))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -904,17 +904,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (239))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -922,17 +922,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -940,17 +940,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (70))
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (76)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -977,17 +977,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -995,17 +995,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1065,17 +1065,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (72)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1102,17 +1102,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (67)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (299))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (match 
                                                                     (returns_inv,
@@ -1141,18 +1141,18 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (263))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (12)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (265))
-                                                                    (Prims.of_int (49))
-                                                                    (Prims.of_int (284))
-                                                                    (Prims.of_int (36)))))
+                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (11))
+                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (100)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.intro_post_hint
                                                                     g
@@ -1175,26 +1175,51 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (266))
+                                                                    (Prims.of_int (269))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (271))
-                                                                    (Prims.of_int (20)))))
+                                                                    (Prims.of_int (269))
+                                                                    (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (273))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (284))
-                                                                    (Prims.of_int (36)))))
-                                                                    (Obj.magic
-                                                                    (withinv_post
-                                                                    (Pulse_Typing_Env.push_binding
+                                                                    (Prims.of_int (269))
+                                                                    (Prims.of_int (79))
+                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (100)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    Pulse_Typing_Env.push_binding
                                                                     g
                                                                     post_hint1.Pulse_Typing.x
                                                                     Pulse_Syntax_Base.ppname_default
-                                                                    post_hint1.Pulse_Typing.ret_ty)
-                                                                    p i1
+                                                                    post_hint1.Pulse_Typing.ret_ty))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    (fun g_x
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (270))
+                                                                    (Prims.of_int (18))
+                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (35)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (100)))))
+                                                                    (Obj.magic
+                                                                    (withinv_post
+                                                                    g_x p i1
                                                                     (Pulse_Syntax_Naming.open_term_nv
                                                                     post_hint1.Pulse_Typing.post
                                                                     (Pulse_Syntax_Base.v_as_nv
@@ -1216,17 +1241,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (280))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (282))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (282))
                                                                     (Prims.of_int (24)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1234,9 +1259,9 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (282))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (282))
                                                                     (Prims.of_int (23)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1276,13 +1301,13 @@ let (check :
                                                                     FStar_Pervasives_Native.Some
                                                                     (Prims.Mkdtuple2
                                                                     (post',
-                                                                    uu___6))
+                                                                    post'_typing))
                                                                     ->
                                                                     Obj.magic
                                                                     (Obj.repr
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___7 ->
+                                                                    uu___6 ->
                                                                     {
                                                                     Pulse_Typing.g
                                                                     =
@@ -1302,7 +1327,10 @@ let (check :
                                                                     Pulse_Typing.ty_typing
                                                                     = ();
                                                                     Pulse_Typing.post
-                                                                    = post';
+                                                                    =
+                                                                    (Pulse_Syntax_Naming.close_term
+                                                                    post'
+                                                                    post_hint1.Pulse_Typing.x);
                                                                     Pulse_Typing.x
                                                                     =
                                                                     (post_hint1.Pulse_Typing.x);
@@ -1311,6 +1339,7 @@ let (check :
                                                                     Pulse_Typing.post_typing
                                                                     = ()
                                                                     }))))
+                                                                    uu___6)))
                                                                     uu___6)))
                                                                     uu___6)))
                                                                     | 
@@ -1327,17 +1356,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1345,17 +1374,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1363,17 +1392,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1381,17 +1410,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1418,17 +1447,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1436,17 +1465,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1454,17 +1483,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1538,17 +1567,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (302))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (302))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (302))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1565,17 +1594,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1594,17 +1623,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (305))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (305))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (305))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1621,17 +1650,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (313))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (313))
                                                                     (Prims.of_int (17)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (314))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1647,17 +1676,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (309))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (309))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (309))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (64))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1676,17 +1705,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (64))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (recheck
@@ -1706,17 +1735,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (recheck
@@ -1738,17 +1767,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (319))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (326))
+                                                                    (Prims.of_int (332))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (334))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (find_inv_post
@@ -1767,17 +1796,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (328))
+                                                                    (Prims.of_int (334))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (332))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (332))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (if
                                                                     FStar_Pervasives_Native.uu___is_None
@@ -1790,17 +1819,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (335))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (332))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (335))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (332))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1808,17 +1837,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (335))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (332))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1826,17 +1855,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (70)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1844,17 +1873,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (70))
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (76)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1881,17 +1910,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (70)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1899,17 +1928,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (70)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1969,17 +1998,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (76))
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (79)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (332))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2006,17 +2035,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (342))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (if
                                                                     Prims.op_Negation
@@ -2030,17 +2059,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (7))
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2048,17 +2077,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (Pulse_Show.show
@@ -2074,17 +2103,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2092,17 +2121,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (Pulse_Show.show
@@ -2120,17 +2149,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2138,9 +2167,9 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (20)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2223,17 +2252,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (347))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (347))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (347))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2254,17 +2283,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (345))
-                                                                    (Prims.of_int (6))
                                                                     (Prims.of_int (351))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (357))
                                                                     (Prims.of_int (73)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (347))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2325,17 +2354,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (358))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (358))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2354,17 +2383,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (353))
+                                                                    (Prims.of_int (359))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (353))
+                                                                    (Prims.of_int (359))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (353))
+                                                                    (Prims.of_int (359))
                                                                     (Prims.of_int (46))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2384,17 +2413,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (355))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (362))
+                                                                    (Prims.of_int (368))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (362))
+                                                                    (Prims.of_int (368))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2454,17 +2483,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (365))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (365))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (368))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (46))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2488,17 +2517,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (369))
+                                                                    (Prims.of_int (375))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (377))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (25)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (378))
+                                                                    (Prims.of_int (384))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2543,17 +2572,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (380))
+                                                                    (Prims.of_int (386))
                                                                     (Prims.of_int (39))
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (389))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (378))
+                                                                    (Prims.of_int (384))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2561,17 +2590,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (387))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (387))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (387))
                                                                     (Prims.of_int (54))
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (389))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2590,17 +2619,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (78)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (389))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (389))
                                                                     (Prims.of_int (35)))))
                                                                     (Obj.magic
                                                                     (check1 g
@@ -2642,17 +2671,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (390))
+                                                                    (Prims.of_int (396))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (393))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (18)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (393))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2676,17 +2705,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (395))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (395))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (395))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (disjointness_remove_i_i
@@ -2703,17 +2732,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (90)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (397))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (93))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2744,17 +2773,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (398))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (443))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (439))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2864,17 +2893,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (445))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (add_remove_inverse
@@ -2891,17 +2920,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (447))
-                                                                    (Prims.of_int (6))
                                                                     (Prims.of_int (453))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (459))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (445))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2956,17 +2985,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (453))
+                                                                    (Prims.of_int (459))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (453))
+                                                                    (Prims.of_int (459))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2985,17 +3014,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (455))
+                                                                    (Prims.of_int (461))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (455))
+                                                                    (Prims.of_int (461))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3035,17 +3064,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (445))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (add_remove_inverse
@@ -3062,17 +3091,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (447))
-                                                                    (Prims.of_int (6))
                                                                     (Prims.of_int (453))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (459))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (445))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3127,17 +3156,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (453))
+                                                                    (Prims.of_int (459))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (453))
+                                                                    (Prims.of_int (459))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3156,17 +3185,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (455))
+                                                                    (Prims.of_int (461))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (455))
+                                                                    (Prims.of_int (461))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3206,17 +3235,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (445))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (add_remove_inverse
@@ -3233,17 +3262,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (447))
-                                                                    (Prims.of_int (6))
                                                                     (Prims.of_int (453))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (459))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (445))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3298,17 +3327,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (453))
+                                                                    (Prims.of_int (459))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (453))
+                                                                    (Prims.of_int (459))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3327,17 +3356,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (455))
+                                                                    (Prims.of_int (461))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (455))
+                                                                    (Prims.of_int (461))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (456))
+                                                                    (Prims.of_int (462))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3376,17 +3405,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (459))
+                                                                    (Prims.of_int (465))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (459))
+                                                                    (Prims.of_int (465))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun

--- a/src/ocaml/plugin/generated/Pulse_Checker_WithInv.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_WithInv.ml
@@ -661,17 +661,17 @@ let rec (withinv_post :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.WithInv.fst"
-                                                         (Prims.of_int (203))
+                                                         (Prims.of_int (209))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (203))
+                                                         (Prims.of_int (209))
                                                          (Prims.of_int (72)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.WithInv.fst"
-                                                         (Prims.of_int (205))
+                                                         (Prims.of_int (211))
                                                          (Prims.of_int (11))
-                                                         (Prims.of_int (213))
+                                                         (Prims.of_int (219))
                                                          (Prims.of_int (16)))))
                                                 (Obj.magic
                                                    (withinv_post g p i l ()
@@ -701,17 +701,17 @@ let rec (withinv_post :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (215))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (215))
                                                                     (Prims.of_int (78)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (216))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (212))
+                                                                    (Prims.of_int (218))
                                                                     (Prims.of_int (29)))))
                                                                   (Obj.magic
                                                                     (withinv_post
@@ -768,13 +768,13 @@ let (check :
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.WithInv.fst"
-                           (Prims.of_int (228)) (Prims.of_int (47))
-                           (Prims.of_int (228)) (Prims.of_int (53)))))
+                           (Prims.of_int (234)) (Prims.of_int (47))
+                           (Prims.of_int (234)) (Prims.of_int (53)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.WithInv.fst"
-                           (Prims.of_int (228)) Prims.int_one
-                           (Prims.of_int (444)) (Prims.of_int (57)))))
+                           (Prims.of_int (234)) Prims.int_one
+                           (Prims.of_int (460)) (Prims.of_int (57)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ -> t.Pulse_Syntax_Base.term1))
                   (fun uu___ ->
@@ -791,17 +791,17 @@ let (check :
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Checker.WithInv.fst"
-                                          (Prims.of_int (229))
+                                          (Prims.of_int (235))
                                           (Prims.of_int (19))
-                                          (Prims.of_int (229))
+                                          (Prims.of_int (235))
                                           (Prims.of_int (46)))))
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Checker.WithInv.fst"
-                                          (Prims.of_int (228))
+                                          (Prims.of_int (234))
                                           (Prims.of_int (56))
-                                          (Prims.of_int (444))
+                                          (Prims.of_int (460))
                                           (Prims.of_int (57)))))
                                  (Obj.magic
                                     (Pulse_Checker_Pure.check_tot_term g i
@@ -816,17 +816,17 @@ let (check :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.WithInv.fst"
-                                                         (Prims.of_int (230))
+                                                         (Prims.of_int (236))
                                                          (Prims.of_int (16))
-                                                         (Prims.of_int (230))
+                                                         (Prims.of_int (236))
                                                          (Prims.of_int (50)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.WithInv.fst"
-                                                         (Prims.of_int (230))
+                                                         (Prims.of_int (236))
                                                          (Prims.of_int (53))
-                                                         (Prims.of_int (444))
+                                                         (Prims.of_int (460))
                                                          (Prims.of_int (57)))))
                                                 (FStar_Tactics_Effect.lift_div_tac
                                                    (fun uu___3 ->
@@ -840,17 +840,17 @@ let (check :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (237))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (237))
                                                                     (Prims.of_int (33)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                            (Obj.magic
                                                               (find_inv g pre
@@ -863,17 +863,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (if
                                                                     FStar_Pervasives_Native.uu___is_None
@@ -886,17 +886,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -904,17 +904,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (239))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -922,17 +922,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -940,17 +940,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (70))
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (76)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -977,17 +977,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -995,17 +995,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1065,17 +1065,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (72)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1102,17 +1102,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (292))
                                                                     (Prims.of_int (67)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (match 
                                                                     (returns_inv,
@@ -1141,17 +1141,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (260))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (12)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (265))
                                                                     (Prims.of_int (49))
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (36)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.intro_post_hint
@@ -1175,17 +1175,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (266))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (271))
                                                                     (Prims.of_int (20)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (273))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (36)))))
                                                                     (Obj.magic
                                                                     (withinv_post
@@ -1216,17 +1216,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (276))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (275))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (24)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1234,9 +1234,9 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (23)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1327,17 +1327,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1345,17 +1345,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1363,17 +1363,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1381,17 +1381,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1418,17 +1418,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1436,17 +1436,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1454,17 +1454,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1538,17 +1538,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (280))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (280))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (280))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1565,17 +1565,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (282))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1594,17 +1594,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1621,17 +1621,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (291))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (291))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (17)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1647,17 +1647,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (64))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1676,17 +1676,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (64))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (recheck
@@ -1706,17 +1706,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (300))
+                                                                    (Prims.of_int (316))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (300))
+                                                                    (Prims.of_int (316))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (recheck
@@ -1738,17 +1738,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (303))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (310))
+                                                                    (Prims.of_int (326))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (312))
+                                                                    (Prims.of_int (328))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (find_inv_post
@@ -1767,17 +1767,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (312))
+                                                                    (Prims.of_int (328))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (332))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (332))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (if
                                                                     FStar_Pervasives_Native.uu___is_None
@@ -1790,17 +1790,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (313))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (332))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (313))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (332))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1808,17 +1808,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (314))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (313))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (332))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1826,17 +1826,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (314))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (314))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (314))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (70)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1844,17 +1844,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (314))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (70))
-                                                                    (Prims.of_int (314))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (314))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (314))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (76)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1881,17 +1881,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (314))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (70)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1899,17 +1899,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (331))
                                                                     (Prims.of_int (70)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1969,17 +1969,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (319))
+                                                                    (Prims.of_int (335))
                                                                     (Prims.of_int (76))
-                                                                    (Prims.of_int (319))
+                                                                    (Prims.of_int (335))
                                                                     (Prims.of_int (79)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (332))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2006,17 +2006,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (320))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (324))
+                                                                    (Prims.of_int (340))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (if
                                                                     Prims.op_Negation
@@ -2030,17 +2030,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (322))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (321))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (7))
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2048,17 +2048,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (322))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (Pulse_Show.show
@@ -2074,17 +2074,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (322))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (322))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2092,17 +2092,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (322))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (Pulse_Show.show
@@ -2120,17 +2120,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (322))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (322))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2138,9 +2138,9 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (20)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2223,17 +2223,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (325))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (325))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (325))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2254,17 +2254,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (73)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (325))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2325,17 +2325,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2354,17 +2354,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (46))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2384,17 +2384,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (355))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (346))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (346))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2454,17 +2454,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (368))
                                                                     (Prims.of_int (46))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2488,17 +2488,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (353))
+                                                                    (Prims.of_int (369))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (361))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (25)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (362))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2543,17 +2543,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (364))
+                                                                    (Prims.of_int (380))
                                                                     (Prims.of_int (39))
-                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (362))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2561,17 +2561,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (365))
+                                                                    (Prims.of_int (381))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (365))
+                                                                    (Prims.of_int (381))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (365))
+                                                                    (Prims.of_int (381))
                                                                     (Prims.of_int (54))
-                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2590,17 +2590,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (78)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (35)))))
                                                                     (Obj.magic
                                                                     (check1 g
@@ -2642,17 +2642,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (374))
+                                                                    (Prims.of_int (390))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (377))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (18)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (377))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2676,17 +2676,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (395))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (395))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (395))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (disjointness_remove_i_i
@@ -2703,17 +2703,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (397))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (397))
                                                                     (Prims.of_int (90)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (397))
                                                                     (Prims.of_int (93))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2744,17 +2744,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (382))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (421))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (439))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2864,17 +2864,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (428))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (428))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (add_remove_inverse
@@ -2891,17 +2891,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (431))
+                                                                    (Prims.of_int (447))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (453))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2956,17 +2956,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (453))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (453))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2985,17 +2985,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (439))
+                                                                    (Prims.of_int (455))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (439))
+                                                                    (Prims.of_int (455))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3035,17 +3035,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (428))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (428))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (add_remove_inverse
@@ -3062,17 +3062,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (431))
+                                                                    (Prims.of_int (447))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (453))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3127,17 +3127,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (453))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (453))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3156,17 +3156,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (439))
+                                                                    (Prims.of_int (455))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (439))
+                                                                    (Prims.of_int (455))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3206,17 +3206,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (428))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (428))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (add_remove_inverse
@@ -3233,17 +3233,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (431))
+                                                                    (Prims.of_int (447))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (453))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (429))
+                                                                    (Prims.of_int (445))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3298,17 +3298,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (453))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (453))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3327,17 +3327,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (439))
+                                                                    (Prims.of_int (455))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (439))
+                                                                    (Prims.of_int (455))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (440))
+                                                                    (Prims.of_int (456))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3376,17 +3376,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (443))
+                                                                    (Prims.of_int (459))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (443))
+                                                                    (Prims.of_int (459))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (444))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun

--- a/src/ocaml/plugin/generated/Pulse_Checker_WithInv.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_WithInv.ml
@@ -612,6 +612,140 @@ let (atomic_or_ghost_with_inames_and_pre_post :
                     Pulse_Syntax_Base.pre = pre;
                     Pulse_Syntax_Base.post = post
                   })
+let rec (withinv_post :
+  Pulse_Typing_Env.env ->
+    Pulse_Syntax_Base.term ->
+      Pulse_Syntax_Base.term ->
+        Pulse_Syntax_Base.term ->
+          unit ->
+            unit ->
+              unit ->
+                ((Pulse_Syntax_Base.term, unit) Prims.dtuple2
+                   FStar_Pervasives_Native.option,
+                  unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun uu___6 ->
+    fun uu___5 ->
+      fun uu___4 ->
+        fun uu___3 ->
+          fun uu___2 ->
+            fun uu___1 ->
+              fun uu___ ->
+                (fun g ->
+                   fun p ->
+                     fun i ->
+                       fun post ->
+                         fun p_typing ->
+                           fun i_typing ->
+                             fun post_typing ->
+                               if Pulse_Syntax_Base.eq_tm post p
+                               then
+                                 Obj.magic
+                                   (Obj.repr
+                                      (FStar_Tactics_Effect.lift_div_tac
+                                         (fun uu___ ->
+                                            FStar_Pervasives_Native.Some
+                                              (Prims.Mkdtuple2
+                                                 ((Pulse_Syntax_Pure.tm_inv i
+                                                     p), ())))))
+                               else
+                                 Obj.magic
+                                   (Obj.repr
+                                      (match Pulse_Syntax_Pure.inspect_term
+                                               post
+                                       with
+                                       | Pulse_Syntax_Pure.Tm_Star (l, r) ->
+                                           Obj.repr
+                                             (FStar_Tactics_Effect.tac_bind
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Checker.WithInv.fst"
+                                                         (Prims.of_int (203))
+                                                         (Prims.of_int (19))
+                                                         (Prims.of_int (203))
+                                                         (Prims.of_int (72)))))
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "Pulse.Checker.WithInv.fst"
+                                                         (Prims.of_int (205))
+                                                         (Prims.of_int (11))
+                                                         (Prims.of_int (213))
+                                                         (Prims.of_int (16)))))
+                                                (Obj.magic
+                                                   (withinv_post g p i l ()
+                                                      () ()))
+                                                (fun uu___1 ->
+                                                   (fun res ->
+                                                      match res with
+                                                      | FStar_Pervasives_Native.Some
+                                                          (Prims.Mkdtuple2
+                                                          (l', uu___1)) ->
+                                                          Obj.magic
+                                                            (Obj.repr
+                                                               (FStar_Tactics_Effect.lift_div_tac
+                                                                  (fun uu___2
+                                                                    ->
+                                                                    FStar_Pervasives_Native.Some
+                                                                    (Prims.Mkdtuple2
+                                                                    ((Pulse_Syntax_Pure.tm_star
+                                                                    l' r),
+                                                                    ())))))
+                                                      | FStar_Pervasives_Native.None
+                                                          ->
+                                                          Obj.magic
+                                                            (Obj.repr
+                                                               (FStar_Tactics_Effect.tac_bind
+                                                                  (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (78)))))
+                                                                  (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (212))
+                                                                    (Prims.of_int (29)))))
+                                                                  (Obj.magic
+                                                                    (withinv_post
+                                                                    g p i r
+                                                                    () () ()))
+                                                                  (fun res1
+                                                                    ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    match res1
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives_Native.Some
+                                                                    (Prims.Mkdtuple2
+                                                                    (r',
+                                                                    uu___2))
+                                                                    ->
+                                                                    FStar_Pervasives_Native.Some
+                                                                    (Prims.Mkdtuple2
+                                                                    ((Pulse_Syntax_Pure.tm_star
+                                                                    l r'),
+                                                                    ()))
+                                                                    | 
+                                                                    FStar_Pervasives_Native.None
+                                                                    ->
+                                                                    FStar_Pervasives_Native.None)))))
+                                                     uu___1))
+                                       | uu___1 ->
+                                           Obj.repr
+                                             (FStar_Tactics_Effect.lift_div_tac
+                                                (fun uu___2 ->
+                                                   FStar_Pervasives_Native.None)))))
+                  uu___6 uu___5 uu___4 uu___3 uu___2 uu___1 uu___
 let (check :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.term ->
@@ -634,13 +768,13 @@ let (check :
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.WithInv.fst"
-                           (Prims.of_int (202)) (Prims.of_int (47))
-                           (Prims.of_int (202)) (Prims.of_int (53)))))
+                           (Prims.of_int (228)) (Prims.of_int (47))
+                           (Prims.of_int (228)) (Prims.of_int (53)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.WithInv.fst"
-                           (Prims.of_int (202)) Prims.int_one
-                           (Prims.of_int (396)) (Prims.of_int (57)))))
+                           (Prims.of_int (228)) Prims.int_one
+                           (Prims.of_int (444)) (Prims.of_int (57)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ -> t.Pulse_Syntax_Base.term1))
                   (fun uu___ ->
@@ -657,17 +791,17 @@ let (check :
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Checker.WithInv.fst"
-                                          (Prims.of_int (203))
+                                          (Prims.of_int (229))
                                           (Prims.of_int (19))
-                                          (Prims.of_int (203))
+                                          (Prims.of_int (229))
                                           (Prims.of_int (46)))))
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Checker.WithInv.fst"
-                                          (Prims.of_int (202))
+                                          (Prims.of_int (228))
                                           (Prims.of_int (56))
-                                          (Prims.of_int (396))
+                                          (Prims.of_int (444))
                                           (Prims.of_int (57)))))
                                  (Obj.magic
                                     (Pulse_Checker_Pure.check_tot_term g i
@@ -682,17 +816,17 @@ let (check :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.WithInv.fst"
-                                                         (Prims.of_int (204))
+                                                         (Prims.of_int (230))
                                                          (Prims.of_int (16))
-                                                         (Prims.of_int (204))
+                                                         (Prims.of_int (230))
                                                          (Prims.of_int (50)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.WithInv.fst"
-                                                         (Prims.of_int (204))
+                                                         (Prims.of_int (230))
                                                          (Prims.of_int (53))
-                                                         (Prims.of_int (396))
+                                                         (Prims.of_int (444))
                                                          (Prims.of_int (57)))))
                                                 (FStar_Tactics_Effect.lift_div_tac
                                                    (fun uu___3 ->
@@ -706,17 +840,17 @@ let (check :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (205))
+                                                                    (Prims.of_int (231))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (205))
+                                                                    (Prims.of_int (231))
                                                                     (Prims.of_int (33)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (232))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                            (Obj.magic
                                                               (find_inv g pre
@@ -729,17 +863,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (206))
+                                                                    (Prims.of_int (232))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (236))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (236))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (if
                                                                     FStar_Pervasives_Native.uu___is_None
@@ -752,17 +886,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (233))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (236))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (233))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (236))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -770,17 +904,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (208))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (233))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (236))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -788,17 +922,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (208))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (208))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (208))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -806,17 +940,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (208))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (70))
-                                                                    (Prims.of_int (208))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (208))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (208))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (76)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -843,17 +977,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (208))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -861,17 +995,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -931,17 +1065,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (212))
-                                                                    (Prims.of_int (78))
-                                                                    (Prims.of_int (212))
-                                                                    (Prims.of_int (81)))))
+                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (72)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (210))
+                                                                    (Prims.of_int (236))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -958,7 +1092,7 @@ let (check :
                                                                     (FStar_Pervasives.Mkdtuple5
                                                                     (p,
                                                                     pre_frame,
-                                                                    inv_typing,
+                                                                    uu___5,
                                                                     pre_frame_typing,
                                                                     d_pre_frame_eq))
                                                                     ->
@@ -968,17 +1102,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (276))
                                                                     (Prims.of_int (67)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (277))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (match 
                                                                     (returns_inv,
@@ -992,7 +1126,7 @@ let (check :
                                                                     (Obj.repr
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     post)))
                                                                     | 
                                                                     (FStar_Pervasives_Native.Some
@@ -1002,6 +1136,24 @@ let (check :
                                                                     ->
                                                                     Obj.magic
                                                                     (Obj.repr
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (12)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (49))
+                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (36)))))
+                                                                    (Obj.magic
                                                                     (Pulse_Checker_Base.intro_post_hint
                                                                     g
                                                                     (Pulse_Syntax_Base.EffectAnnotAtomicOrGhost
@@ -1012,220 +1164,8 @@ let (check :
                                                                     (FStar_Pervasives_Native.Some
                                                                     (b.Pulse_Syntax_Base.binder_ty))
                                                                     post))
-                                                                    | 
-                                                                    (FStar_Pervasives_Native.Some
-                                                                    (uu___5,
-                                                                    post,
-                                                                    uu___6),
-                                                                    FStar_Pervasives_Native.Some
-                                                                    q) ->
-                                                                    Obj.magic
-                                                                    (Obj.repr
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (224))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (226))
-                                                                    (Prims.of_int (60)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (223))
-                                                                    (Prims.of_int (6))
-                                                                    (Prims.of_int (226))
-                                                                    (Prims.of_int (60)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (224))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (226))
-                                                                    (Prims.of_int (60)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (224))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (226))
-                                                                    (Prims.of_int (60)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (60)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (224))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (226))
-                                                                    (Prims.of_int (60)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (51))
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (60)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (225))
-                                                                    (Prims.of_int (60)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_PP.pp
-                                                                    Pulse_PP.printable_term
-                                                                    post))
                                                                     (fun
-                                                                    uu___7 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    FStar_Pprint.prefix
-                                                                    (Prims.of_int (4))
-                                                                    Prims.int_one
-                                                                    (Pulse_PP.text
-                                                                    "First postcondition:")
-                                                                    uu___7))))
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (224))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (226))
-                                                                    (Prims.of_int (60)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (224))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (226))
-                                                                    (Prims.of_int (60)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (226))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (226))
-                                                                    (Prims.of_int (58)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (224))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (226))
-                                                                    (Prims.of_int (60)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (226))
-                                                                    (Prims.of_int (52))
-                                                                    (Prims.of_int (226))
-                                                                    (Prims.of_int (58)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (226))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (226))
-                                                                    (Prims.of_int (58)))))
-                                                                    (Obj.magic
-                                                                    (Pulse_PP.pp
-                                                                    Pulse_PP.printable_post_hint_t
-                                                                    q))
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___9 ->
-                                                                    FStar_Pprint.prefix
-                                                                    (Prims.of_int (4))
-                                                                    Prims.int_one
-                                                                    (Pulse_PP.text
-                                                                    "Second postcondition:")
-                                                                    uu___8))))
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___9 ->
-                                                                    [uu___8]))))
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___9 ->
-                                                                    uu___7 ::
-                                                                    uu___8))))
-                                                                    uu___7)))
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    (FStar_Pprint.doc_of_string
-                                                                    "Fatal: multiple annotated postconditions on with_invariant")
-                                                                    :: uu___7))))
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    (fun
-                                                                    uu___7 ->
-                                                                    Obj.magic
-                                                                    (Pulse_Typing_Env.fail_doc
-                                                                    g
-                                                                    (FStar_Pervasives_Native.Some
-                                                                    (t.Pulse_Syntax_Base.range1))
-                                                                    uu___7))
-                                                                    uu___7)))
-                                                                    | 
-                                                                    (uu___5,
-                                                                    uu___6)
-                                                                    ->
-                                                                    Obj.magic
-                                                                    (Obj.repr
-                                                                    (Pulse_Typing_Env.fail
-                                                                    g
-                                                                    (FStar_Pervasives_Native.Some
-                                                                    (t.Pulse_Syntax_Base.range1))
-                                                                    "Fatal: no post hint on with_invariant")))
-                                                                    (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     (fun
                                                                     post_hint1
                                                                     ->
@@ -1235,24 +1175,387 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (18))
+                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (20)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (36)))))
+                                                                    (Obj.magic
+                                                                    (withinv_post
+                                                                    (Pulse_Typing_Env.push_binding
+                                                                    g
+                                                                    post_hint1.Pulse_Typing.x
+                                                                    Pulse_Syntax_Base.ppname_default
+                                                                    post_hint1.Pulse_Typing.ret_ty)
+                                                                    p i1
+                                                                    (Pulse_Syntax_Naming.open_term_nv
+                                                                    post_hint1.Pulse_Typing.post
+                                                                    (Pulse_Syntax_Base.v_as_nv
+                                                                    post_hint1.Pulse_Typing.x))
+                                                                    () () ()))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    (fun res1
+                                                                    ->
+                                                                    match res1
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives_Native.None
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (24)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (24)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (23)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "prims.fst"
+                                                                    (Prims.of_int (590))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (590))
+                                                                    (Prims.of_int (31)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Show.show
+                                                                    Pulse_Show.tac_showable_r_term
+                                                                    p))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    Prims.strcat
+                                                                    "Cannot find invariant slprop "
+                                                                    (Prims.strcat
+                                                                    uu___6
+                                                                    " in the with_invariants annotated postcondition")))))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    Obj.magic
+                                                                    (Pulse_Typing_Env.fail
+                                                                    g
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    (FStar_Reflection_V1_Builtins.range_of_term
+                                                                    post))
+                                                                    uu___6))
+                                                                    uu___6)))
+                                                                    | 
+                                                                    FStar_Pervasives_Native.Some
+                                                                    (Prims.Mkdtuple2
+                                                                    (post',
+                                                                    uu___6))
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    {
+                                                                    Pulse_Typing.g
+                                                                    =
+                                                                    (post_hint1.Pulse_Typing.g);
+                                                                    Pulse_Typing.effect_annot
+                                                                    =
+                                                                    (post_hint1.Pulse_Typing.effect_annot);
+                                                                    Pulse_Typing.effect_annot_typing
+                                                                    =
+                                                                    (post_hint1.Pulse_Typing.effect_annot_typing);
+                                                                    Pulse_Typing.ret_ty
+                                                                    =
+                                                                    (post_hint1.Pulse_Typing.ret_ty);
+                                                                    Pulse_Typing.u
+                                                                    =
+                                                                    (post_hint1.Pulse_Typing.u);
+                                                                    Pulse_Typing.ty_typing
+                                                                    = ();
+                                                                    Pulse_Typing.post
+                                                                    = post';
+                                                                    Pulse_Typing.x
+                                                                    =
+                                                                    (post_hint1.Pulse_Typing.x);
+                                                                    Pulse_Typing.post_typing_src
+                                                                    = ();
+                                                                    Pulse_Typing.post_typing
+                                                                    = ()
+                                                                    }))))
+                                                                    uu___6)))
+                                                                    uu___6)))
+                                                                    | 
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    (uu___6,
+                                                                    post,
+                                                                    uu___7),
+                                                                    FStar_Pervasives_Native.Some
+                                                                    q) ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (60)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (60)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (60)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (60)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (60)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (60)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (51))
+                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (60)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (60)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.printable_term
+                                                                    post))
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    FStar_Pprint.prefix
+                                                                    (Prims.of_int (4))
+                                                                    Prims.int_one
+                                                                    (Pulse_PP.text
+                                                                    "First postcondition:")
+                                                                    uu___8))))
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (60)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (60)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (58)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (60)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (52))
+                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (58)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (58)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.printable_post_hint_t
+                                                                    q))
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    FStar_Pprint.prefix
+                                                                    (Prims.of_int (4))
+                                                                    Prims.int_one
+                                                                    (Pulse_PP.text
+                                                                    "Second postcondition:")
+                                                                    uu___9))))
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___10
+                                                                    ->
+                                                                    [uu___9]))))
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___10
+                                                                    -> uu___8
+                                                                    :: uu___9))))
+                                                                    uu___8)))
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___9 ->
+                                                                    (FStar_Pprint.doc_of_string
+                                                                    "Fatal: multiple annotated postconditions on with_invariant")
+                                                                    :: uu___8))))
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    Obj.magic
+                                                                    (Pulse_Typing_Env.fail_doc
+                                                                    g
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    (t.Pulse_Syntax_Base.range1))
+                                                                    uu___8))
+                                                                    uu___8)))
+                                                                    | 
+                                                                    (uu___6,
+                                                                    uu___7)
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (Pulse_Typing_Env.fail
+                                                                    g
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    (t.Pulse_Syntax_Base.range1))
+                                                                    "Fatal: no post hint on with_invariant")))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    (fun
+                                                                    post_hint1
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (280))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (280))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (280))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     body.Pulse_Syntax_Base.range1))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     (fun
                                                                     body_range
                                                                     ->
@@ -1262,26 +1565,26 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (282))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (282))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (282))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     Pulse_Syntax_Pure.tm_star
                                                                     p
                                                                     pre_frame))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     (fun
                                                                     pre_body
                                                                     ->
@@ -1291,24 +1594,24 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     ()))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     (fun
                                                                     pre_body_typing
                                                                     ->
@@ -1318,25 +1621,25 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (291))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (291))
                                                                     (Prims.of_int (17)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (292))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     Pulse_Typing_Env.fresh
                                                                     g))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     (fun x ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1344,27 +1647,27 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (64))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     Pulse_Typing_Env.push_binding
                                                                     g x
                                                                     Pulse_Syntax_Base.ppname_default
                                                                     post_hint1.Pulse_Typing.ret_ty))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     (fun g'
                                                                     ->
                                                                     Obj.magic
@@ -1373,17 +1676,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (64))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (recheck
@@ -1393,7 +1696,7 @@ let (check :
                                                                     post_hint1.Pulse_Typing.u)
                                                                     ()))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     (fun
                                                                     post_hint_ret_ty_typing
                                                                     ->
@@ -1403,17 +1706,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (recheck
@@ -1425,7 +1728,7 @@ let (check :
                                                                     Pulse_Syntax_Pure.tm_slprop
                                                                     ()))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     (fun
                                                                     post_hint_post_typing
                                                                     ->
@@ -1435,17 +1738,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (310))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (find_inv_post
@@ -1455,7 +1758,7 @@ let (check :
                                                                     post_hint1.Pulse_Typing.post
                                                                     () () i1))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     (fun res1
                                                                     ->
                                                                     Obj.magic
@@ -1464,17 +1767,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (316))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (316))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (if
                                                                     FStar_Pervasives_Native.uu___is_None
@@ -1487,17 +1790,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (313))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (316))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (313))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (316))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1505,17 +1808,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (266))
+                                                                    (Prims.of_int (314))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (313))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (316))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1523,17 +1826,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (266))
+                                                                    (Prims.of_int (314))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (266))
+                                                                    (Prims.of_int (314))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (266))
+                                                                    (Prims.of_int (314))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (70)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1541,54 +1844,54 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (266))
+                                                                    (Prims.of_int (314))
                                                                     (Prims.of_int (70))
-                                                                    (Prims.of_int (266))
+                                                                    (Prims.of_int (314))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (266))
+                                                                    (Prims.of_int (314))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (266))
+                                                                    (Prims.of_int (314))
                                                                     (Prims.of_int (76)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
                                                                     Pulse_PP.printable_term
                                                                     i1))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___7 ->
                                                                     FStar_Pprint.prefix
                                                                     (Prims.of_int (2))
                                                                     Prims.int_one
                                                                     (Pulse_PP.text
                                                                     "Cannot find invariant resource for iname ")
-                                                                    uu___5))))
+                                                                    uu___6))))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (266))
+                                                                    (Prims.of_int (314))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (70)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1596,104 +1899,104 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (70)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
                                                                     Pulse_PP.printable_term
                                                                     post_hint1.Pulse_Typing.post))
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___7 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___7 ->
+                                                                    uu___8 ->
                                                                     FStar_Pprint.prefix
                                                                     (Prims.of_int (2))
                                                                     Prims.int_one
                                                                     (Pulse_PP.text
                                                                     " in the postcondition ")
-                                                                    uu___6))))
+                                                                    uu___7))))
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    FStar_Pprint.op_Hat_Slash_Hat
+                                                                    uu___6
+                                                                    uu___7))))
+                                                                    uu___6)))
                                                                     (fun
                                                                     uu___6 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___7 ->
-                                                                    FStar_Pprint.op_Hat_Slash_Hat
-                                                                    uu___5
-                                                                    uu___6))))
-                                                                    uu___5)))
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    [uu___6]))))
                                                                     (fun
                                                                     uu___6 ->
-                                                                    [uu___5]))))
                                                                     (fun
-                                                                    uu___5 ->
-                                                                    (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     Obj.magic
                                                                     (Pulse_Typing_Env.fail_doc
                                                                     g
                                                                     (FStar_Pervasives_Native.Some
                                                                     i_range)
-                                                                    uu___5))
-                                                                    uu___5)))
+                                                                    uu___6))
+                                                                    uu___6)))
                                                                     else
                                                                     Obj.magic
                                                                     (Obj.repr
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___7 ->
                                                                     ()))))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (76))
-                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (79)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (316))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___7 ->
                                                                     res1))
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___7 ->
                                                                     (fun
-                                                                    uu___6 ->
-                                                                    match uu___6
+                                                                    uu___7 ->
+                                                                    match uu___7
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.Some
                                                                     (FStar_Pervasives.Mkdtuple5
                                                                     (p',
                                                                     post_frame,
-                                                                    uu___7,
+                                                                    uu___8,
                                                                     post_frame_typing,
                                                                     d_post_frame_equiv))
                                                                     ->
@@ -1703,17 +2006,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (320))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (324))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (if
                                                                     Prims.op_Negation
@@ -1727,17 +2030,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (321))
                                                                     (Prims.of_int (7))
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1745,43 +2048,43 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (Pulse_Show.show
                                                                     Pulse_Show.tac_showable_r_term
                                                                     p'))
                                                                     (fun
-                                                                    uu___8 ->
+                                                                    uu___9 ->
                                                                     (fun
-                                                                    uu___8 ->
+                                                                    uu___9 ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1789,43 +2092,45 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (Pulse_Show.show
                                                                     Pulse_Show.tac_showable_r_term
                                                                     p))
                                                                     (fun
-                                                                    uu___9 ->
+                                                                    uu___10
+                                                                    ->
                                                                     (fun
-                                                                    uu___9 ->
+                                                                    uu___10
+                                                                    ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (322))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1833,9 +2138,9 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (323))
                                                                     (Prims.of_int (20)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1850,11 +2155,11 @@ let (check :
                                                                     Pulse_Show.tac_showable_r_term
                                                                     i1))
                                                                     (fun
-                                                                    uu___10
+                                                                    uu___11
                                                                     ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     fun x1 ->
                                                                     fun x2 ->
@@ -1863,13 +2168,23 @@ let (check :
                                                                     (Prims.strcat
                                                                     "Inconsistent slprops for iname "
                                                                     (Prims.strcat
-                                                                    uu___10
+                                                                    uu___11
                                                                     " in pre ("))
                                                                     (Prims.strcat
                                                                     x1
                                                                     ") and post ("))
                                                                     (Prims.strcat
                                                                     x2 ")")))))
+                                                                    (fun
+                                                                    uu___11
+                                                                    ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___12
+                                                                    ->
+                                                                    uu___11
+                                                                    uu___10))))
+                                                                    uu___10)))
                                                                     (fun
                                                                     uu___10
                                                                     ->
@@ -1882,61 +2197,54 @@ let (check :
                                                                     uu___9)))
                                                                     (fun
                                                                     uu___9 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___10
-                                                                    ->
-                                                                    uu___9
-                                                                    uu___8))))
-                                                                    uu___8)))
-                                                                    (fun
-                                                                    uu___8 ->
-                                                                    (fun
-                                                                    uu___8 ->
+                                                                    uu___9 ->
                                                                     Obj.magic
                                                                     (Pulse_Typing_Env.fail
                                                                     g
                                                                     (FStar_Pervasives_Native.Some
                                                                     i_range)
-                                                                    uu___8))
-                                                                    uu___8)))
+                                                                    uu___9))
+                                                                    uu___9)))
                                                                     else
                                                                     Obj.magic
                                                                     (Obj.repr
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
+                                                                    uu___10
+                                                                    -> ()))))
+                                                                    (fun
                                                                     uu___9 ->
-                                                                    ()))))
                                                                     (fun
-                                                                    uu___8 ->
-                                                                    (fun
-                                                                    uu___8 ->
+                                                                    uu___9 ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___9 ->
+                                                                    uu___10
+                                                                    ->
                                                                     Pulse_Syntax_Pure.tm_star
                                                                     p
                                                                     post_frame))
                                                                     (fun
-                                                                    uu___9 ->
+                                                                    uu___10
+                                                                    ->
                                                                     (fun
                                                                     post_body
                                                                     ->
@@ -1946,21 +2254,22 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (281))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (335))
                                                                     (Prims.of_int (73)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (325))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___9 ->
+                                                                    uu___10
+                                                                    ->
                                                                     match 
                                                                     post_hint1.Pulse_Typing.effect_annot
                                                                     with
@@ -1998,10 +2307,12 @@ let (check :
                                                                     (opens,
                                                                     ())))
                                                                     (fun
-                                                                    uu___9 ->
+                                                                    uu___10
+                                                                    ->
                                                                     (fun
-                                                                    uu___9 ->
-                                                                    match uu___9
+                                                                    uu___10
+                                                                    ->
+                                                                    match uu___10
                                                                     with
                                                                     | 
                                                                     Prims.Mkdtuple2
@@ -2014,27 +2325,28 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___10
-                                                                    -> uu___9))
+                                                                    uu___11
+                                                                    ->
+                                                                    uu___10))
                                                                     (fun
-                                                                    uu___10
+                                                                    uu___11
                                                                     ->
                                                                     (fun
-                                                                    uu___10
+                                                                    uu___11
                                                                     ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2042,26 +2354,26 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (46))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     remove_iname
                                                                     opens i1))
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     (fun
                                                                     opens_remove_i
@@ -2072,21 +2384,21 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (291))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     match 
                                                                     post_hint1.Pulse_Typing.effect_annot
@@ -2102,7 +2414,7 @@ let (check :
                                                                     }
                                                                     | 
                                                                     Pulse_Syntax_Base.EffectAnnotAtomic
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     Pulse_Syntax_Base.EffectAnnotAtomic
                                                                     {
@@ -2112,7 +2424,7 @@ let (check :
                                                                     }
                                                                     | 
                                                                     Pulse_Syntax_Base.EffectAnnotGhost
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     Pulse_Syntax_Base.EffectAnnotGhost
                                                                     {
@@ -2122,7 +2434,7 @@ let (check :
                                                                     }
                                                                     | 
                                                                     Pulse_Syntax_Base.EffectAnnotAtomicOrGhost
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     Pulse_Syntax_Base.EffectAnnotAtomicOrGhost
                                                                     {
@@ -2131,7 +2443,7 @@ let (check :
                                                                     opens_remove_i
                                                                     }))
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     (fun
                                                                     effect_annot
@@ -2142,30 +2454,30 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (349))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (301))
+                                                                    (Prims.of_int (349))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (304))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (46))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     Obj.magic
                                                                     ())
-                                                                    uu___11))
+                                                                    uu___12))
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     (fun
                                                                     effect_annot_typing
@@ -2176,21 +2488,21 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (305))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (313))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (25)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (314))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     {
                                                                     Pulse_Typing.g
@@ -2220,7 +2532,7 @@ let (check :
                                                                     = ()
                                                                     }))
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     (fun
                                                                     post_hint_body
@@ -2231,17 +2543,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (316))
+                                                                    (Prims.of_int (364))
                                                                     (Prims.of_int (39))
-                                                                    (Prims.of_int (319))
+                                                                    (Prims.of_int (367))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (314))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2249,26 +2561,26 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (54))
-                                                                    (Prims.of_int (319))
+                                                                    (Prims.of_int (367))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     Pulse_Syntax_Base.mk_ppname_no_range
                                                                     "with_inv_body"))
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     (fun
                                                                     ppname ->
@@ -2278,17 +2590,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (78)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (319))
+                                                                    (Prims.of_int (367))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (319))
+                                                                    (Prims.of_int (367))
                                                                     (Prims.of_int (35)))))
                                                                     (Obj.magic
                                                                     (check1 g
@@ -2299,7 +2611,7 @@ let (check :
                                                                     ppname
                                                                     body))
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     (fun r ->
                                                                     Obj.magic
@@ -2308,15 +2620,15 @@ let (check :
                                                                     pre_body
                                                                     post_hint_body
                                                                     r ppname))
-                                                                    uu___11)))
-                                                                    uu___11)))
+                                                                    uu___12)))
+                                                                    uu___12)))
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
-                                                                    match uu___11
+                                                                    match uu___12
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives.Mkdtuple3
@@ -2330,21 +2642,21 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (326))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (18)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     atomic_or_ghost_with_inames_and_pre_post
                                                                     c_body
@@ -2354,7 +2666,7 @@ let (check :
                                                                     i1) pre
                                                                     post_hint1.Pulse_Typing.post))
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     (fun
                                                                     c_out ->
@@ -2364,24 +2676,24 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (379))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (379))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (379))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (disjointness_remove_i_i
                                                                     g opens
                                                                     i1))
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     (fun tok
                                                                     ->
@@ -2391,21 +2703,21 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (381))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (381))
                                                                     (Prims.of_int (90)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (381))
                                                                     (Prims.of_int (93))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     Pulse_Typing.wtag
                                                                     (FStar_Pervasives_Native.Some
@@ -2422,7 +2734,7 @@ let (check :
                                                                     FStar_Pervasives_Native.None
                                                                     })))
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     (fun tm
                                                                     ->
@@ -2432,21 +2744,21 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (334))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (373))
+                                                                    (Prims.of_int (421))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (375))
+                                                                    (Prims.of_int (423))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     Pulse_Typing.T_Equiv
                                                                     (g,
@@ -2536,7 +2848,7 @@ let (check :
                                                                     FStar_Reflection_Typing.R_Eq)),
                                                                     (), ())))))
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     (fun d ->
                                                                     match 
@@ -2544,7 +2856,7 @@ let (check :
                                                                     with
                                                                     | 
                                                                     Pulse_Syntax_Base.EffectAnnotGhost
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2552,24 +2864,24 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (380))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (380))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (add_remove_inverse
                                                                     g opens
                                                                     i1 () ()))
                                                                     (fun
-                                                                    uu___13
+                                                                    uu___14
                                                                     ->
                                                                     (fun tok1
                                                                     ->
@@ -2579,21 +2891,21 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (431))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___13
+                                                                    uu___14
                                                                     ->
                                                                     match c_out
                                                                     with
@@ -2626,12 +2938,12 @@ let (check :
                                                                     opens,
                                                                     ())))))
                                                                     (fun
-                                                                    uu___13
+                                                                    uu___14
                                                                     ->
                                                                     (fun
-                                                                    uu___13
+                                                                    uu___14
                                                                     ->
-                                                                    match uu___13
+                                                                    match uu___14
                                                                     with
                                                                     | 
                                                                     Prims.Mkdtuple2
@@ -2644,28 +2956,28 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___14
+                                                                    uu___15
                                                                     ->
-                                                                    uu___13))
+                                                                    uu___14))
                                                                     (fun
-                                                                    uu___14
+                                                                    uu___15
                                                                     ->
                                                                     (fun
-                                                                    uu___14
+                                                                    uu___15
                                                                     ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2673,21 +2985,21 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (391))
+                                                                    (Prims.of_int (439))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (391))
+                                                                    (Prims.of_int (439))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___15
+                                                                    uu___16
                                                                     ->
                                                                     Pulse_Typing.T_Sub
                                                                     (g, tm,
@@ -2696,7 +3008,7 @@ let (check :
                                                                     d,
                                                                     d_sub_c)))
                                                                     (fun
-                                                                    uu___15
+                                                                    uu___16
                                                                     ->
                                                                     (fun d1
                                                                     ->
@@ -2709,13 +3021,13 @@ let (check :
                                                                     c_out_opens,
                                                                     d1))
                                                                     res_ppname))
+                                                                    uu___16)))
                                                                     uu___15)))
                                                                     uu___14)))
-                                                                    uu___13)))
-                                                                    uu___13))
+                                                                    uu___14))
                                                                     | 
                                                                     Pulse_Syntax_Base.EffectAnnotAtomic
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2723,24 +3035,24 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (380))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (380))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (add_remove_inverse
                                                                     g opens
                                                                     i1 () ()))
                                                                     (fun
-                                                                    uu___13
+                                                                    uu___14
                                                                     ->
                                                                     (fun tok1
                                                                     ->
@@ -2750,21 +3062,21 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (431))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___13
+                                                                    uu___14
                                                                     ->
                                                                     match c_out
                                                                     with
@@ -2797,12 +3109,12 @@ let (check :
                                                                     opens,
                                                                     ())))))
                                                                     (fun
-                                                                    uu___13
+                                                                    uu___14
                                                                     ->
                                                                     (fun
-                                                                    uu___13
+                                                                    uu___14
                                                                     ->
-                                                                    match uu___13
+                                                                    match uu___14
                                                                     with
                                                                     | 
                                                                     Prims.Mkdtuple2
@@ -2815,28 +3127,28 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___14
+                                                                    uu___15
                                                                     ->
-                                                                    uu___13))
+                                                                    uu___14))
                                                                     (fun
-                                                                    uu___14
+                                                                    uu___15
                                                                     ->
                                                                     (fun
-                                                                    uu___14
+                                                                    uu___15
                                                                     ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2844,21 +3156,21 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (391))
+                                                                    (Prims.of_int (439))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (391))
+                                                                    (Prims.of_int (439))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___15
+                                                                    uu___16
                                                                     ->
                                                                     Pulse_Typing.T_Sub
                                                                     (g, tm,
@@ -2867,7 +3179,7 @@ let (check :
                                                                     d,
                                                                     d_sub_c)))
                                                                     (fun
-                                                                    uu___15
+                                                                    uu___16
                                                                     ->
                                                                     (fun d1
                                                                     ->
@@ -2880,13 +3192,13 @@ let (check :
                                                                     c_out_opens,
                                                                     d1))
                                                                     res_ppname))
+                                                                    uu___16)))
                                                                     uu___15)))
                                                                     uu___14)))
-                                                                    uu___13)))
-                                                                    uu___13))
+                                                                    uu___14))
                                                                     | 
                                                                     Pulse_Syntax_Base.EffectAnnotAtomicOrGhost
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2894,24 +3206,24 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (380))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (380))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (add_remove_inverse
                                                                     g opens
                                                                     i1 () ()))
                                                                     (fun
-                                                                    uu___13
+                                                                    uu___14
                                                                     ->
                                                                     (fun tok1
                                                                     ->
@@ -2921,21 +3233,21 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (431))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (381))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___13
+                                                                    uu___14
                                                                     ->
                                                                     match c_out
                                                                     with
@@ -2968,12 +3280,12 @@ let (check :
                                                                     opens,
                                                                     ())))))
                                                                     (fun
-                                                                    uu___13
+                                                                    uu___14
                                                                     ->
                                                                     (fun
-                                                                    uu___13
+                                                                    uu___14
                                                                     ->
-                                                                    match uu___13
+                                                                    match uu___14
                                                                     with
                                                                     | 
                                                                     Prims.Mkdtuple2
@@ -2986,28 +3298,28 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___14
+                                                                    uu___15
                                                                     ->
-                                                                    uu___13))
+                                                                    uu___14))
                                                                     (fun
-                                                                    uu___14
+                                                                    uu___15
                                                                     ->
                                                                     (fun
-                                                                    uu___14
+                                                                    uu___15
                                                                     ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3015,21 +3327,21 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (391))
+                                                                    (Prims.of_int (439))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (391))
+                                                                    (Prims.of_int (439))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (440))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___15
+                                                                    uu___16
                                                                     ->
                                                                     Pulse_Typing.T_Sub
                                                                     (g, tm,
@@ -3038,7 +3350,7 @@ let (check :
                                                                     d,
                                                                     d_sub_c)))
                                                                     (fun
-                                                                    uu___15
+                                                                    uu___16
                                                                     ->
                                                                     (fun d1
                                                                     ->
@@ -3051,10 +3363,10 @@ let (check :
                                                                     c_out_opens,
                                                                     d1))
                                                                     res_ppname))
+                                                                    uu___16)))
                                                                     uu___15)))
                                                                     uu___14)))
-                                                                    uu___13)))
-                                                                    uu___13))
+                                                                    uu___14))
                                                                     | 
                                                                     Pulse_Syntax_Base.EffectAnnotSTT
                                                                     ->
@@ -3064,21 +3376,21 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (395))
+                                                                    (Prims.of_int (443))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (395))
+                                                                    (Prims.of_int (443))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     Pulse_Typing.T_Lift
                                                                     (g, tm,
@@ -3091,7 +3403,7 @@ let (check :
                                                                     (g,
                                                                     c_out)))))
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     (fun d1
                                                                     ->
@@ -3106,31 +3418,31 @@ let (check :
                                                                     c_out)),
                                                                     d1))
                                                                     res_ppname))
+                                                                    uu___13)))
+                                                                    uu___13)))
+                                                                    uu___13)))
+                                                                    uu___13)))
+                                                                    uu___13)))
                                                                     uu___12)))
                                                                     uu___12)))
                                                                     uu___12)))
                                                                     uu___12)))
                                                                     uu___12)))
-                                                                    uu___11)))
-                                                                    uu___11)))
-                                                                    uu___11)))
-                                                                    uu___11)))
                                                                     uu___11)))
                                                                     uu___10)))
+                                                                    uu___10)))
                                                                     uu___9)))
-                                                                    uu___9)))
-                                                                    uu___8)))
+                                                                    uu___7)))
                                                                     uu___6)))
-                                                                    uu___5)))
-                                                                    uu___5)))
-                                                                    uu___5)))
-                                                                    uu___5)))
-                                                                    uu___5)))
-                                                                    uu___5)))
-                                                                    uu___5)))
-                                                                    uu___5)))
-                                                                    uu___5)))
-                                                                    uu___5)))
+                                                                    uu___6)))
+                                                                    uu___6)))
+                                                                    uu___6)))
+                                                                    uu___6)))
+                                                                    uu___6)))
+                                                                    uu___6)))
+                                                                    uu___6)))
+                                                                    uu___6)))
+                                                                    uu___6)))
                                                                     uu___4)))
                                                                     uu___3)))
                                                                 uu___3)))


### PR DESCRIPTION
The PR fixes the pulse checker so that the with_invariants ensures can be annotated just as p * frame, as opposed to inv i p * frame.