### PR TITLE
Rewriting the scrutinee in the branches of a match

### DIFF
--- a/Pulse.fst.config.json
+++ b/Pulse.fst.config.json
@@ -9,6 +9,7 @@
     "lib/pulse",
     "lib/pulse/core",
     "lib/pulse/lib",
+    "lib/pulse/lib/pledge",
     "lib/pulse/lib/class",
     "share/pulse/examples",
     "share/pulse/examples/bug-reports",

--- a/lib/pulse/lib/Pulse.Lib.SpinLock.fst
+++ b/lib/pulse/lib/Pulse.Lib.SpinLock.fst
@@ -119,13 +119,9 @@ fn rec acquire (#v:slprop) (#p:perm) (l:lock)
     };
 
   if b {
-    rewrite (if b then v ** GR.pts_to l.gr #0.5R 1ul else emp) as
-            (v ** GR.pts_to l.gr #0.5R 1ul);
     fold (lock_alive l #p v);
     fold (lock_acquired l)
   } else {
-    rewrite (if b then v ** GR.pts_to l.gr #0.5R 1ul else emp) as
-            emp;
     fold (lock_alive l #p v);
     acquire l
   }

--- a/lib/pulse/lib/Pulse.Lib.WhileLoop.fst
+++ b/lib/pulse/lib/Pulse.Lib.WhileLoop.fst
@@ -27,15 +27,9 @@ requires (exists* x. inv x)
 ensures inv false
 {
   let b = cond ();
-  if b
-  {
-     rewrite (inv b) as (inv true);
+  if b {
      body ();
      while_loop' inv cond body;
-  }
-  else
-  {
-    rewrite (inv b) as (inv false);
   }
 }
 ```

--- a/share/pulse/examples/MatchRW.fst
+++ b/share/pulse/examples/MatchRW.fst
@@ -33,3 +33,21 @@ fn test (b:bool)
   }
 }
 ```
+
+
+```pulse
+fn test_if (b:bool)
+  requires p b
+  ensures  q
+{
+  if b {
+    (* Rewrite added by checker *)
+    // rewrite each b as true;
+    foo1 ();
+  } else {
+    (* Rewrite added by checker *)
+    // rewrite each b as false;
+    foo2 ();
+  }
+}
+```

--- a/share/pulse/examples/MatchRW.fst
+++ b/share/pulse/examples/MatchRW.fst
@@ -1,0 +1,35 @@
+module MatchRW
+
+open Pulse.Lib.Pervasives
+
+assume
+val p ([@@@equate_strict] b : bool) : slprop
+
+assume
+val q : slprop
+
+assume
+val foo1 () : stt_ghost unit [] (p true) (fun _ -> q)
+
+assume
+val foo2 () : stt_ghost unit [] (p false) (fun _ -> q)
+
+```pulse
+fn test (b:bool)
+  requires p b
+  ensures  q
+{
+  match b {
+    true -> {
+      (* Rewrite added by checker *)
+      // rewrite each b as true;
+      foo1 ();
+    }
+    false -> {
+      (* Rewrite added by checker *)
+      // rewrite each b as false;
+      foo2 ();
+    }
+  }
+}
+```

--- a/share/pulse/examples/Unfold.fst
+++ b/share/pulse/examples/Unfold.fst
@@ -2,8 +2,6 @@ module Unfold
 
 open Pulse.Lib.Pervasives
 
-let unf = ()
-
 assume
 val p : slprop
 

--- a/share/pulse/examples/by-example/ParallelIncrement.fst
+++ b/share/pulse/examples/by-example/ParallelIncrement.fst
@@ -337,21 +337,22 @@ ensures inv l invp ** qpred ('i + 1)
           ** pts_to continue true
       {
         elim_inv ();
+        unfold cond;
         let b = cas x v (v + 1);
         if b
         {
-          elim_cond_true b _ _;
-          elim_cond_true true _ _;
+          unfold cond;
           with vv. assert (pred vv);
           f vv _;
-          intro_cond_false (qpred 'i) (qpred ('i + 1));
           intro_inv ();
+          fold (cond false (qpred 'i) (qpred ('i + 1)));
           false
         }
         else
         {
-          with p q. rewrite (cond b p q) as q;
+          unfold cond;
           intro_inv ();
+          fold (cond true (qpred 'i) (qpred ('i + 1)));
           true
         }
       };

--- a/share/pulse/examples/by-example/PulseTutorial.Conditionals.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.Conditionals.fst
@@ -193,13 +193,14 @@ ensures pts_to_or_null r #p 'v
 {
     match r {
      Some x -> {
-        elim_pts_to_or_null_some r x;
+        elim_pts_to_or_null_some (Some x) x;
         let o = !x;
         intro_pts_to_or_null_some r x;
         Some o
      }
      None -> {
-        elim_pts_to_or_null_none r;
+        unfold pts_to_or_null None 'v;
+        fold pts_to_or_null None 'v;
         None #a
      }
     }
@@ -234,9 +235,12 @@ requires pts_to_or_null r 'v
 ensures exists* w. pts_to_or_null r w ** pure (Some? r ==> w == Some v)
 {
     match r {
-     None -> { () }
+     None -> {
+        rewrite pts_to_or_null None 'v
+             as pts_to_or_null r 'v;
+     }
      Some x -> {
-        elim_pts_to_or_null_some r x;
+        unfold pts_to_or_null (Some x) 'v;
         x := v;
         intro_pts_to_or_null_some r x;
      }

--- a/share/pulse/examples/by-example/PulseTutorial.ParallelIncrement.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.ParallelIncrement.fst
@@ -362,21 +362,22 @@ ensures inv (C.iname_of c) (C.cinv_vp c (exists* v. pts_to x v ** refine v)) ** 
           ** C.active c p
       {
         C.unpack_cinv_vp c;
+        unfold cond;
         let b = cas x v (v + 1);
         if b
         { 
-          elim_cond_true b _ _;
-          elim_cond_true true _ _;
+          unfold cond;
           with vv. assert (refine vv);
           f vv _;
-          intro_cond_false (aspec 'i) (aspec ('i + 1));
           C.pack_cinv_vp #(exists* v. pts_to x v ** refine v) c;
+          fold (cond false (aspec 'i) (aspec ('i + 1)));
           false
         }
         else
         {
-          with p q. rewrite (cond b p q) as q;
+          unfold cond;
           C.pack_cinv_vp #(exists* v. pts_to x v ** refine v) c;
+          fold (cond true (aspec 'i) (aspec ('i + 1)));
           true
         }
       };

--- a/share/pulse/examples/dice/dpe/DPE.fst
+++ b/share/pulse/examples/dice/dpe/DPE.fst
@@ -872,19 +872,19 @@ fn destroy_ctxt (ctxt:context_t) (#repr:erased context_repr_t)
   {
     Engine_context c ->
     {
-      let uds = rewrite_context_perm_engine ctxt c;
+      let uds = rewrite_context_perm_engine c;
       unfold (engine_context_perm c uds);
       V.free c.uds;
     }
     L0_context c ->
     {
-      let r = rewrite_context_perm_l0 ctxt c;
+      let r = rewrite_context_perm_l0 c;
       unfold (l0_context_perm c r);
       V.free c.cdi;
     }
     L1_context c ->
     {
-      let r = rewrite_context_perm_l1 ctxt c;
+      let r = rewrite_context_perm_l1 c;
       unfold (l1_context_perm c r);
       V.free c.deviceID_pub;
       V.free c.aliasKey_priv;
@@ -918,10 +918,10 @@ fn derive_child_from_context
     Engine_context c -> {
       match record {
         Engine_record r -> {
-          let uds_bytes = rewrite_context_perm_engine context c;
+          let uds_bytes = rewrite_context_perm_engine c;
           unfold (engine_context_perm c uds_bytes);
 
-          let engine_record_repr = rewrite_record_perm_engine record r;
+          let engine_record_repr = rewrite_record_perm_engine r;
 
           let mut cdi = [| 0uy; dice_digest_len |];
 
@@ -974,11 +974,11 @@ fn derive_child_from_context
     L0_context c -> {
       match record {
         L0_record r -> {
-          let cr = rewrite_context_perm_l0 context c;
+          let cr = rewrite_context_perm_l0 c;
           unfold (l0_context_perm c cr);
           with s. assert (V.pts_to c.cdi s);
 
-          let r0 = rewrite_record_perm_l0 record r;
+          let r0 = rewrite_record_perm_l0 r;
           unfold (l0_record_perm r 1.0R r0);
 
           let deviceID_pub = V.alloc 0uy (SZ.uint_to_t 32);
@@ -1259,7 +1259,7 @@ fn certify_key (sid:sid_t)
             0ul
           } else {
             let r = rewrite_session_state_related_available (L1_context c) s t;
-            let r = rewrite_context_perm_l1 (L1_context c) c;
+            let r = rewrite_context_perm_l1 c;
             unfold (l1_context_perm c r);
 
             V.to_array_pts_to c.aliasKey_pub;
@@ -1331,7 +1331,7 @@ fn sign (sid:sid_t)
       match hc.context {
         L1_context c -> {
           let r = rewrite_session_state_related_available (L1_context c) s t;
-          let r = rewrite_context_perm_l1 (L1_context c) c;
+          let r = rewrite_context_perm_l1 c;
           unfold (l1_context_perm c r);
 
           V.to_array_pts_to c.aliasKey_priv;

--- a/share/pulse/examples/dice/dpe/DPETypes.fsti
+++ b/share/pulse/examples/dice/dpe/DPETypes.fsti
@@ -321,21 +321,19 @@ fn intro_context_and_repr_tag_related (c:context_t) (r:context_repr_t)
 
 ```pulse
 ghost
-fn rewrite_context_perm_engine (c:context_t) (ec:engine_context_t) (#r:context_repr_t)
-  requires context_perm c r **
-           pure (c == Engine_context ec)
+fn rewrite_context_perm_engine (ec:engine_context_t) (#r:context_repr_t)
+  requires context_perm (Engine_context ec) r
   returns uds:Ghost.erased (Seq.seq U8.t)
   ensures engine_context_perm ec uds ** pure (r == Engine_context_repr uds)
 {
   match r {
     Engine_context_repr uds -> {
-      rewrite (context_perm c r) as
-              (engine_context_perm ec uds);
+      unfold context_perm;
       hide uds
     }
     _ -> {
       assume_ (pure (~ (Engine_context_repr? r)));
-      rewrite (context_perm c r) as
+      rewrite (context_perm (Engine_context ec) r) as
               (pure False);
       unreachable ()
 
@@ -346,21 +344,19 @@ fn rewrite_context_perm_engine (c:context_t) (ec:engine_context_t) (#r:context_r
 
 ```pulse
 ghost
-fn rewrite_context_perm_l0 (c:context_t) (lc:l0_context_t) (#r:context_repr_t)
-  requires context_perm c r **
-           pure (c == L0_context lc)
+fn rewrite_context_perm_l0 (lc:l0_context_t) (#r:context_repr_t)
+  requires context_perm (L0_context lc) r
   returns lrepr:Ghost.erased l0_context_repr_t
   ensures l0_context_perm lc lrepr ** pure (r == L0_context_repr lrepr)
 {
   match r {
     L0_context_repr lrepr -> {
-      rewrite (context_perm c r) as
-              (l0_context_perm lc lrepr);
+      unfold context_perm;
       hide lrepr
     }
     _ -> {
       assume_ (pure (~ (L0_context_repr? r)));
-      rewrite (context_perm c r) as
+      rewrite (context_perm (L0_context lc) r) as
               (pure False);
       unreachable ()
     }
@@ -370,21 +366,19 @@ fn rewrite_context_perm_l0 (c:context_t) (lc:l0_context_t) (#r:context_repr_t)
 
 ```pulse
 ghost
-fn rewrite_context_perm_l1 (c:context_t) (lc:l1_context_t) (#r:context_repr_t)
-  requires context_perm c r **
-           pure (c == L1_context lc)
+fn rewrite_context_perm_l1 (lc:l1_context_t) (#r:context_repr_t)
+  requires context_perm (L1_context lc) r
   returns lrepr:Ghost.erased l1_context_repr_t
   ensures l1_context_perm lc lrepr ** pure (r == L1_context_repr lrepr)
 {
   match r {
     L1_context_repr lrepr -> {
-      rewrite (context_perm c r) as
-              (l1_context_perm lc lrepr);
+      unfold context_perm;
       hide lrepr
     }
     _ -> {
       assume_ (pure (~ (L1_context_repr? r)));
-      rewrite (context_perm c r) as
+      rewrite (context_perm (L1_context lc) r) as
               (pure False);
       unreachable ()
     }
@@ -433,21 +427,19 @@ fn intro_record_and_repr_tag_related (r:record_t) (p:perm) (repr:repr_t)
 
 ```pulse
 ghost
-fn rewrite_record_perm_engine (r:record_t) (er:engine_record_t) (#p:perm) (#repr:repr_t)
-  requires record_perm r p repr **
-           pure (r == Engine_record er)
+fn rewrite_record_perm_engine (er:engine_record_t) (#p:perm) (#repr:repr_t)
+  requires record_perm (Engine_record er) p repr
   returns erepr:Ghost.erased engine_record_repr
   ensures engine_record_perm er p erepr ** pure (repr == Engine_repr erepr)
 {
   match repr {
     Engine_repr erepr -> {
-      rewrite (record_perm r p repr)
-          as  (engine_record_perm er p erepr);
+      unfold record_perm;
       hide erepr
     }
     L0_repr _ -> {
-      rewrite (record_perm r p repr)
-          as  (pure False);
+      rewrite record_perm (Engine_record er) p repr
+           as pure False;
       unreachable ()
     }
   }
@@ -456,21 +448,19 @@ fn rewrite_record_perm_engine (r:record_t) (er:engine_record_t) (#p:perm) (#repr
 
 ```pulse
 ghost
-fn rewrite_record_perm_l0 (r:record_t) (lr:l0_record_t) (#p:perm) (#repr:repr_t)
-  requires record_perm r p repr **
-           pure (r == L0_record lr)
+fn rewrite_record_perm_l0 (lr:l0_record_t) (#p:perm) (#repr:repr_t)
+  requires record_perm (L0_record lr) p repr
   returns r0:Ghost.erased l0_record_repr_t
   ensures l0_record_perm lr p r0 ** pure (repr == L0_repr r0)
 {
   match repr {
     Engine_repr _ -> {
-      rewrite (record_perm r p repr)
-          as  (pure False);
+      rewrite record_perm (L0_record lr) p repr
+           as pure False;
       unreachable ()
     }
     L0_repr r0 -> {
-      rewrite (record_perm r p repr)
-          as  (l0_record_perm lr p r0);
+      unfold record_perm;
       hide r0
     }
   }

--- a/src/checker/Pulse.Checker.If.fst
+++ b/src/checker/Pulse.Checker.If.fst
@@ -64,6 +64,18 @@ let check
         hyp 
         (mk_eq2 u0 tm_bool b eq_v)
     in
+
+    let br = {
+        term =
+          Tm_ProofHintWithBinders {
+            binders = [];
+            hint_type = RENAME { pairs = [(b, eq_v)]; goal=None; tac_opt=None; };
+            t = br;
+          };
+        range = br.range;
+        effect_tag = br.effect_tag;
+      }
+    in
     
     let (| br, c, d |) =
       let ppname = mk_ppname_no_range "_if_br" in

--- a/src/checker/Pulse.Checker.Match.fst
+++ b/src/checker/Pulse.Checker.Match.fst
@@ -245,9 +245,22 @@ let check_branch
   if (R.Tv_Unknown? (R.inspect_ln (fst (Some?.v elab_p)))) then
     fail g (Some e.range) "should not happen: pattern elaborated to Tv_Unknown";
   // T.print ("Elaborated pattern = " ^ T.term_to_string (fst (Some?.v elab_p)));
-  let eq_typ = mk_sq_eq2 sc_u sc_ty sc (wr (fst (Some?.v elab_p)) Range.range_0) in
+  let elab_p_tm = fst (Some?.v elab_p) in
+  let eq_typ = mk_sq_eq2 sc_u sc_ty sc (wr elab_p_tm Range.range_0) in
   let g' = push_binding g' hyp_var ({name = Sealed.seal "branch equality"; range = Range.range_0 }) eq_typ in
   let e = open_st_term_bs e pulse_bs in
+  let e =
+    {
+      term =
+        Tm_ProofHintWithBinders {
+          binders = [];
+          hint_type = RENAME { pairs = [(sc, elab_p_tm)]; goal=None; tac_opt=None; };
+          t = e;
+        };
+      range = e.range;
+      effect_tag = e.effect_tag;
+    }
+  in
   let pre_typing = tot_typing_weakening_n pulse_bs pre_typing in // weaken w/ binders
   let pre_typing = Pulse.Typing.Metatheory.tot_typing_weakening_single pre_typing hyp_var eq_typ in // weaken w/ branch eq
 

--- a/src/ocaml/plugin/generated/Pulse_Checker_If.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_If.ml
@@ -31,7 +31,7 @@ let (check :
                          (Obj.magic
                             (FStar_Range.mk_range "Pulse.Checker.If.fst"
                                (Prims.of_int (45)) (Prims.of_int (64))
-                               (Prims.of_int (92)) (Prims.of_int (43)))))
+                               (Prims.of_int (104)) (Prims.of_int (43)))))
                       (FStar_Tactics_Effect.lift_div_tac
                          (fun uu___ ->
                             Pulse_Typing_Env.push_context g "check_if"
@@ -54,7 +54,7 @@ let (check :
                                           "Pulse.Checker.If.fst"
                                           (Prims.of_int (45))
                                           (Prims.of_int (64))
-                                          (Prims.of_int (92))
+                                          (Prims.of_int (104))
                                           (Prims.of_int (43)))))
                                  (Obj.magic
                                     (Pulse_Checker_Pure.check_tot_term g1 b
@@ -79,7 +79,7 @@ let (check :
                                                          "Pulse.Checker.If.fst"
                                                          (Prims.of_int (50))
                                                          (Prims.of_int (30))
-                                                         (Prims.of_int (92))
+                                                         (Prims.of_int (104))
                                                          (Prims.of_int (43)))))
                                                 (FStar_Tactics_Effect.lift_div_tac
                                                    (fun uu___1 ->
@@ -102,7 +102,7 @@ let (check :
                                                                     "Pulse.Checker.If.fst"
                                                                     (Prims.of_int (51))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (104))
                                                                     (Prims.of_int (43)))))
                                                            (FStar_Tactics_Effect.lift_div_tac
                                                               (fun uu___1 ->
@@ -126,7 +126,7 @@ let (check :
                                                                     "Pulse.Checker.If.fst"
                                                                     (Prims.of_int (54))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (104))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -154,15 +154,15 @@ let (check :
                                                                     "Pulse.Checker.If.fst"
                                                                     (Prims.of_int (59))
                                                                     (Prims.of_int (47))
-                                                                    (Prims.of_int (79))
+                                                                    (Prims.of_int (91))
                                                                     (Prims.of_int (23)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (80))
-                                                                    (Prims.of_int (4))
                                                                     (Prims.of_int (92))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (104))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -188,7 +188,7 @@ let (check :
                                                                     "Pulse.Checker.If.fst"
                                                                     (Prims.of_int (60))
                                                                     (Prims.of_int (37))
-                                                                    (Prims.of_int (79))
+                                                                    (Prims.of_int (91))
                                                                     (Prims.of_int (23)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -216,7 +216,7 @@ let (check :
                                                                     "Pulse.Checker.If.fst"
                                                                     (Prims.of_int (66))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (79))
+                                                                    (Prims.of_int (91))
                                                                     (Prims.of_int (23)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -233,17 +233,75 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (68))
+                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (76))
+                                                                    (Prims.of_int (35)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.If.fst"
+                                                                    (Prims.of_int (78))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (91))
+                                                                    (Prims.of_int (23)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    {
+                                                                    Pulse_Syntax_Base.term1
+                                                                    =
+                                                                    (Pulse_Syntax_Base.Tm_ProofHintWithBinders
+                                                                    {
+                                                                    Pulse_Syntax_Base.hint_type
+                                                                    =
+                                                                    (Pulse_Syntax_Base.RENAME
+                                                                    {
+                                                                    Pulse_Syntax_Base.pairs
+                                                                    =
+                                                                    [
+                                                                    (b1,
+                                                                    eq_v)];
+                                                                    Pulse_Syntax_Base.goal
+                                                                    =
+                                                                    FStar_Pervasives_Native.None;
+                                                                    Pulse_Syntax_Base.tac_opt
+                                                                    =
+                                                                    FStar_Pervasives_Native.None
+                                                                    });
+                                                                    Pulse_Syntax_Base.binders
+                                                                    = [];
+                                                                    Pulse_Syntax_Base.t
+                                                                    = br
+                                                                    });
+                                                                    Pulse_Syntax_Base.range1
+                                                                    =
+                                                                    (br.Pulse_Syntax_Base.range1);
+                                                                    Pulse_Syntax_Base.effect_tag
+                                                                    =
+                                                                    (br.Pulse_Syntax_Base.effect_tag)
+                                                                    }))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun br1
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.If.fst"
+                                                                    (Prims.of_int (80))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (72))
+                                                                    (Prims.of_int (84))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (78))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (79))
+                                                                    (Prims.of_int (91))
                                                                     (Prims.of_int (23)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -251,17 +309,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (69))
+                                                                    (Prims.of_int (81))
                                                                     (Prims.of_int (49))
-                                                                    (Prims.of_int (72))
+                                                                    (Prims.of_int (84))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -278,17 +336,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (71))
+                                                                    (Prims.of_int (83))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (72))
+                                                                    (Prims.of_int (84))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (72))
+                                                                    (Prims.of_int (84))
                                                                     (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (check1
@@ -296,7 +354,8 @@ let (check :
                                                                     pre ()
                                                                     (FStar_Pervasives_Native.Some
                                                                     post_hint)
-                                                                    ppname br))
+                                                                    ppname
+                                                                    br1))
                                                                     (fun
                                                                     uu___2 ->
                                                                     (fun r ->
@@ -316,7 +375,7 @@ let (check :
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives.Mkdtuple3
-                                                                    (br1, c,
+                                                                    (br2, c,
                                                                     d) ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -324,17 +383,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (74))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (74))
+                                                                    (Prims.of_int (86))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (76))
+                                                                    (Prims.of_int (88))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (79))
+                                                                    (Prims.of_int (91))
                                                                     (Prims.of_int (23)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -354,14 +413,14 @@ let (check :
                                                                     FStar_Set.mem
                                                                     hyp
                                                                     (Pulse_Syntax_Naming.freevars_st
-                                                                    br1)
+                                                                    br2)
                                                                     then
                                                                     Obj.magic
                                                                     (Obj.repr
                                                                     (Pulse_Typing_Env.fail
                                                                     g1
                                                                     (FStar_Pervasives_Native.Some
-                                                                    (br1.Pulse_Syntax_Base.range1))
+                                                                    (br2.Pulse_Syntax_Base.range1))
                                                                     (Prims.strcat
                                                                     "check_if: branch hypothesis is in freevars of checked "
                                                                     (Prims.strcat
@@ -374,9 +433,10 @@ let (check :
                                                                     (fun
                                                                     uu___4 ->
                                                                     FStar_Pervasives.Mkdtuple3
-                                                                    (br1, c,
+                                                                    (br2, c,
                                                                     d)))))
                                                                     uu___3)))
+                                                                    uu___2)))
                                                                     uu___2)))
                                                                     uu___2)))
                                                                     uu___2)))
@@ -391,17 +451,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (94))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (94))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (80))
-                                                                    (Prims.of_int (4))
                                                                     (Prims.of_int (92))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (104))
                                                                     (Prims.of_int (43)))))
                                                                     (Obj.magic
                                                                     (check_branch
@@ -424,17 +484,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (83))
+                                                                    (Prims.of_int (95))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (83))
+                                                                    (Prims.of_int (95))
                                                                     (Prims.of_int (62)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (82))
+                                                                    (Prims.of_int (94))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (104))
                                                                     (Prims.of_int (43)))))
                                                                     (Obj.magic
                                                                     (check_branch
@@ -457,17 +517,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (85))
+                                                                    (Prims.of_int (97))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (85))
+                                                                    (Prims.of_int (97))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (83))
+                                                                    (Prims.of_int (95))
                                                                     (Prims.of_int (65))
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (104))
                                                                     (Prims.of_int (43)))))
                                                                     (Obj.magic
                                                                     (Pulse_JoinComp.join_comps
@@ -498,17 +558,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (87))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (87))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (87))
+                                                                    (Prims.of_int (99))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (104))
                                                                     (Prims.of_int (43)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.comp_typing_from_post_hint
@@ -525,17 +585,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (102))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (90))
+                                                                    (Prims.of_int (102))
                                                                     (Prims.of_int (78)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.If.fst"
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (104))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (104))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun

--- a/src/ocaml/plugin/generated/Pulse_Checker_Match.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Match.ml
@@ -412,7 +412,7 @@ let (check_branch :
                                 (FStar_Range.mk_range
                                    "Pulse.Checker.Match.fst"
                                    (Prims.of_int (236)) (Prims.of_int (27))
-                                   (Prims.of_int (259)) (Prims.of_int (58)))))
+                                   (Prims.of_int (272)) (Prims.of_int (58)))))
                           (match readback_pat p0 with
                            | FStar_Pervasives_Native.Some p ->
                                Obj.magic
@@ -444,7 +444,7 @@ let (check_branch :
                                               "Pulse.Checker.Match.fst"
                                               (Prims.of_int (239))
                                               (Prims.of_int (54))
-                                              (Prims.of_int (259))
+                                              (Prims.of_int (272))
                                               (Prims.of_int (58)))))
                                      (FStar_Tactics_Effect.lift_div_tac
                                         (fun uu___ ->
@@ -468,7 +468,7 @@ let (check_branch :
                                                          "Pulse.Checker.Match.fst"
                                                          (Prims.of_int (240))
                                                          (Prims.of_int (38))
-                                                         (Prims.of_int (259))
+                                                         (Prims.of_int (272))
                                                          (Prims.of_int (58)))))
                                                 (FStar_Tactics_Effect.lift_div_tac
                                                    (fun uu___ ->
@@ -492,7 +492,7 @@ let (check_branch :
                                                                     "Pulse.Checker.Match.fst"
                                                                     (Prims.of_int (241))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (58)))))
                                                            (FStar_Tactics_Effect.lift_div_tac
                                                               (fun uu___ ->
@@ -516,7 +516,7 @@ let (check_branch :
                                                                     "Pulse.Checker.Match.fst"
                                                                     (Prims.of_int (243))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -543,7 +543,7 @@ let (check_branch :
                                                                     "Pulse.Checker.Match.fst"
                                                                     (Prims.of_int (245))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (58)))))
                                                                     (if
                                                                     Prims.op_Negation
@@ -584,7 +584,7 @@ let (check_branch :
                                                                     "Pulse.Checker.Match.fst"
                                                                     (Prims.of_int (246))
                                                                     (Prims.of_int (80))
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (58)))))
                                                                     (if
                                                                     FStar_Reflection_V2_Data.uu___is_Tv_Unknown
@@ -618,16 +618,45 @@ let (check_branch :
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
                                                                     (Prims.of_int (248))
-                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (18))
                                                                     (Prims.of_int (248))
-                                                                    (Prims.of_int (80)))))
+                                                                    (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
                                                                     (Prims.of_int (248))
-                                                                    (Prims.of_int (83))
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (41))
+                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (58)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Pervasives_Native.fst
+                                                                    (FStar_Pervasives_Native.__proj__Some__item__v
+                                                                    elab_p)))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun
+                                                                    elab_p_tm
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Match.fst"
+                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (67)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Match.fst"
+                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (70))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -636,9 +665,7 @@ let (check_branch :
                                                                     sc_u
                                                                     sc_ty sc
                                                                     (Pulse_Syntax_Pure.wr
-                                                                    (FStar_Pervasives_Native.fst
-                                                                    (FStar_Pervasives_Native.__proj__Some__item__v
-                                                                    elab_p))
+                                                                    elab_p_tm
                                                                     FStar_Range.range_0)))
                                                                     (fun
                                                                     uu___2 ->
@@ -650,17 +677,17 @@ let (check_branch :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (106)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (109))
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -687,17 +714,17 @@ let (check_branch :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (39))
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -715,17 +742,75 @@ let (check_branch :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (32)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Match.fst"
+                                                                    (Prims.of_int (263))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (58)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    {
+                                                                    Pulse_Syntax_Base.term1
+                                                                    =
+                                                                    (Pulse_Syntax_Base.Tm_ProofHintWithBinders
+                                                                    {
+                                                                    Pulse_Syntax_Base.hint_type
+                                                                    =
+                                                                    (Pulse_Syntax_Base.RENAME
+                                                                    {
+                                                                    Pulse_Syntax_Base.pairs
+                                                                    =
+                                                                    [
+                                                                    (sc,
+                                                                    elab_p_tm)];
+                                                                    Pulse_Syntax_Base.goal
+                                                                    =
+                                                                    FStar_Pervasives_Native.None;
+                                                                    Pulse_Syntax_Base.tac_opt
+                                                                    =
+                                                                    FStar_Pervasives_Native.None
+                                                                    });
+                                                                    Pulse_Syntax_Base.binders
+                                                                    = [];
+                                                                    Pulse_Syntax_Base.t
+                                                                    = e1
+                                                                    });
+                                                                    Pulse_Syntax_Base.range1
+                                                                    =
+                                                                    (e1.Pulse_Syntax_Base.range1);
+                                                                    Pulse_Syntax_Base.effect_tag
+                                                                    =
+                                                                    (e1.Pulse_Syntax_Base.effect_tag)
+                                                                    }))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun e2
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Match.fst"
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (64))
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -742,17 +827,17 @@ let (check_branch :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (265))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (265))
                                                                     (Prims.of_int (96)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (265))
                                                                     (Prims.of_int (99))
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -769,17 +854,17 @@ let (check_branch :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (270))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (265))
                                                                     (Prims.of_int (99))
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -787,17 +872,17 @@ let (check_branch :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (268))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (268))
                                                                     (Prims.of_int (41)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (268))
                                                                     (Prims.of_int (44))
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (270))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -814,17 +899,17 @@ let (check_branch :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (256))
+                                                                    (Prims.of_int (269))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (256))
+                                                                    (Prims.of_int (269))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (270))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (270))
                                                                     (Prims.of_int (35)))))
                                                                     (Obj.magic
                                                                     (check
@@ -832,7 +917,7 @@ let (check_branch :
                                                                     ()
                                                                     (FStar_Pervasives_Native.Some
                                                                     post_hint)
-                                                                    ppname e1))
+                                                                    ppname e2))
                                                                     (fun
                                                                     uu___2 ->
                                                                     (fun r ->
@@ -852,12 +937,12 @@ let (check_branch :
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives.Mkdtuple3
-                                                                    (e2, c,
+                                                                    (e3, c,
                                                                     e_d) ->
                                                                     FStar_Pervasives.Mkdtuple4
                                                                     (p,
                                                                     (Pulse_Syntax_Naming.close_st_term_n
-                                                                    e2
+                                                                    e3
                                                                     (FStar_List_Tot_Base.map
                                                                     FStar_Pervasives_Native.fst
                                                                     pulse_bs)),
@@ -866,11 +951,13 @@ let (check_branch :
                                                                     (g, sc_u,
                                                                     sc_ty,
                                                                     sc, c, p,
-                                                                    e2, bs,
+                                                                    e3, bs,
                                                                     (), (),
                                                                     (),
                                                                     hyp_var,
                                                                     e_d)))))))
+                                                                    uu___2)))
+                                                                    uu___2)))
                                                                     uu___2)))
                                                                     uu___2)))
                                                                     uu___2)))
@@ -916,13 +1003,13 @@ let (check_branches_aux :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "Pulse.Checker.Match.fst"
-                                 (Prims.of_int (288)) (Prims.of_int (2))
-                                 (Prims.of_int (288)) (Prims.of_int (50)))))
+                                 (Prims.of_int (301)) (Prims.of_int (2))
+                                 (Prims.of_int (301)) (Prims.of_int (50)))))
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "Pulse.Checker.Match.fst"
-                                 (Prims.of_int (288)) (Prims.of_int (51))
-                                 (Prims.of_int (298)) (Prims.of_int (3)))))
+                                 (Prims.of_int (301)) (Prims.of_int (51))
+                                 (Prims.of_int (311)) (Prims.of_int (3)))))
                         (if FStar_List_Tot_Base.isEmpty brs0
                          then
                            Obj.magic
@@ -942,17 +1029,17 @@ let (check_branches_aux :
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Checker.Match.fst"
-                                            (Prims.of_int (291))
+                                            (Prims.of_int (304))
                                             (Prims.of_int (5))
-                                            (Prims.of_int (294))
+                                            (Prims.of_int (307))
                                             (Prims.of_int (23)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Checker.Match.fst"
-                                            (Prims.of_int (295))
+                                            (Prims.of_int (308))
                                             (Prims.of_int (4))
-                                            (Prims.of_int (298))
+                                            (Prims.of_int (311))
                                             (Prims.of_int (3)))))
                                    (FStar_Tactics_Effect.lift_div_tac
                                       (fun uu___1 ->
@@ -963,17 +1050,17 @@ let (check_branches_aux :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Match.fst"
-                                                        (Prims.of_int (291))
+                                                        (Prims.of_int (304))
                                                         (Prims.of_int (19))
-                                                        (Prims.of_int (291))
+                                                        (Prims.of_int (304))
                                                         (Prims.of_int (20)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Match.fst"
-                                                        (Prims.of_int (291))
+                                                        (Prims.of_int (304))
                                                         (Prims.of_int (5))
-                                                        (Prims.of_int (294))
+                                                        (Prims.of_int (307))
                                                         (Prims.of_int (23)))))
                                                (FStar_Tactics_Effect.lift_div_tac
                                                   (fun uu___2 -> b))
@@ -988,18 +1075,18 @@ let (check_branches_aux :
                                                                     (
                                                                     FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (23)))))
                                                               (FStar_Sealed.seal
                                                                  (Obj.magic
                                                                     (
                                                                     FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (291))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (23)))))
                                                               (FStar_Tactics_Effect.lift_div_tac
                                                                  (fun uu___4
@@ -1018,17 +1105,17 @@ let (check_branches_aux :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (95)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (307))
                                                                     (Prims.of_int (23)))))
                                                                     (Obj.magic
                                                                     (check_branch
@@ -1062,17 +1149,17 @@ let (check_branches_aux :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.Match.fst"
-                                                       (Prims.of_int (296))
+                                                       (Prims.of_int (309))
                                                        (Prims.of_int (10))
-                                                       (Prims.of_int (296))
+                                                       (Prims.of_int (309))
                                                        (Prims.of_int (31)))))
                                               (FStar_Sealed.seal
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "Pulse.Checker.Match.fst"
-                                                       (Prims.of_int (296))
+                                                       (Prims.of_int (309))
                                                        (Prims.of_int (6))
-                                                       (Prims.of_int (296))
+                                                       (Prims.of_int (309))
                                                        (Prims.of_int (7)))))
                                               (Obj.magic
                                                  (Pulse_Common.zipWith tr1
@@ -1117,13 +1204,13 @@ let (weaken_branch_observability :
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "Pulse.Checker.Match.fst"
-                               (Prims.of_int (317)) (Prims.of_int (29))
-                               (Prims.of_int (317)) (Prims.of_int (39)))))
+                               (Prims.of_int (330)) (Prims.of_int (29))
+                               (Prims.of_int (330)) (Prims.of_int (39)))))
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "Pulse.Checker.Match.fst"
-                               (Prims.of_int (317)) Prims.int_one
-                               (Prims.of_int (326)) (Prims.of_int (3)))))
+                               (Prims.of_int (330)) Prims.int_one
+                               (Prims.of_int (339)) (Prims.of_int (3)))))
                       (FStar_Tactics_Effect.lift_div_tac
                          (fun uu___ -> checked_br))
                       (fun uu___ ->
@@ -1136,17 +1223,17 @@ let (weaken_branch_observability :
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.Match.fst"
-                                              (Prims.of_int (318))
+                                              (Prims.of_int (331))
                                               (Prims.of_int (29))
-                                              (Prims.of_int (318))
+                                              (Prims.of_int (331))
                                               (Prims.of_int (31)))))
                                      (FStar_Sealed.seal
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Checker.Match.fst"
-                                              (Prims.of_int (317))
+                                              (Prims.of_int (330))
                                               (Prims.of_int (42))
-                                              (Prims.of_int (326))
+                                              (Prims.of_int (339))
                                               (Prims.of_int (3)))))
                                      (FStar_Tactics_Effect.lift_div_tac
                                         (fun uu___1 -> c0))
@@ -1308,17 +1395,17 @@ let (join_branches :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Match.fst"
-                                                        (Prims.of_int (350))
+                                                        (Prims.of_int (363))
                                                         (Prims.of_int (25))
-                                                        (Prims.of_int (350))
+                                                        (Prims.of_int (363))
                                                         (Prims.of_int (35)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Match.fst"
-                                                        (Prims.of_int (349))
+                                                        (Prims.of_int (362))
                                                         (Prims.of_int (23))
-                                                        (Prims.of_int (366))
+                                                        (Prims.of_int (379))
                                                         (Prims.of_int (26)))))
                                                (FStar_Tactics_Effect.lift_div_tac
                                                   (fun uu___1 -> checked_br))
@@ -1388,17 +1475,17 @@ let (join_branches :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (363))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (68))
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (379))
                                                                     (Prims.of_int (26)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1418,17 +1505,17 @@ let (join_branches :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (364))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (364))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (364))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (379))
                                                                     (Prims.of_int (26)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1447,17 +1534,17 @@ let (join_branches :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (365))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (365))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (81)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (379))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (379))
                                                                     (Prims.of_int (26)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Util.map
@@ -1516,13 +1603,13 @@ let (check_branches :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "Pulse.Checker.Match.fst"
-                                 (Prims.of_int (382)) (Prims.of_int (20))
-                                 (Prims.of_int (382)) (Prims.of_int (95)))))
+                                 (Prims.of_int (395)) (Prims.of_int (20))
+                                 (Prims.of_int (395)) (Prims.of_int (95)))))
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "Pulse.Checker.Match.fst"
-                                 (Prims.of_int (382)) (Prims.of_int (98))
-                                 (Prims.of_int (395)) (Prims.of_int (18)))))
+                                 (Prims.of_int (395)) (Prims.of_int (98))
+                                 (Prims.of_int (408)) (Prims.of_int (18)))))
                         (Obj.magic
                            (check_branches_aux g pre () post_hint check sc_u
                               sc_ty sc brs0 bnds))
@@ -1534,17 +1621,17 @@ let (check_branches :
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Checker.Match.fst"
-                                            (Prims.of_int (383))
+                                            (Prims.of_int (396))
                                             (Prims.of_int (30))
-                                            (Prims.of_int (383))
+                                            (Prims.of_int (396))
                                             (Prims.of_int (58)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Checker.Match.fst"
-                                            (Prims.of_int (382))
-                                            (Prims.of_int (98))
                                             (Prims.of_int (395))
+                                            (Prims.of_int (98))
+                                            (Prims.of_int (408))
                                             (Prims.of_int (18)))))
                                    (Obj.magic
                                       (join_branches g pre post_hint sc_u
@@ -1599,13 +1686,13 @@ let (check :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Match.fst"
-                             (Prims.of_int (409)) (Prims.of_int (10))
-                             (Prims.of_int (409)) (Prims.of_int (64)))))
+                             (Prims.of_int (422)) (Prims.of_int (10))
+                             (Prims.of_int (422)) (Prims.of_int (64)))))
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Match.fst"
-                             (Prims.of_int (411)) (Prims.of_int (2))
-                             (Prims.of_int (461)) (Prims.of_int (55)))))
+                             (Prims.of_int (424)) (Prims.of_int (2))
+                             (Prims.of_int (474)) (Prims.of_int (55)))))
                     (FStar_Tactics_Effect.lift_div_tac
                        (fun uu___ ->
                           Pulse_Typing_Env.push_context_no_range g
@@ -1618,17 +1705,17 @@ let (check :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.Match.fst"
-                                        (Prims.of_int (411))
+                                        (Prims.of_int (424))
                                         (Prims.of_int (2))
-                                        (Prims.of_int (412))
+                                        (Prims.of_int (425))
                                         (Prims.of_int (85)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.Match.fst"
-                                        (Prims.of_int (412))
+                                        (Prims.of_int (425))
                                         (Prims.of_int (86))
-                                        (Prims.of_int (461))
+                                        (Prims.of_int (474))
                                         (Prims.of_int (55)))))
                                (if
                                   Pulse_Syntax_Base.uu___is_EffectAnnotAtomicOrGhost
@@ -1652,17 +1739,17 @@ let (check :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Match.fst"
-                                                   (Prims.of_int (414))
+                                                   (Prims.of_int (427))
                                                    (Prims.of_int (17))
-                                                   (Prims.of_int (414))
+                                                   (Prims.of_int (427))
                                                    (Prims.of_int (52)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "Pulse.Checker.Match.fst"
-                                                   (Prims.of_int (414))
+                                                   (Prims.of_int (427))
                                                    (Prims.of_int (55))
-                                                   (Prims.of_int (461))
+                                                   (Prims.of_int (474))
                                                    (Prims.of_int (55)))))
                                           (FStar_Tactics_Effect.lift_div_tac
                                              (fun uu___1 ->
@@ -1676,17 +1763,17 @@ let (check :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Match.fst"
-                                                              (Prims.of_int (415))
+                                                              (Prims.of_int (428))
                                                               (Prims.of_int (17))
-                                                              (Prims.of_int (415))
+                                                              (Prims.of_int (428))
                                                               (Prims.of_int (20)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Match.fst"
-                                                              (Prims.of_int (415))
+                                                              (Prims.of_int (428))
                                                               (Prims.of_int (23))
-                                                              (Prims.of_int (461))
+                                                              (Prims.of_int (474))
                                                               (Prims.of_int (55)))))
                                                      (FStar_Tactics_Effect.lift_div_tac
                                                         (fun uu___1 -> brs))
@@ -1698,17 +1785,17 @@ let (check :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (416))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (416))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (24)))))
                                                                 (FStar_Sealed.seal
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (416))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (55)))))
                                                                 (FStar_Tactics_Effect.lift_div_tac
                                                                    (fun
@@ -1725,17 +1812,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (431))
                                                                     (Prims.of_int (55))
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (431))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (416))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (55)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Pure.compute_tot_term_type_and_u
@@ -1760,17 +1847,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (419))
+                                                                    (Prims.of_int (432))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (419))
+                                                                    (Prims.of_int (432))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (424))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1791,17 +1878,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (431))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (434))
+                                                                    (Prims.of_int (447))
                                                                     (Prims.of_int (75)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (424))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (55)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1809,17 +1896,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (431))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (431))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (64)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (431))
+                                                                    (Prims.of_int (444))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (434))
+                                                                    (Prims.of_int (447))
                                                                     (Prims.of_int (75)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.check_match_complete
@@ -1885,17 +1972,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (435))
+                                                                    (Prims.of_int (448))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (435))
+                                                                    (Prims.of_int (448))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1911,17 +1998,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (436))
+                                                                    (Prims.of_int (449))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (436))
+                                                                    (Prims.of_int (449))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1940,17 +2027,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (437))
+                                                                    (Prims.of_int (450))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (438))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (438))
+                                                                    (Prims.of_int (451))
                                                                     (Prims.of_int (61))
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (55)))))
                                                                     (if
                                                                     FStar_Pervasives_Native.uu___is_None
@@ -1980,17 +2067,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (439))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (439))
+                                                                    (Prims.of_int (452))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (452))
+                                                                    (Prims.of_int (465))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (55)))))
                                                                     (Obj.magic
                                                                     (Pulse_Common.zipWith
@@ -2026,17 +2113,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (455))
+                                                                    (Prims.of_int (468))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (455))
+                                                                    (Prims.of_int (468))
                                                                     (Prims.of_int (92)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (452))
+                                                                    (Prims.of_int (465))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (55)))))
                                                                     (Obj.magic
                                                                     (check_branches
@@ -2065,17 +2152,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (459))
+                                                                    (Prims.of_int (472))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (459))
+                                                                    (Prims.of_int (472))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (459))
+                                                                    (Prims.of_int (472))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (55)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.comp_typing_from_post_hint
@@ -2092,17 +2179,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (473))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (460))
+                                                                    (Prims.of_int (473))
                                                                     (Prims.of_int (92)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Match.fst"
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun


### PR DESCRIPTION
A very common step after a `match e { Foo a1 .. an -> { .. } }` is to rewrite `e` in the context to `Foo a1 .. an`. This patch makes this happen automatically.

This is not exactly backwards compatible, see for instance the patches to PulseTutorial.Conditionals. For DPE, I tweaked some rewrite lemmas which seemed to be working around the fact that the context is not automatically rewritten, I think it's a bit simpler now.

If the behavior seems fine I can probably simplify some more code. 