### PR TITLE
Normalize context for with_inv detection

### DIFF
--- a/share/pulse/examples/Invariant.fst
+++ b/share/pulse/examples/Invariant.fst
@@ -273,3 +273,26 @@ fn test_returns1 (i:iname)
   fold folded_inv i
 }
 ```
+
+(* Testing that the with_invariants checker respects
+pulse_unfold. *)
+
+[@@pulse_unfold]
+let pp = p
+
+```pulse
+ghost
+fn test_returns2 (i:iname)
+  requires folded_inv i
+  ensures folded_inv i ** q
+  opens [i]
+{
+  unfold folded_inv i;
+  with_invariants i
+    returns _:unit
+    ensures pp ** q {
+    ghost_p_to_q ()
+  };
+  fold folded_inv i
+}
+```

--- a/src/ocaml/plugin/generated/Pulse_Checker_WithInv.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_WithInv.ml
@@ -477,7 +477,7 @@ let (find_inv_post :
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.WithInv.fst"
                              (Prims.of_int (172)) (Prims.of_int (60))
-                             (Prims.of_int (180)) (Prims.of_int (71)))))
+                             (Prims.of_int (183)) (Prims.of_int (114)))))
                     (FStar_Tactics_Effect.lift_div_tac
                        (fun uu___ ->
                           Pulse_Syntax_Naming.open_term_nv post
@@ -490,90 +490,131 @@ let (find_inv_post :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.WithInv.fst"
-                                        (Prims.of_int (173))
-                                        (Prims.of_int (12))
-                                        (Prims.of_int (173))
-                                        (Prims.of_int (50)))))
+                                        (Prims.of_int (174))
+                                        (Prims.of_int (4))
+                                        (Prims.of_int (174))
+                                        (Prims.of_int (95)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Checker.WithInv.fst"
-                                        (Prims.of_int (174))
-                                        (Prims.of_int (2))
-                                        (Prims.of_int (180))
-                                        (Prims.of_int (71)))))
+                                        (Prims.of_int (172))
+                                        (Prims.of_int (60))
+                                        (Prims.of_int (183))
+                                        (Prims.of_int (114)))))
                                (Obj.magic
-                                  (find_inv
+                                  (Pulse_Checker_Prover.normalize_slprop_welltyped
                                      (Pulse_Typing_Env.push_binding g x
                                         Pulse_Syntax_Base.ppname_default
-                                        ret_ty) post_opened () i))
+                                        ret_ty) post_opened ()))
                                (fun uu___ ->
-                                  (fun res ->
-                                     match res with
-                                     | FStar_Pervasives_Native.None ->
-                                         Obj.magic
-                                           (Obj.repr
-                                              (FStar_Tactics_Effect.lift_div_tac
-                                                 (fun uu___ ->
-                                                    FStar_Pervasives_Native.None)))
-                                     | FStar_Pervasives_Native.Some
-                                         (FStar_Pervasives.Mkdtuple5
-                                         (p, frame, inv_typing, frame_typing,
-                                          d_eq))
+                                  (fun uu___ ->
+                                     match uu___ with
+                                     | FStar_Pervasives.Mkdtuple3
+                                         (post_opened1, post_equiv,
+                                          post_typing1)
                                          ->
                                          Obj.magic
-                                           (Obj.repr
-                                              (FStar_Tactics_Effect.tac_bind
-                                                 (FStar_Sealed.seal
-                                                    (Obj.magic
-                                                       (FStar_Range.mk_range
-                                                          "Pulse.Checker.WithInv.fst"
-                                                          (Prims.of_int (177))
-                                                          (Prims.of_int (54))
-                                                          (Prims.of_int (177))
-                                                          (Prims.of_int (66)))))
-                                                 (FStar_Sealed.seal
-                                                    (Obj.magic
-                                                       (FStar_Range.mk_range
-                                                          "Pulse.Checker.WithInv.fst"
-                                                          (Prims.of_int (178))
-                                                          (Prims.of_int (55))
-                                                          (Prims.of_int (180))
-                                                          (Prims.of_int (71)))))
-                                                 (FStar_Tactics_Effect.lift_div_tac
-                                                    (fun uu___ -> ()))
-                                                 (fun uu___ ->
-                                                    (fun frame_typing1 ->
-                                                       Obj.magic
-                                                         (FStar_Tactics_Effect.tac_bind
-                                                            (FStar_Sealed.seal
-                                                               (Obj.magic
-                                                                  (FStar_Range.mk_range
-                                                                    "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (179))
-                                                                    (Prims.of_int (62))
-                                                                    (Prims.of_int (179))
-                                                                    (Prims.of_int (72)))))
-                                                            (FStar_Sealed.seal
-                                                               (Obj.magic
-                                                                  (FStar_Range.mk_range
+                                           (FStar_Tactics_Effect.tac_bind
+                                              (FStar_Sealed.seal
+                                                 (Obj.magic
+                                                    (FStar_Range.mk_range
+                                                       "Pulse.Checker.WithInv.fst"
+                                                       (Prims.of_int (176))
+                                                       (Prims.of_int (12))
+                                                       (Prims.of_int (176))
+                                                       (Prims.of_int (34)))))
+                                              (FStar_Sealed.seal
+                                                 (Obj.magic
+                                                    (FStar_Range.mk_range
+                                                       "Pulse.Checker.WithInv.fst"
+                                                       (Prims.of_int (177))
+                                                       (Prims.of_int (2))
+                                                       (Prims.of_int (183))
+                                                       (Prims.of_int (114)))))
+                                              (Obj.magic
+                                                 (find_inv
+                                                    (Pulse_Typing_Env.push_binding
+                                                       g x
+                                                       Pulse_Syntax_Base.ppname_default
+                                                       ret_ty) post_opened1
+                                                    () i))
+                                              (fun uu___1 ->
+                                                 (fun res ->
+                                                    match res with
+                                                    | FStar_Pervasives_Native.None
+                                                        ->
+                                                        Obj.magic
+                                                          (Obj.repr
+                                                             (FStar_Tactics_Effect.lift_div_tac
+                                                                (fun uu___1
+                                                                   ->
+                                                                   FStar_Pervasives_Native.None)))
+                                                    | FStar_Pervasives_Native.Some
+                                                        (FStar_Pervasives.Mkdtuple5
+                                                        (p, frame,
+                                                         inv_typing,
+                                                         frame_typing, d_eq))
+                                                        ->
+                                                        Obj.magic
+                                                          (Obj.repr
+                                                             (FStar_Tactics_Effect.tac_bind
+                                                                (FStar_Sealed.seal
+                                                                   (Obj.magic
+                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
                                                                     (Prims.of_int (180))
-                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (54))
                                                                     (Prims.of_int (180))
-                                                                    (Prims.of_int (71)))))
-                                                            (Obj.magic
-                                                               (recheck g
-                                                                  (Pulse_Syntax_Pure.tm_inv
-                                                                    i p)
-                                                                  Pulse_Syntax_Pure.tm_slprop
-                                                                  ()))
-                                                            (fun
-                                                               tm_inv_typing
-                                                               ->
-                                                               FStar_Tactics_Effect.lift_div_tac
-                                                                 (fun uu___
+                                                                    (Prims.of_int (66)))))
+                                                                (FStar_Sealed.seal
+                                                                   (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (55))
+                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (114)))))
+                                                                (FStar_Tactics_Effect.lift_div_tac
+                                                                   (fun
+                                                                    uu___1 ->
+                                                                    ()))
+                                                                (fun uu___1
+                                                                   ->
+                                                                   (fun
+                                                                    frame_typing1
                                                                     ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (62))
+                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (72)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (183))
+                                                                    (Prims.of_int (114)))))
+                                                                    (Obj.magic
+                                                                    (recheck
+                                                                    g
+                                                                    (Pulse_Syntax_Pure.tm_inv
+                                                                    i p)
+                                                                    Pulse_Syntax_Pure.tm_slprop
+                                                                    ()))
+                                                                    (fun
+                                                                    tm_inv_typing
+                                                                    ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
                                                                     FStar_Pervasives_Native.Some
                                                                     (FStar_Pervasives.Mkdtuple5
                                                                     (p,
@@ -581,8 +622,8 @@ let (find_inv_post :
                                                                     frame x),
                                                                     (), (),
                                                                     ()))))))
-                                                      uu___)))) uu___)))
-                         uu___)
+                                                                    uu___1))))
+                                                   uu___1))) uu___))) uu___)
 let (atomic_or_ghost_with_inames_and_pre_post :
   Pulse_Syntax_Base.comp ->
     Pulse_Syntax_Base.term ->
@@ -612,7 +653,7 @@ let (atomic_or_ghost_with_inames_and_pre_post :
                     Pulse_Syntax_Base.pre = pre;
                     Pulse_Syntax_Base.post = post
                   })
-let rec (withinv_post :
+let rec (__withinv_post :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.term ->
       Pulse_Syntax_Base.term ->
@@ -661,20 +702,20 @@ let rec (withinv_post :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.WithInv.fst"
-                                                         (Prims.of_int (213))
+                                                         (Prims.of_int (216))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (213))
-                                                         (Prims.of_int (72)))))
+                                                         (Prims.of_int (216))
+                                                         (Prims.of_int (74)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.WithInv.fst"
-                                                         (Prims.of_int (215))
+                                                         (Prims.of_int (218))
                                                          (Prims.of_int (11))
-                                                         (Prims.of_int (223))
+                                                         (Prims.of_int (226))
                                                          (Prims.of_int (16)))))
                                                 (Obj.magic
-                                                   (withinv_post g p i l ()
+                                                   (__withinv_post g p i l ()
                                                       () ()))
                                                 (fun uu___1 ->
                                                    (fun res ->
@@ -701,20 +742,20 @@ let rec (withinv_post :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (219))
+                                                                    (Prims.of_int (222))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (219))
-                                                                    (Prims.of_int (78)))))
+                                                                    (Prims.of_int (222))
+                                                                    (Prims.of_int (80)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (220))
+                                                                    (Prims.of_int (223))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (222))
+                                                                    (Prims.of_int (225))
                                                                     (Prims.of_int (29)))))
                                                                   (Obj.magic
-                                                                    (withinv_post
+                                                                    (__withinv_post
                                                                     g p i r
                                                                     () () ()))
                                                                   (fun res1
@@ -746,7 +787,73 @@ let rec (withinv_post :
                                                 (fun uu___2 ->
                                                    FStar_Pervasives_Native.None)))))
                   uu___6 uu___5 uu___4 uu___3 uu___2 uu___1 uu___
-let (check :
+let (withinv_post :
+  Pulse_Typing_Env.env ->
+    Pulse_Syntax_Base.term ->
+      Pulse_Syntax_Base.term ->
+        Pulse_Syntax_Base.term ->
+          unit ->
+            unit ->
+              unit ->
+                ((Pulse_Syntax_Base.term, unit) Prims.dtuple2
+                   FStar_Pervasives_Native.option,
+                  unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun g ->
+    fun p ->
+      fun i ->
+        fun post ->
+          fun p_typing ->
+            fun i_typing ->
+              fun post_typing ->
+                FStar_Tactics_Effect.tac_bind
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range "Pulse.Checker.WithInv.fst"
+                           (Prims.of_int (237)) (Prims.of_int (29))
+                           (Prims.of_int (237)) (Prims.of_int (75)))))
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range "Pulse.Checker.WithInv.fst"
+                           (Prims.of_int (236)) (Prims.of_int (51))
+                           (Prims.of_int (239)) (Prims.of_int (61)))))
+                  (Obj.magic
+                     (Pulse_Checker_Prover.normalize_slprop_welltyped g p ()))
+                  (fun uu___ ->
+                     (fun uu___ ->
+                        match uu___ with
+                        | FStar_Pervasives.Mkdtuple3 (p1, uu___1, p_typing1)
+                            ->
+                            Obj.magic
+                              (FStar_Tactics_Effect.tac_bind
+                                 (FStar_Sealed.seal
+                                    (Obj.magic
+                                       (FStar_Range.mk_range
+                                          "Pulse.Checker.WithInv.fst"
+                                          (Prims.of_int (238))
+                                          (Prims.of_int (35))
+                                          (Prims.of_int (238))
+                                          (Prims.of_int (87)))))
+                                 (FStar_Sealed.seal
+                                    (Obj.magic
+                                       (FStar_Range.mk_range
+                                          "Pulse.Checker.WithInv.fst"
+                                          (Prims.of_int (237))
+                                          (Prims.of_int (78))
+                                          (Prims.of_int (239))
+                                          (Prims.of_int (61)))))
+                                 (Obj.magic
+                                    (Pulse_Checker_Prover.normalize_slprop_welltyped
+                                       g post ()))
+                                 (fun uu___2 ->
+                                    (fun uu___2 ->
+                                       match uu___2 with
+                                       | FStar_Pervasives.Mkdtuple3
+                                           (post1, uu___3, post_typing1) ->
+                                           Obj.magic
+                                             (__withinv_post g p1 i post1 ()
+                                                () ())) uu___2))) uu___)
+let (check0 :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.term ->
       unit ->
@@ -763,18 +870,18 @@ let (check :
         fun post_hint ->
           fun res_ppname ->
             fun t ->
-              fun check1 ->
+              fun check ->
                 FStar_Tactics_Effect.tac_bind
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.WithInv.fst"
-                           (Prims.of_int (238)) (Prims.of_int (47))
-                           (Prims.of_int (238)) (Prims.of_int (53)))))
+                           (Prims.of_int (252)) (Prims.of_int (47))
+                           (Prims.of_int (252)) (Prims.of_int (53)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.WithInv.fst"
-                           (Prims.of_int (238)) Prims.int_one
-                           (Prims.of_int (466)) (Prims.of_int (57)))))
+                           (Prims.of_int (252)) Prims.int_one
+                           (Prims.of_int (481)) (Prims.of_int (57)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ -> t.Pulse_Syntax_Base.term1))
                   (fun uu___ ->
@@ -791,17 +898,17 @@ let (check :
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Checker.WithInv.fst"
-                                          (Prims.of_int (239))
+                                          (Prims.of_int (253))
                                           (Prims.of_int (19))
-                                          (Prims.of_int (239))
+                                          (Prims.of_int (253))
                                           (Prims.of_int (46)))))
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Checker.WithInv.fst"
-                                          (Prims.of_int (238))
+                                          (Prims.of_int (252))
                                           (Prims.of_int (56))
-                                          (Prims.of_int (466))
+                                          (Prims.of_int (481))
                                           (Prims.of_int (57)))))
                                  (Obj.magic
                                     (Pulse_Checker_Pure.check_tot_term g i
@@ -816,17 +923,17 @@ let (check :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.WithInv.fst"
-                                                         (Prims.of_int (240))
+                                                         (Prims.of_int (254))
                                                          (Prims.of_int (16))
-                                                         (Prims.of_int (240))
+                                                         (Prims.of_int (254))
                                                          (Prims.of_int (50)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.WithInv.fst"
-                                                         (Prims.of_int (240))
+                                                         (Prims.of_int (254))
                                                          (Prims.of_int (53))
-                                                         (Prims.of_int (466))
+                                                         (Prims.of_int (481))
                                                          (Prims.of_int (57)))))
                                                 (FStar_Tactics_Effect.lift_div_tac
                                                    (fun uu___3 ->
@@ -840,17 +947,17 @@ let (check :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (33)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (256))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                            (Obj.magic
                                                               (find_inv g pre
@@ -863,17 +970,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (256))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (260))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (260))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (if
                                                                     FStar_Pervasives_Native.uu___is_None
@@ -886,17 +993,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (260))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (260))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -904,17 +1011,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (260))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -922,17 +1029,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -940,17 +1047,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (70))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (76)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -977,17 +1084,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -995,17 +1102,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1065,17 +1172,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (262))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (262))
                                                                     (Prims.of_int (72)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (260))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1102,17 +1209,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (268))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (313))
                                                                     (Prims.of_int (67)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (314))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (match 
                                                                     (returns_inv,
@@ -1141,17 +1248,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (281))
                                                                     (Prims.of_int (12)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (282))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (100)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Base.intro_post_hint
@@ -1175,17 +1282,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (269))
+                                                                    (Prims.of_int (283))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (269))
+                                                                    (Prims.of_int (283))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (269))
+                                                                    (Prims.of_int (283))
                                                                     (Prims.of_int (79))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (100)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1205,17 +1312,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (270))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (291))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (305))
                                                                     (Prims.of_int (100)))))
                                                                     (Obj.magic
                                                                     (withinv_post
@@ -1241,56 +1348,108 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (280))
-                                                                    (Prims.of_int (12))
-                                                                    (Prims.of_int (282))
-                                                                    (Prims.of_int (24)))))
+                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (297))
+                                                                    (Prims.of_int (11)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (279))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (282))
-                                                                    (Prims.of_int (24)))))
+                                                                    (Prims.of_int (297))
+                                                                    (Prims.of_int (11)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (282))
-                                                                    (Prims.of_int (15))
-                                                                    (Prims.of_int (282))
-                                                                    (Prims.of_int (23)))))
+                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
-                                                                    "prims.fst"
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (19))
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (31)))))
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (66))
+                                                                    (Prims.of_int (297))
+                                                                    (Prims.of_int (11)))))
                                                                     (Obj.magic
-                                                                    (Pulse_Show.show
-                                                                    Pulse_Show.tac_showable_r_term
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (20)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (66)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (20)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.WithInv.fst"
+                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (20)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.printable_term
                                                                     p))
                                                                     (fun
                                                                     uu___6 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___7 ->
-                                                                    Prims.strcat
-                                                                    "Cannot find invariant slprop "
-                                                                    (Prims.strcat
+                                                                    FStar_Pprint.prefix
+                                                                    (Prims.of_int (2))
+                                                                    Prims.int_one
+                                                                    (Pulse_PP.text
+                                                                    "Cannot find invariant slprop")
+                                                                    uu___6))))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    FStar_Pprint.op_Hat_Slash_Hat
                                                                     uu___6
-                                                                    " in the with_invariants annotated postcondition")))))
+                                                                    (Pulse_PP.text
+                                                                    "in the with_invariants annotated postcondition.")))))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    [uu___6]))))
                                                                     (fun
                                                                     uu___6 ->
                                                                     (fun
                                                                     uu___6 ->
                                                                     Obj.magic
-                                                                    (Pulse_Typing_Env.fail
+                                                                    (Pulse_Typing_Env.fail_doc
                                                                     g
                                                                     (FStar_Pervasives_Native.Some
                                                                     (FStar_Reflection_V1_Builtins.range_of_term
@@ -1356,17 +1515,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1374,17 +1533,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1392,17 +1551,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (310))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (310))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1410,17 +1569,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (310))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (310))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (310))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (310))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1447,17 +1606,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1465,17 +1624,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (60)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1483,17 +1642,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1567,17 +1726,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (317))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1594,17 +1753,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (304))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (304))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (304))
+                                                                    (Prims.of_int (319))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1623,17 +1782,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (326))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (326))
                                                                     (Prims.of_int (66)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (326))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1650,17 +1809,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (313))
+                                                                    (Prims.of_int (328))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (313))
+                                                                    (Prims.of_int (328))
                                                                     (Prims.of_int (17)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (314))
+                                                                    (Prims.of_int (329))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1676,17 +1835,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (315))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (64))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1705,17 +1864,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (332))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (332))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (332))
                                                                     (Prims.of_int (64))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (recheck
@@ -1735,17 +1894,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (322))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (322))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (323))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (recheck
@@ -1767,17 +1926,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (325))
+                                                                    (Prims.of_int (340))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (332))
+                                                                    (Prims.of_int (347))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (334))
+                                                                    (Prims.of_int (349))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (find_inv_post
@@ -1796,17 +1955,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (334))
+                                                                    (Prims.of_int (349))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (if
                                                                     FStar_Pervasives_Native.uu___is_None
@@ -1819,17 +1978,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1837,17 +1996,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (335))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1855,17 +2014,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (70)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1873,17 +2032,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (70))
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (76)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1910,17 +2069,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (70)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1928,17 +2087,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (70)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -1998,17 +2157,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (356))
                                                                     (Prims.of_int (76))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (356))
                                                                     (Prims.of_int (79)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2035,17 +2194,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (357))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (346))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (if
                                                                     Prims.op_Negation
@@ -2059,17 +2218,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (359))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (358))
                                                                     (Prims.of_int (7))
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2077,17 +2236,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (30))
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (359))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (Pulse_Show.show
@@ -2103,17 +2262,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (359))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (359))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2121,17 +2280,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (359))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (Pulse_Show.show
@@ -2149,17 +2308,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (359))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (359))
                                                                     (Prims.of_int (9))
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (40)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2167,9 +2326,9 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (345))
+                                                                    (Prims.of_int (360))
                                                                     (Prims.of_int (20)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2252,17 +2411,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2283,17 +2442,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (351))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (357))
+                                                                    (Prims.of_int (372))
                                                                     (Prims.of_int (73)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2354,17 +2513,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (358))
+                                                                    (Prims.of_int (373))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (358))
+                                                                    (Prims.of_int (373))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2383,17 +2542,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (359))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (359))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (359))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (46))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2413,17 +2572,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (361))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (368))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (368))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (58))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2483,17 +2642,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (386))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (386))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (374))
+                                                                    (Prims.of_int (389))
                                                                     (Prims.of_int (46))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2517,17 +2676,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (375))
+                                                                    (Prims.of_int (390))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (25)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2572,17 +2731,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (386))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (39))
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (384))
+                                                                    (Prims.of_int (399))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2590,17 +2749,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (402))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (402))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (402))
                                                                     (Prims.of_int (54))
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2619,20 +2778,20 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (78)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (35)))))
                                                                     (Obj.magic
-                                                                    (check1 g
+                                                                    (check g
                                                                     pre_body
                                                                     ()
                                                                     (FStar_Pervasives_Native.Some
@@ -2671,17 +2830,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (396))
+                                                                    (Prims.of_int (411))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (414))
                                                                     (Prims.of_int (18)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (414))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2705,17 +2864,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (401))
+                                                                    (Prims.of_int (416))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (401))
+                                                                    (Prims.of_int (416))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (401))
+                                                                    (Prims.of_int (416))
                                                                     (Prims.of_int (48))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (disjointness_remove_i_i
@@ -2732,17 +2891,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (403))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (11))
-                                                                    (Prims.of_int (403))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (90)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (403))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (93))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2773,17 +2932,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (404))
+                                                                    (Prims.of_int (419))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (443))
+                                                                    (Prims.of_int (458))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (445))
+                                                                    (Prims.of_int (460))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2893,17 +3052,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (450))
+                                                                    (Prims.of_int (465))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (450))
+                                                                    (Prims.of_int (465))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (451))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (add_remove_inverse
@@ -2920,17 +3079,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (453))
+                                                                    (Prims.of_int (468))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (459))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (451))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2985,17 +3144,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (459))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (459))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3014,17 +3173,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (476))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (476))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3064,17 +3223,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (450))
+                                                                    (Prims.of_int (465))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (450))
+                                                                    (Prims.of_int (465))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (451))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (add_remove_inverse
@@ -3091,17 +3250,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (453))
+                                                                    (Prims.of_int (468))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (459))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (451))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3156,17 +3315,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (459))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (459))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3185,17 +3344,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (476))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (476))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3235,17 +3394,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (450))
+                                                                    (Prims.of_int (465))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (450))
+                                                                    (Prims.of_int (465))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (451))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (add_remove_inverse
@@ -3262,17 +3421,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (453))
+                                                                    (Prims.of_int (468))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (459))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (451))
+                                                                    (Prims.of_int (466))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3327,17 +3486,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (459))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (459))
+                                                                    (Prims.of_int (474))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3356,17 +3515,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (476))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (461))
+                                                                    (Prims.of_int (476))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (462))
+                                                                    (Prims.of_int (477))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3405,17 +3564,17 @@ let (check :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (465))
+                                                                    (Prims.of_int (480))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (465))
+                                                                    (Prims.of_int (480))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.WithInv.fst"
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (466))
+                                                                    (Prims.of_int (481))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3477,3 +3636,86 @@ let (check :
                                                                 uu___3)))
                                                      uu___3))) uu___1)))
                        uu___)
+let (norm_and_check :
+  Pulse_Typing_Env.env ->
+    Pulse_Syntax_Base.term ->
+      unit ->
+        unit Pulse_Typing.post_hint_opt ->
+          Pulse_Syntax_Base.ppname ->
+            Pulse_Syntax_Base.st_term ->
+              Pulse_Checker_Base.check_t ->
+                ((unit, unit, unit) Pulse_Checker_Base.checker_result_t,
+                  unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun g ->
+    fun pre ->
+      fun pre_typing ->
+        fun post_hint ->
+          fun res_ppname ->
+            fun t ->
+              fun check ->
+                FStar_Tactics_Effect.tac_bind
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range "Pulse.Checker.WithInv.fst"
+                           (Prims.of_int (494)) (Prims.of_int (43))
+                           (Prims.of_int (494)) (Prims.of_int (93)))))
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range "Pulse.Checker.WithInv.fst"
+                           (Prims.of_int (494)) Prims.int_one
+                           (Prims.of_int (496)) (Prims.of_int (64)))))
+                  (Obj.magic
+                     (Pulse_Checker_Prover.normalize_slprop_welltyped g pre
+                        ()))
+                  (fun uu___ ->
+                     (fun uu___ ->
+                        match uu___ with
+                        | FStar_Pervasives.Mkdtuple3
+                            (pre', pre_equiv, pre'_typing) ->
+                            Obj.magic
+                              (FStar_Tactics_Effect.tac_bind
+                                 (FStar_Sealed.seal
+                                    (Obj.magic
+                                       (FStar_Range.mk_range
+                                          "Pulse.Checker.WithInv.fst"
+                                          (Prims.of_int (495))
+                                          (Prims.of_int (10))
+                                          (Prims.of_int (495))
+                                          (Prims.of_int (64)))))
+                                 (FStar_Sealed.seal
+                                    (Obj.magic
+                                       (FStar_Range.mk_range
+                                          "Pulse.Checker.WithInv.fst"
+                                          (Prims.of_int (496))
+                                          (Prims.of_int (2))
+                                          (Prims.of_int (496))
+                                          (Prims.of_int (64)))))
+                                 (Obj.magic
+                                    (check0 g pre' () post_hint res_ppname t
+                                       check))
+                                 (fun r ->
+                                    FStar_Tactics_Effect.lift_div_tac
+                                      (fun uu___1 ->
+                                         Pulse_Checker_Base.checker_result_t_equiv_ctxt
+                                           g pre' pre post_hint () r))))
+                       uu___)
+let (check :
+  Pulse_Typing_Env.env ->
+    Pulse_Syntax_Base.term ->
+      unit ->
+        unit Pulse_Typing.post_hint_opt ->
+          Pulse_Syntax_Base.ppname ->
+            Pulse_Syntax_Base.st_term ->
+              Pulse_Checker_Base.check_t ->
+                ((unit, unit, unit) Pulse_Checker_Base.checker_result_t,
+                  unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun g ->
+    fun pre ->
+      fun pre_typing ->
+        fun post_hint ->
+          fun res_ppname ->
+            fun t ->
+              fun check1 ->
+                norm_and_check g pre () post_hint res_ppname t check1


### PR DESCRIPTION
Prompted by Nik noticing we are not unfolding resources when checking a with_invariants block, where we need to find the resource associated with the invariant.

It is not kicking in by default since normalization of the context and goals happens only in the _prover_, not at every iteration of the _checker_. Maybe it should?

