### PR TITLE
Pulse.Lib.HashTable: prevent internal overflows by bounding size

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.HashTable.fsti
+++ b/lib/pulse/lib/Pulse.Lib.HashTable.fsti
@@ -46,7 +46,9 @@ let related #kt #vt (ht:ht_t kt vt) (pht:pht_t kt vt) : GTot prop =
 
 let models #kt #vt (ht:ht_t kt vt) (pht:pht_t kt vt) : slprop =
   V.pts_to ht.contents pht.repr.seq **
-  pure (related ht pht /\ V.is_full_vec ht.contents)
+  pure (related ht pht /\
+        V.is_full_vec ht.contents /\
+        SZ.fits (2 `op_Multiply` SZ.v ht.sz))
 
 val models_is_slprop2 #kt #vt (ht:ht_t kt vt) (pht:pht_t kt vt)
 : Lemma (is_slprop2 (models ht pht))
@@ -54,12 +56,16 @@ val models_is_slprop2 #kt #vt (ht:ht_t kt vt) (pht:pht_t kt vt)
 
 let pht_sz #k #v (pht:pht_t k v) : GTot pos = pht.repr.sz
 
+(* A hash table can be created as long as the size isn't too big.
+*Twice* the size must fit in a size_t, since this means
+overflow will not occur internally when traversing the table.
+We could probably relax this to just a fitting in a size_t. *)
 val alloc
   (#[@@@ Rust_generics_bounds ["Copy"; "PartialEq"; "Clone"]] k:eqtype)
   (#[@@@ Rust_generics_bounds ["Clone"]] v:Type0)
   (hashf:(k -> SZ.t)) (l:pos_us)
 : stt (ht_t k v)
-    (requires emp)
+    (requires pure (SZ.fits (2 `op_Multiply` SZ.v l)))
     (ensures fun ht -> exists* pht. models ht pht ** pure (pht == mk_init_pht hashf l))
 
 val dealloc
@@ -81,11 +87,11 @@ val lookup
   (#pht:erased (pht_t kt vt))
   (ht:ht_t kt vt)
   (k:kt)
-: stt (ht_t kt vt & bool & option SZ.t)
+: stt (ht_t kt vt & option SZ.t)
     (requires models ht pht)
     (ensures fun p ->
-       models (tfst p) pht ** 
-       pure (same_sz_and_hashf (tfst p) ht /\ (tsnd p ==> tthd p == PHT.lookup_index_us pht k)))
+       models (fst p) pht ** 
+       pure (same_sz_and_hashf (fst p) ht /\ (snd p == PHT.lookup_index_us pht k)))
 
 val replace
   (#[@@@ Rust_generics_bounds ["Copy"; "PartialEq"; "Clone"]] kt:eqtype)

--- a/pulse2rust/dpe/src/generated/dpe.rs
+++ b/pulse2rust/dpe/src/generated/dpe.rs
@@ -128,33 +128,28 @@ pub fn replace_session(
             if sid < ctr {
                 let ret = super::pulse_lib_hashtable::lookup((), tbl, sid);
                 let tbl1 = ret.0;
-                let b = ret.1;
-                let idx = ret.2;
-                if b {
-                    match idx {
-                        Some(mut idx1) => {
-                            let ret1 = super::pulse_lib_hashtable::replace(
-                                (),
-                                tbl1,
-                                idx1,
-                                sid,
-                                sst,
-                                (),
-                            );
-                            let tbl2 = ret1.0;
-                            let st1 = ret1.1;
-                            let s1 = super::dpe::st {
-                                st_ctr: ctr,
-                                st_tbl: tbl2,
-                            };
-                            *mg = Some(s1);
-                            std::mem::drop(mg);
-                            st1
-                        }
-                        None => panic!(),
+                let idx = ret.1;
+                match idx {
+                    Some(mut idx1) => {
+                        let ret1 = super::pulse_lib_hashtable::replace(
+                            (),
+                            tbl1,
+                            idx1,
+                            sid,
+                            sst,
+                            (),
+                        );
+                        let tbl2 = ret1.0;
+                        let st1 = ret1.1;
+                        let s1 = super::dpe::st {
+                            st_ctr: ctr,
+                            st_tbl: tbl2,
+                        };
+                        *mg = Some(s1);
+                        std::mem::drop(mg);
+                        st1
                     }
-                } else {
-                    panic!()
+                    None => panic!(),
                 }
             } else {
                 panic!()

--- a/pulse2rust/dpe/src/generated/pulse_lib_hashtable.rs
+++ b/pulse2rust/dpe/src/generated/pulse_lib_hashtable.rs
@@ -29,17 +29,6 @@ pub fn alloc<K: Copy + PartialEq + Clone, V: Clone>(
     let ht = super::pulse_lib_hashtable::mk_ht(l, hashf, contents);
     ht
 }
-pub fn sz_add(x: usize, y: usize) -> std::option::Option<usize> {
-    match x <= 0xffff {
-        true => {
-            match y <= 0xffff - x {
-                true => Some(x + y),
-                _ => None,
-            }
-        }
-        _ => None,
-    }
-}
 pub fn size_t_mod(x: usize, y: usize) -> usize {
     x % y
 }
@@ -47,86 +36,69 @@ pub fn lookup<KT: Copy + PartialEq + Clone, VT: Clone>(
     pht: (),
     ht: super::pulse_lib_hashtable_type::ht_t<KT, VT>,
     k: KT,
-) -> (super::pulse_lib_hashtable_type::ht_t<KT, VT>, bool, std::option::Option<usize>) {
+) -> (super::pulse_lib_hashtable_type::ht_t<KT, VT>, std::option::Option<usize>) {
     let hashf = ht.hashf;
     let mut contents = ht.contents;
     let cidx = super::pulse_lib_hashtable::size_t_mod(hashf(k), ht.sz);
     let mut off = 0;
     let mut cont = true;
-    let mut err = false;
     let mut ret = None;
     while {
         let voff = off;
         let vcont = cont;
-        let verr = err;
-        voff <= ht.sz && vcont == true && verr == false
+        voff <= ht.sz && vcont == true
     } {
         let voff = off;
         if voff == ht.sz {
             cont = false;
         } else {
-            let opt_sum = super::pulse_lib_hashtable::sz_add(cidx, voff);
-            match opt_sum {
-                Some(mut sum) => {
-                    let idx = super::pulse_lib_hashtable::size_t_mod(sum, ht.sz);
-                    let c = std::mem::replace::<
-                        super::pulse_lib_hashtable_spec::cell<KT, VT>,
-                    >(&mut contents[idx], super::pulse_lib_hashtable_spec::cell::Zombie);
-                    match c {
-                        super::pulse_lib_hashtable_spec::cell::Used(mut k_, mut v_) => {
-                            if k_ == k {
-                                cont = false;
-                                ret = Some(idx);
-                                let uu___2 = std::mem::replace::<
-                                    super::pulse_lib_hashtable_spec::cell<KT, VT>,
-                                >(
-                                    &mut contents[idx],
-                                    super::pulse_lib_hashtable_spec::cell::Used(k_, v_),
-                                );
-                            } else {
-                                off = voff + 1;
-                                let uu___1 = std::mem::replace::<
-                                    super::pulse_lib_hashtable_spec::cell<KT, VT>,
-                                >(
-                                    &mut contents[idx],
-                                    super::pulse_lib_hashtable_spec::cell::Used(k_, v_),
-                                );
-                            }
-                        }
-                        super::pulse_lib_hashtable_spec::cell::Clean => {
-                            cont = false;
-                            let uu___1 = std::mem::replace::<
-                                super::pulse_lib_hashtable_spec::cell<KT, VT>,
-                            >(&mut contents[idx], c);
-                        }
-                        super::pulse_lib_hashtable_spec::cell::Zombie => {
-                            off = voff + 1;
-                            let uu___1 = std::mem::replace::<
-                                super::pulse_lib_hashtable_spec::cell<KT, VT>,
-                            >(&mut contents[idx], c);
-                        }
+            let sum = cidx + voff;
+            let idx = super::pulse_lib_hashtable::size_t_mod(sum, ht.sz);
+            let c = std::mem::replace::<
+                super::pulse_lib_hashtable_spec::cell<KT, VT>,
+            >(&mut contents[idx], super::pulse_lib_hashtable_spec::cell::Zombie);
+            match c {
+                super::pulse_lib_hashtable_spec::cell::Used(mut k_, mut v_) => {
+                    if k_ == k {
+                        cont = false;
+                        ret = Some(idx);
+                        let uu___2 = std::mem::replace::<
+                            super::pulse_lib_hashtable_spec::cell<KT, VT>,
+                        >(
+                            &mut contents[idx],
+                            super::pulse_lib_hashtable_spec::cell::Used(k_, v_),
+                        );
+                    } else {
+                        off = voff + 1;
+                        let uu___1 = std::mem::replace::<
+                            super::pulse_lib_hashtable_spec::cell<KT, VT>,
+                        >(
+                            &mut contents[idx],
+                            super::pulse_lib_hashtable_spec::cell::Used(k_, v_),
+                        );
                     }
                 }
-                None => {
-                    err = true;
+                super::pulse_lib_hashtable_spec::cell::Clean => {
+                    cont = false;
+                    let uu___1 = std::mem::replace::<
+                        super::pulse_lib_hashtable_spec::cell<KT, VT>,
+                    >(&mut contents[idx], c);
+                }
+                super::pulse_lib_hashtable_spec::cell::Zombie => {
+                    off = voff + 1;
+                    let uu___1 = std::mem::replace::<
+                        super::pulse_lib_hashtable_spec::cell<KT, VT>,
+                    >(&mut contents[idx], c);
                 }
             }
         };
     }
-    let verr = err;
     let o = ret;
     let vcontents = contents;
     let ht1 = super::pulse_lib_hashtable::mk_ht(ht.sz, ht.hashf, vcontents);
-    let _bind_c = if verr {
-        let res = (ht1, false, o);
-        res
-    } else {
-        let res = (ht1, true, o);
-        res
-    };
-    let ret1 = _bind_c;
-    let err1 = ret1;
-    let cont1 = err1;
+    let res = (ht1, o);
+    let ret1 = res;
+    let cont1 = ret1;
     let off1 = cont1;
     let contents1 = off1;
     contents1
@@ -168,85 +140,70 @@ pub fn insert<KT: Copy + PartialEq + Clone, VT: Clone>(
     let cidx = super::pulse_lib_hashtable::size_t_mod(hashf(k), ht.sz);
     let mut off = 0;
     let mut cont = true;
-    let mut err = false;
     let mut idx = 0;
     while {
         let vcont = cont;
-        let verr = err;
-        vcont == true && verr == false
+        vcont == true
     } {
         let voff = off;
         if voff == ht.sz {
             panic!()
         } else {
-            let opt_sum = super::pulse_lib_hashtable::sz_add(cidx, voff);
-            match opt_sum {
-                Some(mut sum) => {
-                    let vidx = super::pulse_lib_hashtable::size_t_mod(sum, ht.sz);
-                    let c = std::mem::replace::<
-                        super::pulse_lib_hashtable_spec::cell<KT, VT>,
-                    >(
-                        &mut contents[vidx],
-                        super::pulse_lib_hashtable_spec::cell::Zombie,
-                    );
-                    match c {
-                        super::pulse_lib_hashtable_spec::cell::Used(mut k_, mut v_) => {
-                            if k_ == k {
-                                contents[vidx] = super::pulse_lib_hashtable_spec::cell::Used(
-                                    k_,
-                                    v_,
-                                );
-                                cont = false;
-                                idx = vidx;
-                            } else {
-                                contents[vidx] = super::pulse_lib_hashtable_spec::cell::Used(
-                                    k_,
-                                    v_,
-                                );
-                                off = voff + 1;
-                            }
-                        }
-                        super::pulse_lib_hashtable_spec::cell::Clean => {
-                            contents[vidx] = super::pulse_lib_hashtable_spec::cell::Clean;
+            let sum = cidx + voff;
+            let vidx = super::pulse_lib_hashtable::size_t_mod(sum, ht.sz);
+            let c = std::mem::replace::<
+                super::pulse_lib_hashtable_spec::cell<KT, VT>,
+            >(&mut contents[vidx], super::pulse_lib_hashtable_spec::cell::Zombie);
+            match c {
+                super::pulse_lib_hashtable_spec::cell::Used(mut k_, mut v_) => {
+                    if k_ == k {
+                        contents[vidx] = super::pulse_lib_hashtable_spec::cell::Used(
+                            k_,
+                            v_,
+                        );
+                        cont = false;
+                        idx = vidx;
+                    } else {
+                        contents[vidx] = super::pulse_lib_hashtable_spec::cell::Used(
+                            k_,
+                            v_,
+                        );
+                        off = voff + 1;
+                    }
+                }
+                super::pulse_lib_hashtable_spec::cell::Clean => {
+                    contents[vidx] = super::pulse_lib_hashtable_spec::cell::Clean;
+                    cont = false;
+                    idx = vidx;
+                }
+                super::pulse_lib_hashtable_spec::cell::Zombie => {
+                    let vcontents = contents;
+                    let ht1 = super::pulse_lib_hashtable_type::ht_t {
+                        sz: ht.sz,
+                        hashf: hashf,
+                        contents: vcontents,
+                    };
+                    let res = super::pulse_lib_hashtable::lookup((), ht1, k);
+                    contents = res.0.contents;
+                    let o = res.1;
+                    match o {
+                        Some(mut p) => {
+                            contents[p] = super::pulse_lib_hashtable_spec::cell::Zombie;
                             cont = false;
                             idx = vidx;
                         }
-                        super::pulse_lib_hashtable_spec::cell::Zombie => {
-                            let vcontents = contents;
-                            let ht1 = super::pulse_lib_hashtable_type::ht_t {
-                                sz: ht.sz,
-                                hashf: hashf,
-                                contents: vcontents,
-                            };
-                            let res = super::pulse_lib_hashtable::lookup((), ht1, k);
-                            contents = res.0.contents;
-                            if res.1 {
-                                let o = res.2;
-                                match o {
-                                    Some(mut p) => {
-                                        contents[p] = super::pulse_lib_hashtable_spec::cell::Zombie;
-                                        cont = false;
-                                        idx = vidx;
-                                    }
-                                    None => {
-                                        cont = false;
-                                        idx = vidx;
-                                    }
-                                }
-                            } else {
-                                err = true
-                            }
+                        None => {
+                            cont = false;
+                            idx = vidx;
                         }
                     }
                 }
-                None => err = true,
             }
         };
     }
     let vcont = cont;
-    let verr = err;
     let vidx = idx;
-    let _bind_c = if vcont == false && verr == false {
+    let _bind_c = if vcont == false {
         contents[vidx] = super::pulse_lib_hashtable::mk_used_cell(k, v);
         let vcontents = contents;
         let ht1 = super::pulse_lib_hashtable::mk_ht(ht.sz, hashf, vcontents);
@@ -259,8 +216,7 @@ pub fn insert<KT: Copy + PartialEq + Clone, VT: Clone>(
         res
     };
     let idx1 = _bind_c;
-    let err1 = idx1;
-    let cont1 = err1;
+    let cont1 = idx1;
     let off1 = cont1;
     let contents1 = off1;
     contents1


### PR DESCRIPTION
Internally, the hash table performs an addition of two SZ.t, which are then taken modulo the size of the table. Since the addition can overflow, the hash table was dynamically checking for an overflow (by checking that it the addition wouldn't surpass 0xffff, a lower bound for a max SZ.t) and handling overflows by returning an error code.

That is of course not ideal, especially since said overflows could really just be impossible (e.g. on a table of size 256).

This patch changes the interface to only allow creating tables with a size `l` such that `2*l` fits in a SZ.t, which prevents any possible overflow. With the SizeT module as it is now this means we can always create tables up to size 0x7fff, and larger ones by assuming `fits_u32` or `fits_u64`.

This simplifies the code somewhat too. It also removes some impossible branches from DPE.