### PR TITLE
Lib: removing uses of InvList

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.Stick.fst
+++ b/lib/pulse/lib/Pulse.Lib.Stick.fst
@@ -26,7 +26,7 @@ let emp_unit_left (p:slprop)
   = elim_slprop_equiv (slprop_equiv_unit p)
 
 (* This module is just a special case of trades. The tactic
-instantiates the implicit InvList to [] everywhere. We do not
+instantiates the implicit inames to emp_inames everywhere. We do not
 even need to use the Pulse checker for it. *)
 
 let stick (p q : slprop) =

--- a/lib/pulse/lib/pledge/Pulse.Lib.Pledge.fst
+++ b/lib/pulse/lib/pledge/Pulse.Lib.Pledge.fst
@@ -77,28 +77,6 @@ fn make_pledge
 
 ```pulse
 ghost
-fn make_pledge_invs
-  (is:invlist)
-  (f v extra:slprop)
-  (k:unit -> stt_ghost unit emp_inames (invlist_v is ** f ** extra) (fun _ -> invlist_v is ** f ** v))
-  requires invlist_inv is ** extra
-  ensures pledge (invlist_names is) f v
-{
-  ghost
-  fn aux ()
-    requires invlist_v is ** extra ** f
-    ensures invlist_v is ** (f ** v)
-  {
-    k ()
-  };
-  intro_trade_invs #is f (f ** v) extra aux;
-  fold ((==>*) #(invlist_names is) f (f ** v));
-  fold pledge
-}
-```
-
-```pulse
-ghost
 fn redeem_pledge (is:inames) (f v:slprop)
   requires f ** pledge is f v
   ensures f ** v

--- a/lib/pulse/lib/pledge/Pulse.Lib.Pledge.fsti
+++ b/lib/pulse/lib/pledge/Pulse.Lib.Pledge.fsti
@@ -17,7 +17,6 @@
 module Pulse.Lib.Pledge
 
 open Pulse.Lib.Pervasives
-open Pulse.Lib.InvList
 
 val pledge (is:inames) (f:slprop) (v:slprop) : slprop
 
@@ -42,10 +41,6 @@ val return_pledge (f v:slprop)
 val make_pledge (is:inames) (f:slprop) (v:slprop) (extra:slprop)
   (k:unit -> stt_ghost unit is (f ** extra) (fun _ -> f ** v))
   : stt_ghost unit emp_inames extra (fun _ -> pledge is f v)
-
-val make_pledge_invs (is:invlist) (f v extra:slprop)
-  (k:unit -> stt_ghost unit emp_inames (invlist_v is ** f ** extra) (fun _ -> invlist_v is ** f ** v))
-  : stt_ghost unit emp_inames (invlist_inv is ** extra) (fun _ -> pledge (invlist_names is) f v)
 
 val redeem_pledge (is:inames) (f v:slprop)
   : stt_ghost unit is (f ** pledge is f v) (fun () -> f ** v)

--- a/lib/pulse/lib/pledge/Pulse.Lib.SmallTrade.fsti
+++ b/lib/pulse/lib/pledge/Pulse.Lib.SmallTrade.fsti
@@ -17,51 +17,39 @@
 module Pulse.Lib.SmallTrade
 
 open Pulse.Lib.Core
-open Pulse.Lib.InvList
 
 module T = FStar.Tactics
 
 val trade :
-  (#[T.exact (`[])] is:invlist) ->
+  (#[T.exact (`[])] is:inames) ->
   (hyp:slprop) ->
   (concl:slprop) ->
   slprop
 
-val trade_is_slprop2 (#is:invlist) (hyp concl:slprop)
+val trade_is_slprop2 (#is:inames) (hyp concl:slprop)
   : Lemma (is_slprop2 (trade #is hyp concl))
 
 val intro_trade
-  (#is:invlist)
+  (#is:inames)
   (hyp concl:slprop)
   (extra:slprop { is_slprop2 extra })
   (f_elim:unit -> (
-    stt_ghost unit (invlist_names is)
-    (invlist_inv is ** extra ** hyp)
-    (fun _ -> invlist_inv is ** concl)
-  ))
-: stt_ghost unit emp_inames extra (fun _ -> trade #is hyp concl)
-
-val intro_trade_invs
-  (#is:invlist)
-  (hyp concl:slprop)
-  (extra:slprop { is_slprop2 extra })
-  (f_elim:unit -> (
-    stt_ghost unit emp_inames
-      (invlist_v is ** extra ** hyp)
-      (fun _ -> invlist_v is ** concl)
+    stt_ghost unit is
+    (extra ** hyp)
+    (fun _ -> concl)
   ))
 : stt_ghost unit emp_inames extra (fun _ -> trade #is hyp concl)
 
 val elim_trade
-  (#is:invlist)
+  (#is:inames)
   (hyp concl:slprop)
-: stt_ghost unit (invlist_names is)
-    (invlist_inv is ** trade #is hyp concl ** hyp)
-    (fun _ -> invlist_inv is ** concl)
+: stt_ghost unit is
+    (trade #is hyp concl ** hyp)
+    (fun _ -> concl)
 
 val trade_sub_inv
-  (#is1:invlist)
-  (#is2:invlist { invlist_sub is1 is2 })
+  (#is1:inames)
+  (#is2:inames { inames_subset is1 is2 })
   (hyp concl:slprop)
 : stt_ghost unit emp_inames
     (trade #is1 hyp concl)
@@ -70,7 +58,7 @@ val trade_sub_inv
 // Could weaken `f` to
 // (f : unit -> stt_ghost unit (invlist_names os) (invlist_inv os ** q) (fun _ -> invlist_inv os ** r))
 val trade_map
-  (#os : invlist)
+  (#os : inames)
   (p q r : slprop)
   (f : unit -> stt_ghost unit emp_inames q (fun _ -> r))
 : stt_ghost unit emp_inames
@@ -78,7 +66,7 @@ val trade_map
     (fun _ -> trade #os p r)
 
 val trade_compose
-  (#os : invlist)
+  (#os : inames)
   (p q r : slprop)
 : stt_ghost unit emp_inames
     (trade #os p q ** trade #os q r)

--- a/lib/pulse/lib/pledge/Pulse.Lib.Trade.fst
+++ b/lib/pulse/lib/pledge/Pulse.Lib.Trade.fst
@@ -17,7 +17,6 @@
 module Pulse.Lib.Trade
 
 open Pulse.Lib.Pervasives
-open Pulse.Lib.InvList
 
 module T = FStar.Tactics
 
@@ -49,40 +48,6 @@ fn __intro_trade
 }
 ```
 let intro_trade #is = __intro_trade #is
-
-```pulse
-ghost
-fn intro_trade_invs_aux
-  (#is:invlist)
-  (hyp concl extra:slprop)
-  (f_elim: unit -> (
-    stt_ghost unit emp_inames
-    (invlist_v is ** extra ** hyp)
-    (fun _ -> invlist_v is ** concl)
-  ))
-  requires invlist_inv is ** extra
-  ensures trade #(invlist_names is) hyp concl
-{
-  ghost
-  fn aux ()
-    requires ((invlist_inv is ** extra) ** hyp)
-    ensures concl
-    opens (invlist_names is)
-  {
-    ghost fn aux' ()
-      requires (invlist_v is ** (extra ** hyp))
-      ensures (invlist_v is ** concl)
-    {
-      f_elim ()
-    };
-    with_invlist is aux';
-    drop_ (invlist_inv _)
-  };
-  intro_trade #(invlist_names is) hyp concl (invlist_inv is ** extra) aux
-}
-```
-
-let intro_trade_invs #is = intro_trade_invs_aux #is
 
 let sqeq (p : Type) (_ : squash p) : erased p =
   FStar.IndefiniteDescription.elim_squash #p ()

--- a/lib/pulse/lib/pledge/Pulse.Lib.Trade.fsti
+++ b/lib/pulse/lib/pledge/Pulse.Lib.Trade.fsti
@@ -17,7 +17,6 @@
 module Pulse.Lib.Trade
 
 open Pulse.Lib.Core
-open Pulse.Lib.InvList
 
 module T = FStar.Tactics
 
@@ -46,18 +45,6 @@ val intro_trade
 : stt_ghost unit emp_inames
     extra
     (fun _ -> trade #is hyp concl)
-
-val intro_trade_invs
-  (#[T.exact (`[])] is:invlist)
-  (hyp concl extra:slprop)
-  (f_elim: unit -> (
-    stt_ghost unit emp_inames
-    (invlist_v is ** extra ** hyp)
-    (fun _ -> invlist_v is ** concl)
-  ))
-: stt_ghost unit emp_inames
-    (invlist_inv is ** extra)
-    (fun _ -> trade #(invlist_names is) hyp concl)
 
 val elim_trade
   (#[T.exact (`emp_inames)] is:inames)

--- a/share/pulse/examples/PledgeArith.fst
+++ b/share/pulse/examples/PledgeArith.fst
@@ -19,7 +19,6 @@ module PledgeArith
 (* automation wishlist for pledges *)
 
 open Pulse.Lib.Pervasives
-open Pulse.Lib.InvList
 module T = Pulse.Lib.Task
 open Pulse.Lib.Pledge
 

--- a/share/pulse/examples/Quicksort.Task.fst
+++ b/share/pulse/examples/Quicksort.Task.fst
@@ -22,8 +22,6 @@ module R = Pulse.Lib.Reference
 module SZ = FStar.SizeT
 module GSet = FStar.GhostSet
 
-open Pulse.Lib.InvList
-
 module T = Pulse.Lib.Task
 open Quicksort.Base
 open Pulse.Lib.Pledge
@@ -103,10 +101,10 @@ fn rec t_quicksort
 ```
 
 assume val split_pledge (#is:inames) (#f:slprop) (v1:slprop) (v2:slprop)
-  : stt_atomic (pi:invlist_elem { not (mem_inv is (snd pi)) })
+  : stt_atomic iname
                is
                (pledge is f (v1 ** v2))
-               (fun pi -> pledge (add_inv is (snd pi)) f v1 ** pledge (add_inv is (snd pi)) f v2)
+               (fun i -> pledge (add_inv is i) f v1 ** pledge (add_inv is i) f v2)
 
 ```pulse
 fn rec quicksort

--- a/share/pulse/examples/parix/ParallelFor.fst
+++ b/share/pulse/examples/parix/ParallelFor.fst
@@ -21,7 +21,6 @@ open Pulse.Lib.Fixpoints
 open Pulse.Lib.Task
 open FStar.Real
 open Pulse.Lib.Pledge
-open Pulse.Lib.InvList
 open Pulse.Lib.OnRange
 
 module P = Pulse.Lib.Pledge

--- a/share/pulse/examples/parix/Promises.Examples3.fst
+++ b/share/pulse/examples/parix/Promises.Examples3.fst
@@ -18,7 +18,6 @@ module Promises.Examples3
 
 open Pulse.Lib.Pervasives
 open Pulse.Lib.Pledge
-open Pulse.Lib.InvList
 module GR = Pulse.Lib.GhostReference
 
 assume val done : ref bool
@@ -113,8 +112,6 @@ fn proof
   }
 }
 ```
-
-let is (i:iname) : invlist = [(inv_p <: slprop), i]
 
 let cheat_proof (i:iname)
   : (_:unit) ->


### PR DESCRIPTION
Keeping the module for posterity, but not depending on it