### PR TITLE
Missing closing substitution in desugar; fix ranges when opening a variable

### DIFF
--- a/share/pulse/examples/bug-reports/error-messages/Bug.DesugaringError.fst
+++ b/share/pulse/examples/bug-reports/error-messages/Bug.DesugaringError.fst
@@ -19,3 +19,14 @@ ensures emp
 {
     ()
 }
+
+let id (#a:Type) (x y:a) = x
+
+[@@expect_failure]
+fn test3 (x:nat) (y:bool)
+requires emp
+returns z:nat
+ensures emp
+{
+    id x y
+}

--- a/share/pulse/examples/bug-reports/error-messages/Bug.DesugaringError.fst.expected
+++ b/share/pulse/examples/bug-reports/error-messages/Bug.DesugaringError.fst.expected
@@ -16,5 +16,14 @@
   - Identifier not found: [something]
 
 >>]
+>> Got issues: [
+* Error 189 at Bug.DesugaringError.fst(26,18-26,19):
+  - Expected expression of type Prims.nat got expression y of type Prims.bool
+  - Raised within Tactics.refl_instantiate_implicits
+
+* Error 228 at Bug.DesugaringError.fst(31,4-31,4):
+  - Could not check term: Bug.DesugaringError.id x y
+
+>>]
 Verified module: Bug.DesugaringError
 All verification conditions discharged successfully

--- a/share/pulse/examples/bug-reports/error-messages/Bug.DesugaringError.fst.expected
+++ b/share/pulse/examples/bug-reports/error-messages/Bug.DesugaringError.fst.expected
@@ -17,12 +17,12 @@
 
 >>]
 >> Got issues: [
-* Error 189 at Bug.DesugaringError.fst(26,18-26,19):
-  - Expected expression of type Prims.nat got expression y of type Prims.bool
-  - Raised within Tactics.refl_instantiate_implicits
-
 * Error 228 at Bug.DesugaringError.fst(31,4-31,4):
   - Could not check term: Bug.DesugaringError.id x y
+
+* Error 189 at Bug.DesugaringError.fst(31,9-31,10):
+  - Expected expression of type Prims.nat got expression y of type Prims.bool
+  - Raised within Tactics.refl_instantiate_implicits
 
 >>]
 Verified module: Bug.DesugaringError

--- a/src/checker/Pulse.Checker.Pure.fst
+++ b/src/checker/Pulse.Checker.Pure.fst
@@ -186,7 +186,7 @@ let maybe_fail_doc (issues:list FStar.Issue.issue)
   in
   if has_localized_error
   then let message = FStar.Stubs.Pprint.(pretty_string RU.float_one 80 (concat doc)) in
-       T.fail message (* Would be nice to tag this failure with the provided range *)
+       T.fail_at message (Some <| RU.start_of_range rng)
   else fail_doc g (Some rng) doc
 
 let instantiate_term_implicits (g:env) (t0:term) (expected:option typ) =
@@ -200,7 +200,7 @@ let instantiate_term_implicits (g:env) (t0:term) (expected:option typ) =
     let open Pulse.PP in
     maybe_fail_doc issues
          g rng [
-              prefix 4 1 (text "Could not infer implicit arguments in")
+              prefix 4 1 (text ("Could not check term:"))
                         (pp t0)
             ]
   )
@@ -210,8 +210,7 @@ let instantiate_term_implicits (g:env) (t0:term) (expected:option typ) =
       let open Pulse.PP in
       maybe_fail_doc []
         g rng [
-          prefix 4 1 (text "check_term: could not infer implicit arguments in")
-                        (pp t0)
+          prefix 4 1 (text "Could not check term:") (pp t0)
         ]
     else t, ty
 
@@ -226,7 +225,7 @@ let instantiate_term_implicits_uvs (g:env) (t0:term) =
     let open Pulse.PP in
     maybe_fail_doc issues
          g rng [
-              prefix 4 1 (text "Could not infer implicit arguments in")
+              prefix 4 1 (text "Could not check term:")
                         (pp t0)
             ]
   )

--- a/src/checker/Pulse.Main.fst
+++ b/src/checker/Pulse.Main.fst
@@ -288,7 +288,7 @@ let main t pre : RT.dsl_tac_t = fun (g, expected_t) ->
   res
 
 let check_pulse_core 
-        (as_decl: unit -> Dv (either Pulse.Syntax.decl (option (string & R.range))))
+        (as_decl: unit -> Tac (either Pulse.Syntax.decl (option (string & R.range))))
   : RT.dsl_tac_t
   = fun (env, expected_t) ->
       if ext_getv "pulse:dump_on_failure" <> "1" then

--- a/src/checker/Pulse.RuntimeUtils.fsti
+++ b/src/checker/Pulse.RuntimeUtils.fsti
@@ -31,6 +31,7 @@ val bv_range (x:bv) : range
 val binder_set_range (x:binder) (r:range) : b:binder{b==x}
 val binder_range (x:binder) : range
 val range_of_term (t:T.term) : range
+val start_of_range (r:range) : range
 val set_range (t:T.term) (r:range) : t':T.term{t == t'}
 val set_use_range (t:T.term) (r:range) : t':T.term{t == t'}
 val error_code_uninstantiated_variable (_:unit) : int

--- a/src/checker/Pulse.Syntax.Naming.fst
+++ b/src/checker/Pulse.Syntax.Naming.fst
@@ -27,7 +27,13 @@ module RU = Pulse.RuntimeUtils
 let r_subst_of_rt_subst_elt (x:subst_elt)
   : FStar.Reflection.V2.subst_elt
   = match x with
-    | RT.DT i t -> R2.DT i t
+    | RT.DT i t -> (
+      match R2.inspect_ln t with
+      //map (i->n) specially, to ensure that ranges on opened variables
+      //are assigned properly
+      | R2.Tv_Var n -> R2.DB i n
+      | _ -> R2.DT i t
+    )
     | RT.NT x t -> R2.NT (RT.var_as_namedv x) t
     | RT.ND x i -> R2.NM (RT.var_as_namedv x) i
 

--- a/src/checker/Pulse.Syntax.Naming.fsti
+++ b/src/checker/Pulse.Syntax.Naming.fsti
@@ -679,23 +679,17 @@ let close_term t v = close_term' t v 0
 let close_st_term t v = close_st_term' t v 0
 let close_comp t v = close_comp' t v 0
 
-let close_term_n t vs =
-  let rec aux (i:nat) (vs:list var) (t:term) : Tot term (decreases vs) =
+let close_n (x:'a) (f:'a -> var -> index -> 'a) (vs:list var) : 'a =
+  let rec aux (i:nat) (vs:list var) (x:'a) : Tot 'a (decreases vs) =
     match vs with
-    | [] -> t
-    | v::vs ->
-      aux (i+1) vs (close_term' t v i)
+    | [] -> x
+    | v::vs -> aux (i+1) vs (f x v i)
   in
-  aux 0 (List.rev vs) t
+  aux 0 (List.rev vs) x
 
-let close_st_term_n t vs =
-  let rec aux (i:nat) (vs:list var) (t:st_term) : Tot st_term (decreases vs) =
-    match vs with
-    | [] -> t
-    | v::vs ->
-      aux (i+1) vs (close_st_term' t v i)
-  in
-  aux 0 (List.rev vs) t
+let close_term_n t vs = close_n t close_term' vs
+let close_st_term_n t vs = close_n t close_st_term' vs
+let close_comp_n (c:comp) vs : comp = close_n c close_comp' vs
 
 val close_open_inverse' (t:term) 
                         (x:var { ~(x `Set.mem` freevars t) } )

--- a/src/ocaml/plugin/PulseSyntaxExtension_SyntaxWrapper.ml
+++ b/src/ocaml/plugin/PulseSyntaxExtension_SyntaxWrapper.ml
@@ -186,6 +186,7 @@ let close_term t v = Pulse_Syntax_Naming.close_term t v
 let close_st_term t v = Pulse_Syntax_Naming.close_st_term t v
 let close_st_term_n t v = Pulse_Syntax_Naming.close_st_term_n t v
 let close_comp t v = Pulse_Syntax_Naming.close_comp t v
+let close_comp_n t v = Pulse_Syntax_Naming.close_comp_n t v
 let comp_pre c =
   match c with
    | C_ST st

--- a/src/ocaml/plugin/Pulse_RuntimeUtils.ml
+++ b/src/ocaml/plugin/Pulse_RuntimeUtils.ml
@@ -52,7 +52,10 @@ let bv_range (bv:FStar_Syntax_Syntax.bv) = FStar_Syntax_Syntax.range_of_bv bv
 let binder_set_range (b:FStar_Syntax_Syntax.binder) (r:FStar_Range.range) =
     { b with FStar_Syntax_Syntax.binder_bv = (bv_set_range b.FStar_Syntax_Syntax.binder_bv r) }
 let binder_range (b:FStar_Syntax_Syntax.binder) = bv_range b.FStar_Syntax_Syntax.binder_bv
-let set_range (t:FStar_Syntax_Syntax.term) (r:FStar_Range.range) = { t with FStar_Syntax_Syntax.pos = r}
+let start_of_range (r:FStar_Range.range) =
+  let open FStar_Compiler_Range in
+  mk_range (file_of_range r) (start_of_range r) (start_of_range r)
+  let set_range (t:FStar_Syntax_Syntax.term) (r:FStar_Range.range) = { t with FStar_Syntax_Syntax.pos = r}
 let set_use_range (t:FStar_Syntax_Syntax.term) (r:FStar_Range.range) = FStar_Syntax_Subst.set_use_range r t
 let error_code_uninstantiated_variable () = FStar_Errors.errno FStar_Errors_Codes.Error_UninstantiatedUnificationVarInTactic
 let is_range_zero (r:FStar_Range.range) = r = FStar_Range.range_0

--- a/src/ocaml/plugin/generated/PulseSyntaxExtension_Desugar.ml
+++ b/src/ocaml/plugin/generated/PulseSyntaxExtension_Desugar.ml
@@ -2,6 +2,28 @@ open Prims
 type error =
   (Prims.string * FStar_Compiler_Range_Type.range)
     FStar_Pervasives_Native.option
+let (close_st_term_bvs :
+  PulseSyntaxExtension_SyntaxWrapper.st_term ->
+    PulseSyntaxExtension_SyntaxWrapper.bv Prims.list ->
+      PulseSyntaxExtension_SyntaxWrapper.st_term)
+  =
+  fun e ->
+    fun xs ->
+      let uu___ =
+        FStar_Compiler_List.map
+          PulseSyntaxExtension_SyntaxWrapper.index_of_bv xs in
+      PulseSyntaxExtension_SyntaxWrapper.close_st_term_n e uu___
+let (close_comp_bvs :
+  PulseSyntaxExtension_SyntaxWrapper.comp ->
+    PulseSyntaxExtension_SyntaxWrapper.bv Prims.list ->
+      PulseSyntaxExtension_SyntaxWrapper.comp)
+  =
+  fun e ->
+    fun xs ->
+      let uu___ =
+        FStar_Compiler_List.map
+          PulseSyntaxExtension_SyntaxWrapper.index_of_bv xs in
+      PulseSyntaxExtension_SyntaxWrapper.close_comp_n e uu___
 let rec fold_right1 : 'a . ('a -> 'a -> 'a) -> 'a Prims.list -> 'a =
   fun f ->
     fun l ->
@@ -3027,6 +3049,12 @@ and (desugar_decl :
                                                   (PulseSyntaxExtension_Err.return
                                                      uu___4)) uu___4)))
                                 uu___1))) uu___3 uu___2 uu___1 uu___ in
+           let close_st_term_binders qbs body =
+             let bvs =
+               FStar_List_Tot_Base.map
+                 (fun uu___ -> match uu___ with | (uu___1, uu___2, b) -> b)
+                 qbs in
+             close_st_term_bvs body bvs in
            match d with
            | PulseSyntaxExtension_Sugar.FnDefn
                { PulseSyntaxExtension_Sugar.id2 = id;
@@ -3259,6 +3287,10 @@ and (desugar_decl :
                                                                     let qbs =
                                                                     Obj.magic
                                                                     qbs in
+                                                                    let body3
+                                                                    =
+                                                                    close_st_term_binders
+                                                                    qbs body2 in
                                                                     let uu___12
                                                                     =
                                                                     PulseSyntaxExtension_SyntaxWrapper.fn_defn
@@ -3266,7 +3298,7 @@ and (desugar_decl :
                                                                     is_rec
                                                                     qbs comp
                                                                     meas
-                                                                    body2 in
+                                                                    body3 in
                                                                     Obj.magic
                                                                     (PulseSyntaxExtension_Err.return
                                                                     uu___12))
@@ -3358,13 +3390,16 @@ and (desugar_decl :
                                                                let qbs =
                                                                  Obj.magic
                                                                    qbs in
+                                                               let body2 =
+                                                                 close_st_term_binders
+                                                                   qbs body1 in
                                                                let uu___6 =
                                                                  PulseSyntaxExtension_SyntaxWrapper.fn_defn
                                                                    range id
                                                                    false qbs
                                                                    comp
                                                                    FStar_Pervasives_Native.None
-                                                                   body1 in
+                                                                   body2 in
                                                                Obj.magic
                                                                  (PulseSyntaxExtension_Err.return
                                                                     uu___6))
@@ -3407,9 +3442,18 @@ and (desugar_decl :
                                               (fun uu___5 ->
                                                  (fun qbs ->
                                                     let qbs = Obj.magic qbs in
+                                                    let comp1 =
+                                                      close_comp_bvs comp
+                                                        (FStar_List_Tot_Base.map
+                                                           (fun uu___5 ->
+                                                              match uu___5
+                                                              with
+                                                              | (uu___6,
+                                                                 uu___7, bv)
+                                                                  -> bv) qbs) in
                                                     let uu___5 =
                                                       PulseSyntaxExtension_SyntaxWrapper.fn_decl
-                                                        range id qbs comp in
+                                                        range id qbs comp1 in
                                                     Obj.magic
                                                       (PulseSyntaxExtension_Err.return
                                                          uu___5)) uu___5)))

--- a/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
@@ -2380,7 +2380,7 @@ let maybe_fail_doc :
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
                                   (Prims.of_int (189)) (Prims.of_int (7))
-                                  (Prims.of_int (189)) (Prims.of_int (21)))))
+                                  (Prims.of_int (189)) (Prims.of_int (56)))))
                          (FStar_Tactics_Effect.lift_div_tac
                             (fun uu___ ->
                                FStar_Pprint.pretty_string
@@ -2388,7 +2388,9 @@ let maybe_fail_doc :
                                  (Prims.of_int (80))
                                  (FStar_Pprint.concat doc)))
                          (fun message ->
-                            FStar_Tactics_V2_Derived.fail message))
+                            FStar_Tactics_V2_Derived.fail_at message
+                              (FStar_Pervasives_Native.Some
+                                 (Pulse_RuntimeUtils.start_of_range rng))))
                   else
                     Obj.magic
                       (Pulse_Typing_Env.fail_doc g
@@ -2413,7 +2415,7 @@ let (instantiate_term_implicits :
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
                    (Prims.of_int (193)) (Prims.of_int (23))
-                   (Prims.of_int (216)) (Prims.of_int (14)))))
+                   (Prims.of_int (215)) (Prims.of_int (14)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ -> Pulse_Typing.elab_env g))
           (fun uu___ ->
@@ -2429,7 +2431,7 @@ let (instantiate_term_implicits :
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
                               (Prims.of_int (194)) (Prims.of_int (34))
-                              (Prims.of_int (216)) (Prims.of_int (14)))))
+                              (Prims.of_int (215)) (Prims.of_int (14)))))
                      (FStar_Tactics_Effect.lift_div_tac
                         (fun uu___ -> Pulse_RuntimeUtils.range_of_term t0))
                      (fun uu___ ->
@@ -2450,7 +2452,7 @@ let (instantiate_term_implicits :
                                          "Pulse.Checker.Pure.fst"
                                          (Prims.of_int (195))
                                          (Prims.of_int (73))
-                                         (Prims.of_int (216))
+                                         (Prims.of_int (215))
                                          (Prims.of_int (14)))))
                                 (Obj.magic
                                    (FStar_Tactics_Effect.tac_bind
@@ -2496,7 +2498,7 @@ let (instantiate_term_implicits :
                                                     "Pulse.Checker.Pure.fst"
                                                     (Prims.of_int (195))
                                                     (Prims.of_int (73))
-                                                    (Prims.of_int (216))
+                                                    (Prims.of_int (215))
                                                     (Prims.of_int (14)))))
                                            (Obj.magic
                                               (catch_all
@@ -2523,7 +2525,7 @@ let (instantiate_term_implicits :
                                                                    "Pulse.Checker.Pure.fst"
                                                                    (Prims.of_int (198))
                                                                    (Prims.of_int (2))
-                                                                   (Prims.of_int (216))
+                                                                   (Prims.of_int (215))
                                                                    (Prims.of_int (14)))))
                                                           (Obj.magic
                                                              (FStar_Tactics_V2_Builtins.log_issues
@@ -2602,7 +2604,7 @@ let (instantiate_term_implicits :
                                                                     (Prims.of_int (4))
                                                                     Prims.int_one
                                                                     (Pulse_PP.text
-                                                                    "Could not infer implicit arguments in")
+                                                                    "Could not check term:")
                                                                     uu___2))))
                                                                     (fun
                                                                     uu___2 ->
@@ -2639,7 +2641,7 @@ let (instantiate_term_implicits :
                                                                     "Pulse.Checker.Pure.fst"
                                                                     (Prims.of_int (212))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (214))
                                                                     (Prims.of_int (9)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2647,7 +2649,7 @@ let (instantiate_term_implicits :
                                                                     "Pulse.Checker.Pure.fst"
                                                                     (Prims.of_int (211))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (214))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2657,15 +2659,15 @@ let (instantiate_term_implicits :
                                                                     "Pulse.Checker.Pure.fst"
                                                                     (Prims.of_int (213))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (214))
-                                                                    (Prims.of_int (31)))))
+                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
                                                                     (Prims.of_int (212))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (214))
                                                                     (Prims.of_int (9)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2673,18 +2675,18 @@ let (instantiate_term_implicits :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (214))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (214))
-                                                                    (Prims.of_int (31)))))
+                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (52))
+                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
                                                                     (Prims.of_int (213))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (214))
-                                                                    (Prims.of_int (31)))))
+                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (59)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
                                                                     Pulse_PP.printable_term
@@ -2698,7 +2700,7 @@ let (instantiate_term_implicits :
                                                                     (Prims.of_int (4))
                                                                     Prims.int_one
                                                                     (Pulse_PP.text
-                                                                    "check_term: could not infer implicit arguments in")
+                                                                    "Could not check term:")
                                                                     uu___2))))
                                                                     (fun
                                                                     uu___2 ->
@@ -2737,13 +2739,13 @@ let (instantiate_term_implicits_uvs :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (219)) (Prims.of_int (10))
-                 (Prims.of_int (219)) (Prims.of_int (20)))))
+                 (Prims.of_int (218)) (Prims.of_int (10))
+                 (Prims.of_int (218)) (Prims.of_int (20)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (219)) (Prims.of_int (23))
-                 (Prims.of_int (247)) (Prims.of_int (20)))))
+                 (Prims.of_int (218)) (Prims.of_int (23))
+                 (Prims.of_int (246)) (Prims.of_int (20)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -2753,13 +2755,13 @@ let (instantiate_term_implicits_uvs :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (220)) (Prims.of_int (12))
-                            (Prims.of_int (220)) (Prims.of_int (31)))))
+                            (Prims.of_int (219)) (Prims.of_int (12))
+                            (Prims.of_int (219)) (Prims.of_int (31)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (220)) (Prims.of_int (34))
-                            (Prims.of_int (247)) (Prims.of_int (20)))))
+                            (Prims.of_int (219)) (Prims.of_int (34))
+                            (Prims.of_int (246)) (Prims.of_int (20)))))
                    (FStar_Tactics_Effect.lift_div_tac
                       (fun uu___ -> Pulse_RuntimeUtils.range_of_term t0))
                    (fun uu___ ->
@@ -2770,17 +2772,17 @@ let (instantiate_term_implicits_uvs :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (221))
+                                       (Prims.of_int (220))
                                        (Prims.of_int (10))
-                                       (Prims.of_int (221))
+                                       (Prims.of_int (220))
                                        (Prims.of_int (70)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (221))
+                                       (Prims.of_int (220))
                                        (Prims.of_int (73))
-                                       (Prims.of_int (247))
+                                       (Prims.of_int (246))
                                        (Prims.of_int (20)))))
                               (Obj.magic
                                  (FStar_Tactics_Effect.tac_bind
@@ -2788,17 +2790,17 @@ let (instantiate_term_implicits_uvs :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Pure.fst"
-                                             (Prims.of_int (221))
+                                             (Prims.of_int (220))
                                              (Prims.of_int (29))
-                                             (Prims.of_int (221))
+                                             (Prims.of_int (220))
                                              (Prims.of_int (70)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Pure.fst"
-                                             (Prims.of_int (221))
+                                             (Prims.of_int (220))
                                              (Prims.of_int (10))
-                                             (Prims.of_int (221))
+                                             (Prims.of_int (220))
                                              (Prims.of_int (70)))))
                                     (Obj.magic
                                        (Pulse_Typing_Env.get_range g
@@ -2816,17 +2818,17 @@ let (instantiate_term_implicits_uvs :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (222))
+                                                  (Prims.of_int (221))
                                                   (Prims.of_int (21))
-                                                  (Prims.of_int (222))
+                                                  (Prims.of_int (221))
                                                   (Prims.of_int (79)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (221))
+                                                  (Prims.of_int (220))
                                                   (Prims.of_int (73))
-                                                  (Prims.of_int (247))
+                                                  (Prims.of_int (246))
                                                   (Prims.of_int (20)))))
                                          (Obj.magic
                                             (catch_all
@@ -2844,17 +2846,17 @@ let (instantiate_term_implicits_uvs :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (223))
+                                                                 (Prims.of_int (222))
                                                                  (Prims.of_int (2))
-                                                                 (Prims.of_int (223))
+                                                                 (Prims.of_int (222))
                                                                  (Prims.of_int (21)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (224))
+                                                                 (Prims.of_int (223))
                                                                  (Prims.of_int (2))
-                                                                 (Prims.of_int (247))
+                                                                 (Prims.of_int (246))
                                                                  (Prims.of_int (20)))))
                                                         (Obj.magic
                                                            (FStar_Tactics_V2_Builtins.log_issues
@@ -2871,17 +2873,35 @@ let (instantiate_term_implicits_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (230))
                                                                     (Prims.of_int (13)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (13)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Pure.fst"
+                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
                                                                     (Prims.of_int (227))
-                                                                    (Prims.of_int (4))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (230))
                                                                     (Prims.of_int (13)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2890,34 +2910,16 @@ let (instantiate_term_implicits_uvs :
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
                                                                     (Prims.of_int (229))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (24))
+                                                                    (Prims.of_int (229))
                                                                     (Prims.of_int (31)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
                                                                     (Prims.of_int (228))
-                                                                    (Prims.of_int (15))
-                                                                    (Prims.of_int (231))
-                                                                    (Prims.of_int (13)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (230))
-                                                                    (Prims.of_int (24))
-                                                                    (Prims.of_int (230))
-                                                                    (Prims.of_int (31)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (229))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (230))
+                                                                    (Prims.of_int (229))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -2932,7 +2934,7 @@ let (instantiate_term_implicits_uvs :
                                                                     (Prims.of_int (4))
                                                                     Prims.int_one
                                                                     (Pulse_PP.text
-                                                                    "Could not infer implicit arguments in")
+                                                                    "Could not check term:")
                                                                     uu___2))))
                                                                     (fun
                                                                     uu___2 ->
@@ -2961,17 +2963,17 @@ let (instantiate_term_implicits_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (237))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (73)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (232))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (246))
                                                                     (Prims.of_int (20)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Util.fold_left
@@ -3096,13 +3098,13 @@ let (check_universe :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (251)) (Prims.of_int (12))
-                 (Prims.of_int (251)) (Prims.of_int (22)))))
+                 (Prims.of_int (250)) (Prims.of_int (12))
+                 (Prims.of_int (250)) (Prims.of_int (22)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (251)) (Prims.of_int (25))
-                 (Prims.of_int (265)) (Prims.of_int (23)))))
+                 (Prims.of_int (250)) (Prims.of_int (25))
+                 (Prims.of_int (264)) (Prims.of_int (23)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -3112,13 +3114,13 @@ let (check_universe :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (252)) (Prims.of_int (25))
-                            (Prims.of_int (252)) (Prims.of_int (67)))))
+                            (Prims.of_int (251)) (Prims.of_int (25))
+                            (Prims.of_int (251)) (Prims.of_int (67)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (251)) (Prims.of_int (25))
-                            (Prims.of_int (265)) (Prims.of_int (23)))))
+                            (Prims.of_int (250)) (Prims.of_int (25))
+                            (Prims.of_int (264)) (Prims.of_int (23)))))
                    (Obj.magic
                       (catch_all (fun uu___ -> rtb_universe_of g f t)))
                    (fun uu___ ->
@@ -3131,17 +3133,17 @@ let (check_universe :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (253))
+                                           (Prims.of_int (252))
                                            (Prims.of_int (4))
-                                           (Prims.of_int (253))
+                                           (Prims.of_int (252))
                                            (Prims.of_int (23)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (254))
+                                           (Prims.of_int (253))
                                            (Prims.of_int (4))
-                                           (Prims.of_int (265))
+                                           (Prims.of_int (264))
                                            (Prims.of_int (23)))))
                                   (Obj.magic
                                      (FStar_Tactics_V2_Builtins.log_issues
@@ -3157,17 +3159,17 @@ let (check_universe :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Checker.Pure.fst"
-                                                             (Prims.of_int (258))
+                                                             (Prims.of_int (257))
                                                              (Prims.of_int (31))
-                                                             (Prims.of_int (258))
+                                                             (Prims.of_int (257))
                                                              (Prims.of_int (81)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Checker.Pure.fst"
-                                                             (Prims.of_int (256))
+                                                             (Prims.of_int (255))
                                                              (Prims.of_int (6))
-                                                             (Prims.of_int (258))
+                                                             (Prims.of_int (257))
                                                              (Prims.of_int (81)))))
                                                     (Obj.magic
                                                        (ill_typed_term t
@@ -3209,25 +3211,25 @@ let (tc_meta_callback :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (270)) (Prims.of_int (6))
-                   (Prims.of_int (275)) (Prims.of_int (14)))))
+                   (Prims.of_int (269)) (Prims.of_int (6))
+                   (Prims.of_int (274)) (Prims.of_int (14)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (269)) (Prims.of_int (8))
-                   (Prims.of_int (269)) (Prims.of_int (11)))))
+                   (Prims.of_int (268)) (Prims.of_int (8))
+                   (Prims.of_int (268)) (Prims.of_int (11)))))
           (Obj.magic
              (FStar_Tactics_Effect.tac_bind
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                         (Prims.of_int (270)) (Prims.of_int (12))
-                         (Prims.of_int (270)) (Prims.of_int (50)))))
+                         (Prims.of_int (269)) (Prims.of_int (12))
+                         (Prims.of_int (269)) (Prims.of_int (50)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                         (Prims.of_int (270)) (Prims.of_int (6))
-                         (Prims.of_int (275)) (Prims.of_int (14)))))
+                         (Prims.of_int (269)) (Prims.of_int (6))
+                         (Prims.of_int (274)) (Prims.of_int (14)))))
                 (Obj.magic (catch_all (fun uu___ -> rtb_tc_term g f e)))
                 (fun uu___ ->
                    FStar_Tactics_Effect.lift_div_tac
@@ -3256,12 +3258,12 @@ let (compute_term_type :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (284)) (Prims.of_int (13))
-                 (Prims.of_int (284)) (Prims.of_int (23)))))
+                 (Prims.of_int (283)) (Prims.of_int (13))
+                 (Prims.of_int (283)) (Prims.of_int (23)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (285)) (Prims.of_int (4)) (Prims.of_int (295))
+                 (Prims.of_int (284)) (Prims.of_int (4)) (Prims.of_int (294))
                  (Prims.of_int (63)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
@@ -3272,13 +3274,13 @@ let (compute_term_type :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (285)) (Prims.of_int (4))
-                            (Prims.of_int (288)) (Prims.of_int (43)))))
+                            (Prims.of_int (284)) (Prims.of_int (4))
+                            (Prims.of_int (287)) (Prims.of_int (43)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (288)) (Prims.of_int (44))
-                            (Prims.of_int (295)) (Prims.of_int (63)))))
+                            (Prims.of_int (287)) (Prims.of_int (44))
+                            (Prims.of_int (294)) (Prims.of_int (63)))))
                    (Obj.magic
                       (debug g
                          (fun uu___ ->
@@ -3287,17 +3289,17 @@ let (compute_term_type :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (288))
+                                       (Prims.of_int (287))
                                        (Prims.of_int (22))
-                                       (Prims.of_int (288))
+                                       (Prims.of_int (287))
                                        (Prims.of_int (42)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (286))
+                                       (Prims.of_int (285))
                                        (Prims.of_int (12))
-                                       (Prims.of_int (288))
+                                       (Prims.of_int (287))
                                        (Prims.of_int (42)))))
                               (Obj.magic
                                  (FStar_Tactics_V2_Builtins.term_to_string t))
@@ -3309,17 +3311,17 @@ let (compute_term_type :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (286))
+                                                  (Prims.of_int (285))
                                                   (Prims.of_int (12))
-                                                  (Prims.of_int (288))
+                                                  (Prims.of_int (287))
                                                   (Prims.of_int (42)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "Pulse.Checker.Pure.fst"
-                                                  (Prims.of_int (286))
+                                                  (Prims.of_int (285))
                                                   (Prims.of_int (12))
-                                                  (Prims.of_int (288))
+                                                  (Prims.of_int (287))
                                                   (Prims.of_int (42)))))
                                          (Obj.magic
                                             (FStar_Tactics_Effect.tac_bind
@@ -3327,9 +3329,9 @@ let (compute_term_type :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "Pulse.Checker.Pure.fst"
-                                                        (Prims.of_int (287))
+                                                        (Prims.of_int (286))
                                                         (Prims.of_int (22))
-                                                        (Prims.of_int (287))
+                                                        (Prims.of_int (286))
                                                         (Prims.of_int (42)))))
                                                (FStar_Sealed.seal
                                                   (Obj.magic
@@ -3365,17 +3367,17 @@ let (compute_term_type :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (289))
+                                       (Prims.of_int (288))
                                        (Prims.of_int (22))
-                                       (Prims.of_int (289))
+                                       (Prims.of_int (288))
                                        (Prims.of_int (45)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (288))
+                                       (Prims.of_int (287))
                                        (Prims.of_int (44))
-                                       (Prims.of_int (295))
+                                       (Prims.of_int (294))
                                        (Prims.of_int (63)))))
                               (Obj.magic (tc_meta_callback g fg t))
                               (fun uu___1 ->
@@ -3388,17 +3390,17 @@ let (compute_term_type :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (290))
+                                                      (Prims.of_int (289))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (290))
+                                                      (Prims.of_int (289))
                                                       (Prims.of_int (23)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (291))
+                                                      (Prims.of_int (290))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (295))
+                                                      (Prims.of_int (294))
                                                       (Prims.of_int (63)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.log_issues
@@ -3415,17 +3417,17 @@ let (compute_term_type :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (63)))))
                                                                (FStar_Sealed.seal
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (292))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (63)))))
                                                                (Obj.magic
                                                                   (ill_typed_term
@@ -3469,13 +3471,13 @@ let (compute_term_type_and_u :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (304)) (Prims.of_int (13))
-                 (Prims.of_int (304)) (Prims.of_int (23)))))
+                 (Prims.of_int (303)) (Prims.of_int (13))
+                 (Prims.of_int (303)) (Prims.of_int (23)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (304)) (Prims.of_int (26))
-                 (Prims.of_int (314)) (Prims.of_int (45)))))
+                 (Prims.of_int (303)) (Prims.of_int (26))
+                 (Prims.of_int (313)) (Prims.of_int (45)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -3485,13 +3487,13 @@ let (compute_term_type_and_u :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (305)) (Prims.of_int (22))
-                            (Prims.of_int (305)) (Prims.of_int (45)))))
+                            (Prims.of_int (304)) (Prims.of_int (22))
+                            (Prims.of_int (304)) (Prims.of_int (45)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (304)) (Prims.of_int (26))
-                            (Prims.of_int (314)) (Prims.of_int (45)))))
+                            (Prims.of_int (303)) (Prims.of_int (26))
+                            (Prims.of_int (313)) (Prims.of_int (45)))))
                    (Obj.magic (tc_meta_callback g fg t))
                    (fun uu___ ->
                       (fun uu___ ->
@@ -3503,17 +3505,17 @@ let (compute_term_type_and_u :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (306))
+                                           (Prims.of_int (305))
                                            (Prims.of_int (4))
-                                           (Prims.of_int (306))
+                                           (Prims.of_int (305))
                                            (Prims.of_int (23)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (307))
+                                           (Prims.of_int (306))
                                            (Prims.of_int (4))
-                                           (Prims.of_int (314))
+                                           (Prims.of_int (313))
                                            (Prims.of_int (45)))))
                                   (Obj.magic
                                      (FStar_Tactics_V2_Builtins.log_issues
@@ -3528,17 +3530,17 @@ let (compute_term_type_and_u :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (311))
+                                                          (Prims.of_int (310))
                                                           (Prims.of_int (31))
-                                                          (Prims.of_int (311))
+                                                          (Prims.of_int (310))
                                                           (Prims.of_int (59)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (309))
+                                                          (Prims.of_int (308))
                                                           (Prims.of_int (6))
-                                                          (Prims.of_int (311))
+                                                          (Prims.of_int (310))
                                                           (Prims.of_int (59)))))
                                                  (Obj.magic
                                                     (ill_typed_term t
@@ -3561,17 +3563,17 @@ let (compute_term_type_and_u :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (313))
+                                                          (Prims.of_int (312))
                                                           (Prims.of_int (25))
-                                                          (Prims.of_int (313))
+                                                          (Prims.of_int (312))
                                                           (Prims.of_int (45)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (312))
+                                                          (Prims.of_int (311))
                                                           (Prims.of_int (37))
-                                                          (Prims.of_int (314))
+                                                          (Prims.of_int (313))
                                                           (Prims.of_int (45)))))
                                                  (Obj.magic
                                                     (check_universe g ty'))
@@ -3603,13 +3605,13 @@ let (check_term :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (319)) (Prims.of_int (13))
-                     (Prims.of_int (319)) (Prims.of_int (52)))))
+                     (Prims.of_int (318)) (Prims.of_int (13))
+                     (Prims.of_int (318)) (Prims.of_int (52)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (317)) (Prims.of_int (39))
-                     (Prims.of_int (334)) (Prims.of_int (78)))))
+                     (Prims.of_int (316)) (Prims.of_int (39))
+                     (Prims.of_int (333)) (Prims.of_int (78)))))
             (Obj.magic
                (instantiate_term_implicits g e
                   (FStar_Pervasives_Native.Some t)))
@@ -3623,14 +3625,14 @@ let (check_term :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Pure.fst"
-                                    (Prims.of_int (321)) (Prims.of_int (11))
-                                    (Prims.of_int (321)) (Prims.of_int (21)))))
+                                    (Prims.of_int (320)) (Prims.of_int (11))
+                                    (Prims.of_int (320)) (Prims.of_int (21)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Pure.fst"
-                                    (Prims.of_int (321)) (Prims.of_int (24))
-                                    (Prims.of_int (334)) (Prims.of_int (78)))))
+                                    (Prims.of_int (320)) (Prims.of_int (24))
+                                    (Prims.of_int (333)) (Prims.of_int (78)))))
                            (FStar_Tactics_Effect.lift_div_tac
                               (fun uu___2 -> Pulse_Typing.elab_env g))
                            (fun uu___2 ->
@@ -3641,17 +3643,17 @@ let (check_term :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Pure.fst"
-                                               (Prims.of_int (324))
+                                               (Prims.of_int (323))
                                                (Prims.of_int (4))
-                                               (Prims.of_int (327))
+                                               (Prims.of_int (326))
                                                (Prims.of_int (20)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Pure.fst"
-                                               (Prims.of_int (321))
+                                               (Prims.of_int (320))
                                                (Prims.of_int (24))
-                                               (Prims.of_int (334))
+                                               (Prims.of_int (333))
                                                (Prims.of_int (78)))))
                                       (Obj.magic
                                          (catch_all
@@ -3672,17 +3674,17 @@ let (check_term :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Pure.fst"
-                                                              (Prims.of_int (328))
+                                                              (Prims.of_int (327))
                                                               (Prims.of_int (2))
-                                                              (Prims.of_int (328))
+                                                              (Prims.of_int (327))
                                                               (Prims.of_int (21)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Checker.Pure.fst"
-                                                              (Prims.of_int (329))
+                                                              (Prims.of_int (328))
                                                               (Prims.of_int (2))
-                                                              (Prims.of_int (334))
+                                                              (Prims.of_int (333))
                                                               (Prims.of_int (78)))))
                                                      (Obj.magic
                                                         (FStar_Tactics_V2_Builtins.log_issues
@@ -3700,17 +3702,17 @@ let (check_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (332))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (332))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (331))
+                                                                    (Prims.of_int (330))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (332))
                                                                     (Prims.of_int (61)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
@@ -3756,13 +3758,13 @@ let (check_term_at_type :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (339)) (Prims.of_int (13))
-                   (Prims.of_int (339)) (Prims.of_int (52)))))
+                   (Prims.of_int (338)) (Prims.of_int (13))
+                   (Prims.of_int (338)) (Prims.of_int (52)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (337)) (Prims.of_int (60))
-                   (Prims.of_int (354)) (Prims.of_int (65)))))
+                   (Prims.of_int (336)) (Prims.of_int (60))
+                   (Prims.of_int (353)) (Prims.of_int (65)))))
           (Obj.magic
              (instantiate_term_implicits g e (FStar_Pervasives_Native.Some t)))
           (fun uu___ ->
@@ -3774,13 +3776,13 @@ let (check_term_at_type :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (340)) (Prims.of_int (11))
-                                  (Prims.of_int (340)) (Prims.of_int (21)))))
+                                  (Prims.of_int (339)) (Prims.of_int (11))
+                                  (Prims.of_int (339)) (Prims.of_int (21)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (340)) (Prims.of_int (24))
-                                  (Prims.of_int (354)) (Prims.of_int (65)))))
+                                  (Prims.of_int (339)) (Prims.of_int (24))
+                                  (Prims.of_int (353)) (Prims.of_int (65)))))
                          (FStar_Tactics_Effect.lift_div_tac
                             (fun uu___2 -> Pulse_Typing.elab_env g))
                          (fun uu___2 ->
@@ -3791,17 +3793,17 @@ let (check_term_at_type :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Pure.fst"
-                                             (Prims.of_int (343))
+                                             (Prims.of_int (342))
                                              (Prims.of_int (4))
-                                             (Prims.of_int (346))
+                                             (Prims.of_int (345))
                                              (Prims.of_int (13)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Pure.fst"
-                                             (Prims.of_int (340))
+                                             (Prims.of_int (339))
                                              (Prims.of_int (24))
-                                             (Prims.of_int (354))
+                                             (Prims.of_int (353))
                                              (Prims.of_int (65)))))
                                     (Obj.magic
                                        (catch_all
@@ -3822,17 +3824,17 @@ let (check_term_at_type :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Checker.Pure.fst"
-                                                            (Prims.of_int (347))
+                                                            (Prims.of_int (346))
                                                             (Prims.of_int (2))
-                                                            (Prims.of_int (347))
+                                                            (Prims.of_int (346))
                                                             (Prims.of_int (21)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Checker.Pure.fst"
-                                                            (Prims.of_int (348))
+                                                            (Prims.of_int (347))
                                                             (Prims.of_int (2))
-                                                            (Prims.of_int (354))
+                                                            (Prims.of_int (353))
                                                             (Prims.of_int (65)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_V2_Builtins.log_issues
@@ -3849,17 +3851,17 @@ let (check_term_at_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (350))
+                                                                    (Prims.of_int (349))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (61)))))
                                                                     (Obj.magic
                                                                     (ill_typed_term
@@ -3907,13 +3909,13 @@ let (tc_with_core :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (358)) (Prims.of_int (23))
-                   (Prims.of_int (358)) (Prims.of_int (124)))))
+                   (Prims.of_int (357)) (Prims.of_int (23))
+                   (Prims.of_int (357)) (Prims.of_int (124)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (358)) (Prims.of_int (3))
-                   (Prims.of_int (362)) (Prims.of_int (76)))))
+                   (Prims.of_int (357)) (Prims.of_int (3))
+                   (Prims.of_int (361)) (Prims.of_int (76)))))
           (Obj.magic
              (catch_all
                 (fun uu___ ->
@@ -3947,13 +3949,13 @@ let (core_compute_term_type :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (368)) (Prims.of_int (13))
-                 (Prims.of_int (368)) (Prims.of_int (23)))))
+                 (Prims.of_int (367)) (Prims.of_int (13))
+                 (Prims.of_int (367)) (Prims.of_int (23)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (368)) (Prims.of_int (26))
-                 (Prims.of_int (376)) (Prims.of_int (55)))))
+                 (Prims.of_int (367)) (Prims.of_int (26))
+                 (Prims.of_int (375)) (Prims.of_int (55)))))
         (FStar_Tactics_Effect.lift_div_tac
            (fun uu___ -> Pulse_Typing.elab_env g))
         (fun uu___ ->
@@ -3963,13 +3965,13 @@ let (core_compute_term_type :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (369)) (Prims.of_int (22))
-                            (Prims.of_int (369)) (Prims.of_int (92)))))
+                            (Prims.of_int (368)) (Prims.of_int (22))
+                            (Prims.of_int (368)) (Prims.of_int (92)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                            (Prims.of_int (368)) (Prims.of_int (26))
-                            (Prims.of_int (376)) (Prims.of_int (55)))))
+                            (Prims.of_int (367)) (Prims.of_int (26))
+                            (Prims.of_int (375)) (Prims.of_int (55)))))
                    (Obj.magic
                       (tc_with_core
                          (Pulse_Typing_Env.push_context g "core_check_term"
@@ -3985,17 +3987,17 @@ let (core_compute_term_type :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (370))
+                                           (Prims.of_int (369))
                                            (Prims.of_int (4))
-                                           (Prims.of_int (370))
+                                           (Prims.of_int (369))
                                            (Prims.of_int (23)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (371))
+                                           (Prims.of_int (370))
                                            (Prims.of_int (4))
-                                           (Prims.of_int (376))
+                                           (Prims.of_int (375))
                                            (Prims.of_int (55)))))
                                   (Obj.magic
                                      (FStar_Tactics_V2_Builtins.log_issues
@@ -4011,17 +4013,17 @@ let (core_compute_term_type :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Checker.Pure.fst"
-                                                             (Prims.of_int (375))
+                                                             (Prims.of_int (374))
                                                              (Prims.of_int (31))
-                                                             (Prims.of_int (375))
+                                                             (Prims.of_int (374))
                                                              (Prims.of_int (59)))))
                                                     (FStar_Sealed.seal
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "Pulse.Checker.Pure.fst"
-                                                             (Prims.of_int (373))
+                                                             (Prims.of_int (372))
                                                              (Prims.of_int (6))
-                                                             (Prims.of_int (375))
+                                                             (Prims.of_int (374))
                                                              (Prims.of_int (59)))))
                                                     (Obj.magic
                                                        (ill_typed_term t
@@ -4059,13 +4061,13 @@ let (core_check_term :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (379)) (Prims.of_int (11))
-                     (Prims.of_int (379)) (Prims.of_int (21)))))
+                     (Prims.of_int (378)) (Prims.of_int (11))
+                     (Prims.of_int (378)) (Prims.of_int (21)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (379)) (Prims.of_int (24))
-                     (Prims.of_int (391)) (Prims.of_int (69)))))
+                     (Prims.of_int (378)) (Prims.of_int (24))
+                     (Prims.of_int (390)) (Prims.of_int (69)))))
             (FStar_Tactics_Effect.lift_div_tac
                (fun uu___ -> Pulse_Typing.elab_env g))
             (fun uu___ ->
@@ -4075,13 +4077,13 @@ let (core_check_term :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (381)) (Prims.of_int (4))
-                                (Prims.of_int (384)) (Prims.of_int (18)))))
+                                (Prims.of_int (380)) (Prims.of_int (4))
+                                (Prims.of_int (383)) (Prims.of_int (18)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (379)) (Prims.of_int (24))
-                                (Prims.of_int (391)) (Prims.of_int (69)))))
+                                (Prims.of_int (378)) (Prims.of_int (24))
+                                (Prims.of_int (390)) (Prims.of_int (69)))))
                        (Obj.magic
                           (catch_all
                              (fun uu___ ->
@@ -4100,17 +4102,17 @@ let (core_check_term :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Pure.fst"
-                                               (Prims.of_int (385))
+                                               (Prims.of_int (384))
                                                (Prims.of_int (2))
-                                               (Prims.of_int (385))
+                                               (Prims.of_int (384))
                                                (Prims.of_int (21)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Pure.fst"
-                                               (Prims.of_int (386))
+                                               (Prims.of_int (385))
                                                (Prims.of_int (2))
-                                               (Prims.of_int (391))
+                                               (Prims.of_int (390))
                                                (Prims.of_int (69)))))
                                       (Obj.magic
                                          (FStar_Tactics_V2_Builtins.log_issues
@@ -4126,17 +4128,17 @@ let (core_check_term :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (390))
+                                                                 (Prims.of_int (389))
                                                                  (Prims.of_int (29))
-                                                                 (Prims.of_int (390))
+                                                                 (Prims.of_int (389))
                                                                  (Prims.of_int (61)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (388))
+                                                                 (Prims.of_int (387))
                                                                  (Prims.of_int (4))
-                                                                 (Prims.of_int (390))
+                                                                 (Prims.of_int (389))
                                                                  (Prims.of_int (61)))))
                                                         (Obj.magic
                                                            (ill_typed_term e
@@ -4172,13 +4174,13 @@ let (core_check_term_at_type :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (394)) (Prims.of_int (11))
-                   (Prims.of_int (394)) (Prims.of_int (21)))))
+                   (Prims.of_int (393)) (Prims.of_int (11))
+                   (Prims.of_int (393)) (Prims.of_int (21)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (394)) (Prims.of_int (24))
-                   (Prims.of_int (407)) (Prims.of_int (62)))))
+                   (Prims.of_int (393)) (Prims.of_int (24))
+                   (Prims.of_int (406)) (Prims.of_int (62)))))
           (FStar_Tactics_Effect.lift_div_tac
              (fun uu___ -> Pulse_Typing.elab_env g))
           (fun uu___ ->
@@ -4188,13 +4190,13 @@ let (core_check_term_at_type :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                              (Prims.of_int (396)) (Prims.of_int (4))
-                              (Prims.of_int (399)) (Prims.of_int (14)))))
+                              (Prims.of_int (395)) (Prims.of_int (4))
+                              (Prims.of_int (398)) (Prims.of_int (14)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                              (Prims.of_int (394)) (Prims.of_int (24))
-                              (Prims.of_int (407)) (Prims.of_int (62)))))
+                              (Prims.of_int (393)) (Prims.of_int (24))
+                              (Prims.of_int (406)) (Prims.of_int (62)))))
                      (Obj.magic
                         (catch_all
                            (fun uu___ ->
@@ -4213,17 +4215,17 @@ let (core_check_term_at_type :
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Pure.fst"
-                                             (Prims.of_int (400))
+                                             (Prims.of_int (399))
                                              (Prims.of_int (2))
-                                             (Prims.of_int (400))
+                                             (Prims.of_int (399))
                                              (Prims.of_int (21)))))
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range
                                              "Pulse.Checker.Pure.fst"
-                                             (Prims.of_int (401))
+                                             (Prims.of_int (400))
                                              (Prims.of_int (2))
-                                             (Prims.of_int (407))
+                                             (Prims.of_int (406))
                                              (Prims.of_int (62)))))
                                     (Obj.magic
                                        (FStar_Tactics_V2_Builtins.log_issues
@@ -4239,17 +4241,17 @@ let (core_check_term_at_type :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Pure.fst"
-                                                               (Prims.of_int (405))
+                                                               (Prims.of_int (404))
                                                                (Prims.of_int (29))
-                                                               (Prims.of_int (405))
+                                                               (Prims.of_int (404))
                                                                (Prims.of_int (61)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Pure.fst"
-                                                               (Prims.of_int (403))
+                                                               (Prims.of_int (402))
                                                                (Prims.of_int (4))
-                                                               (Prims.of_int (405))
+                                                               (Prims.of_int (404))
                                                                (Prims.of_int (61)))))
                                                       (Obj.magic
                                                          (ill_typed_term e
@@ -4309,13 +4311,13 @@ let (try_get_non_informative_witness_aux :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (436)) (Prims.of_int (15))
-                     (Prims.of_int (436)) (Prims.of_int (41)))))
+                     (Prims.of_int (435)) (Prims.of_int (15))
+                     (Prims.of_int (435)) (Prims.of_int (41)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (436)) (Prims.of_int (44))
-                     (Prims.of_int (455)) (Prims.of_int (5)))))
+                     (Prims.of_int (435)) (Prims.of_int (44))
+                     (Prims.of_int (454)) (Prims.of_int (5)))))
             (FStar_Tactics_Effect.lift_div_tac
                (fun uu___ -> Pulse_Typing.non_informative_class u ty))
             (fun uu___ ->
@@ -4325,13 +4327,13 @@ let (try_get_non_informative_witness_aux :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (437)) (Prims.of_int (16))
-                                (Prims.of_int (437)) (Prims.of_int (26)))))
+                                (Prims.of_int (436)) (Prims.of_int (16))
+                                (Prims.of_int (436)) (Prims.of_int (26)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (437)) (Prims.of_int (29))
-                                (Prims.of_int (455)) (Prims.of_int (5)))))
+                                (Prims.of_int (436)) (Prims.of_int (29))
+                                (Prims.of_int (454)) (Prims.of_int (5)))))
                        (FStar_Tactics_Effect.lift_div_tac
                           (fun uu___ -> Pulse_Typing.elab_env g))
                        (fun uu___ ->
@@ -4342,17 +4344,17 @@ let (try_get_non_informative_witness_aux :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (438))
+                                           (Prims.of_int (437))
                                            (Prims.of_int (28))
-                                           (Prims.of_int (438))
+                                           (Prims.of_int (437))
                                            (Prims.of_int (73)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Checker.Pure.fst"
-                                           (Prims.of_int (441))
+                                           (Prims.of_int (440))
                                            (Prims.of_int (6))
-                                           (Prims.of_int (455))
+                                           (Prims.of_int (454))
                                            (Prims.of_int (5)))))
                                   (FStar_Tactics_Effect.lift_div_tac
                                      (fun uu___ -> ()))
@@ -4364,17 +4366,17 @@ let (try_get_non_informative_witness_aux :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (442))
+                                                      (Prims.of_int (441))
                                                       (Prims.of_int (12))
-                                                      (Prims.of_int (442))
+                                                      (Prims.of_int (441))
                                                       (Prims.of_int (74)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Checker.Pure.fst"
-                                                      (Prims.of_int (443))
+                                                      (Prims.of_int (442))
                                                       (Prims.of_int (4))
-                                                      (Prims.of_int (455))
+                                                      (Prims.of_int (454))
                                                       (Prims.of_int (5)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.call_subtac
@@ -4417,13 +4419,13 @@ let (try_get_non_informative_witness :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (458)) (Prims.of_int (16))
-                     (Prims.of_int (458)) (Prims.of_int (68)))))
+                     (Prims.of_int (457)) (Prims.of_int (16))
+                     (Prims.of_int (457)) (Prims.of_int (68)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (457)) (Prims.of_int (54))
-                     (Prims.of_int (459)) (Prims.of_int (6)))))
+                     (Prims.of_int (456)) (Prims.of_int (54))
+                     (Prims.of_int (458)) (Prims.of_int (6)))))
             (Obj.magic (try_get_non_informative_witness_aux g u ty ()))
             (fun uu___ ->
                FStar_Tactics_Effect.lift_div_tac
@@ -4444,13 +4446,13 @@ let (get_non_informative_witness :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (463)) (Prims.of_int (10))
-                     (Prims.of_int (463)) (Prims.of_int (60)))))
+                     (Prims.of_int (462)) (Prims.of_int (10))
+                     (Prims.of_int (462)) (Prims.of_int (60)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                     (Prims.of_int (463)) (Prims.of_int (4))
-                     (Prims.of_int (474)) (Prims.of_int (7)))))
+                     (Prims.of_int (462)) (Prims.of_int (4))
+                     (Prims.of_int (473)) (Prims.of_int (7)))))
             (Obj.magic (try_get_non_informative_witness_aux g u t ()))
             (fun uu___ ->
                (fun uu___ ->
@@ -4462,14 +4464,14 @@ let (get_non_informative_witness :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Pure.fst"
-                                    (Prims.of_int (465)) (Prims.of_int (6))
-                                    (Prims.of_int (465)) (Prims.of_int (25)))))
+                                    (Prims.of_int (464)) (Prims.of_int (6))
+                                    (Prims.of_int (464)) (Prims.of_int (25)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Pure.fst"
-                                    (Prims.of_int (467)) (Prims.of_int (6))
-                                    (Prims.of_int (471)) (Prims.of_int (7)))))
+                                    (Prims.of_int (466)) (Prims.of_int (6))
+                                    (Prims.of_int (470)) (Prims.of_int (7)))))
                            (Obj.magic
                               (FStar_Tactics_V2_Builtins.log_issues issues))
                            (fun uu___1 ->
@@ -4480,17 +4482,17 @@ let (get_non_informative_witness :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Pure.fst"
-                                               (Prims.of_int (467))
+                                               (Prims.of_int (466))
                                                (Prims.of_int (45))
-                                               (Prims.of_int (471))
+                                               (Prims.of_int (470))
                                                (Prims.of_int (7)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Checker.Pure.fst"
-                                               (Prims.of_int (467))
+                                               (Prims.of_int (466))
                                                (Prims.of_int (6))
-                                               (Prims.of_int (471))
+                                               (Prims.of_int (470))
                                                (Prims.of_int (7)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -4498,17 +4500,17 @@ let (get_non_informative_witness :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Checker.Pure.fst"
-                                                     (Prims.of_int (467))
+                                                     (Prims.of_int (466))
                                                      (Prims.of_int (45))
-                                                     (Prims.of_int (471))
+                                                     (Prims.of_int (470))
                                                      (Prims.of_int (7)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Checker.Pure.fst"
-                                                     (Prims.of_int (467))
+                                                     (Prims.of_int (466))
                                                      (Prims.of_int (45))
-                                                     (Prims.of_int (471))
+                                                     (Prims.of_int (470))
                                                      (Prims.of_int (7)))))
                                             (Obj.magic
                                                (FStar_Tactics_Effect.tac_bind
@@ -4516,17 +4518,17 @@ let (get_non_informative_witness :
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Checker.Pure.fst"
-                                                           (Prims.of_int (469))
+                                                           (Prims.of_int (468))
                                                            (Prims.of_int (8))
-                                                           (Prims.of_int (470))
+                                                           (Prims.of_int (469))
                                                            (Prims.of_int (16)))))
                                                   (FStar_Sealed.seal
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Checker.Pure.fst"
-                                                           (Prims.of_int (467))
+                                                           (Prims.of_int (466))
                                                            (Prims.of_int (45))
-                                                           (Prims.of_int (471))
+                                                           (Prims.of_int (470))
                                                            (Prims.of_int (7)))))
                                                   (Obj.magic
                                                      (FStar_Tactics_Effect.tac_bind
@@ -4534,17 +4536,17 @@ let (get_non_informative_witness :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (470))
+                                                                 (Prims.of_int (469))
                                                                  (Prims.of_int (10))
-                                                                 (Prims.of_int (470))
+                                                                 (Prims.of_int (469))
                                                                  (Prims.of_int (16)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "Pulse.Checker.Pure.fst"
-                                                                 (Prims.of_int (469))
+                                                                 (Prims.of_int (468))
                                                                  (Prims.of_int (8))
-                                                                 (Prims.of_int (470))
+                                                                 (Prims.of_int (469))
                                                                  (Prims.of_int (16)))))
                                                         (Obj.magic
                                                            (Pulse_PP.pp
@@ -4584,14 +4586,14 @@ let (get_non_informative_witness :
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Pure.fst"
-                                    (Prims.of_int (473)) (Prims.of_int (6))
-                                    (Prims.of_int (473)) (Prims.of_int (25)))))
+                                    (Prims.of_int (472)) (Prims.of_int (6))
+                                    (Prims.of_int (472)) (Prims.of_int (25)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range
                                     "Pulse.Checker.Pure.fst"
-                                    (Prims.of_int (472)) (Prims.of_int (11))
-                                    (Prims.of_int (472)) (Prims.of_int (12)))))
+                                    (Prims.of_int (471)) (Prims.of_int (11))
+                                    (Prims.of_int (471)) (Prims.of_int (12)))))
                            (Obj.magic
                               (FStar_Tactics_V2_Builtins.log_issues issues))
                            (fun uu___1 ->
@@ -4611,13 +4613,13 @@ let (try_check_prop_validity :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (478)) (Prims.of_int (24))
-                   (Prims.of_int (478)) (Prims.of_int (69)))))
+                   (Prims.of_int (477)) (Prims.of_int (24))
+                   (Prims.of_int (477)) (Prims.of_int (69)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (478)) (Prims.of_int (3))
-                   (Prims.of_int (479)) (Prims.of_int (9)))))
+                   (Prims.of_int (477)) (Prims.of_int (3))
+                   (Prims.of_int (478)) (Prims.of_int (9)))))
           (Obj.magic
              (rtb_check_prop_validity g true (Pulse_Typing.elab_env g) p))
           (fun uu___1 ->
@@ -4635,13 +4637,13 @@ let (check_prop_validity :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (483)) (Prims.of_int (24))
-                   (Prims.of_int (483)) (Prims.of_int (70)))))
+                   (Prims.of_int (482)) (Prims.of_int (24))
+                   (Prims.of_int (482)) (Prims.of_int (70)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (483)) (Prims.of_int (3))
-                   (Prims.of_int (491)) (Prims.of_int (21)))))
+                   (Prims.of_int (482)) (Prims.of_int (3))
+                   (Prims.of_int (490)) (Prims.of_int (21)))))
           (Obj.magic
              (rtb_check_prop_validity g false (Pulse_Typing.elab_env g) p))
           (fun uu___1 ->
@@ -4653,13 +4655,13 @@ let (check_prop_validity :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (484)) (Prims.of_int (4))
-                                  (Prims.of_int (484)) (Prims.of_int (23)))))
+                                  (Prims.of_int (483)) (Prims.of_int (4))
+                                  (Prims.of_int (483)) (Prims.of_int (23)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (485)) (Prims.of_int (4))
-                                  (Prims.of_int (491)) (Prims.of_int (21)))))
+                                  (Prims.of_int (484)) (Prims.of_int (4))
+                                  (Prims.of_int (490)) (Prims.of_int (21)))))
                          (Obj.magic
                             (FStar_Tactics_V2_Builtins.log_issues issues))
                          (fun uu___2 ->
@@ -4673,17 +4675,17 @@ let (check_prop_validity :
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Pure.fst"
-                                                    (Prims.of_int (488))
+                                                    (Prims.of_int (487))
                                                     (Prims.of_int (51))
-                                                    (Prims.of_int (490))
+                                                    (Prims.of_int (489))
                                                     (Prims.of_int (7)))))
                                            (FStar_Sealed.seal
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "Pulse.Checker.Pure.fst"
-                                                    (Prims.of_int (488))
+                                                    (Prims.of_int (487))
                                                     (Prims.of_int (6))
-                                                    (Prims.of_int (490))
+                                                    (Prims.of_int (489))
                                                     (Prims.of_int (7)))))
                                            (Obj.magic
                                               (FStar_Tactics_Effect.tac_bind
@@ -4691,17 +4693,17 @@ let (check_prop_validity :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (489))
+                                                          (Prims.of_int (488))
                                                           (Prims.of_int (8))
-                                                          (Prims.of_int (489))
+                                                          (Prims.of_int (488))
                                                           (Prims.of_int (65)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Checker.Pure.fst"
-                                                          (Prims.of_int (488))
+                                                          (Prims.of_int (487))
                                                           (Prims.of_int (51))
-                                                          (Prims.of_int (490))
+                                                          (Prims.of_int (489))
                                                           (Prims.of_int (7)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_Effect.tac_bind
@@ -4709,17 +4711,17 @@ let (check_prop_validity :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Pure.fst"
-                                                                (Prims.of_int (489))
+                                                                (Prims.of_int (488))
                                                                 (Prims.of_int (59))
-                                                                (Prims.of_int (489))
+                                                                (Prims.of_int (488))
                                                                 (Prims.of_int (65)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Pure.fst"
-                                                                (Prims.of_int (489))
+                                                                (Prims.of_int (488))
                                                                 (Prims.of_int (8))
-                                                                (Prims.of_int (489))
+                                                                (Prims.of_int (488))
                                                                 (Prims.of_int (65)))))
                                                        (Obj.magic
                                                           (Pulse_PP.pp
@@ -4760,37 +4762,37 @@ let fail_expected_tot_found_ghost :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (494)) (Prims.of_int (41))
-                 (Prims.of_int (497)) (Prims.of_int (3)))))
+                 (Prims.of_int (493)) (Prims.of_int (41))
+                 (Prims.of_int (496)) (Prims.of_int (3)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (494)) (Prims.of_int (2)) (Prims.of_int (497))
+                 (Prims.of_int (493)) (Prims.of_int (2)) (Prims.of_int (496))
                  (Prims.of_int (3)))))
         (Obj.magic
            (FStar_Tactics_Effect.tac_bind
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                       (Prims.of_int (495)) (Prims.of_int (4))
-                       (Prims.of_int (496)) (Prims.of_int (12)))))
+                       (Prims.of_int (494)) (Prims.of_int (4))
+                       (Prims.of_int (495)) (Prims.of_int (12)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                       (Prims.of_int (494)) (Prims.of_int (41))
-                       (Prims.of_int (497)) (Prims.of_int (3)))))
+                       (Prims.of_int (493)) (Prims.of_int (41))
+                       (Prims.of_int (496)) (Prims.of_int (3)))))
               (Obj.magic
                  (FStar_Tactics_Effect.tac_bind
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                             (Prims.of_int (496)) (Prims.of_int (6))
-                             (Prims.of_int (496)) (Prims.of_int (12)))))
+                             (Prims.of_int (495)) (Prims.of_int (6))
+                             (Prims.of_int (495)) (Prims.of_int (12)))))
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                             (Prims.of_int (495)) (Prims.of_int (4))
-                             (Prims.of_int (496)) (Prims.of_int (12)))))
+                             (Prims.of_int (494)) (Prims.of_int (4))
+                             (Prims.of_int (495)) (Prims.of_int (12)))))
                     (Obj.magic (Pulse_PP.pp Pulse_PP.printable_term t))
                     (fun uu___ ->
                        FStar_Tactics_Effect.lift_div_tac
@@ -4821,13 +4823,13 @@ let (compute_tot_term_type :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (500)) (Prims.of_int (35))
-                 (Prims.of_int (500)) (Prims.of_int (56)))))
+                 (Prims.of_int (499)) (Prims.of_int (35))
+                 (Prims.of_int (499)) (Prims.of_int (56)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (499)) (Prims.of_int (31))
-                 (Prims.of_int (502)) (Prims.of_int (40)))))
+                 (Prims.of_int (498)) (Prims.of_int (31))
+                 (Prims.of_int (501)) (Prims.of_int (40)))))
         (Obj.magic (compute_term_type g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -4856,13 +4858,13 @@ let (compute_tot_term_type_and_u :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (505)) (Prims.of_int (55))
-                 (Prims.of_int (505)) (Prims.of_int (82)))))
+                 (Prims.of_int (504)) (Prims.of_int (55))
+                 (Prims.of_int (504)) (Prims.of_int (82)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (504)) (Prims.of_int (37))
-                 (Prims.of_int (507)) (Prims.of_int (40)))))
+                 (Prims.of_int (503)) (Prims.of_int (37))
+                 (Prims.of_int (506)) (Prims.of_int (40)))))
         (Obj.magic (compute_term_type_and_u g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -4899,13 +4901,13 @@ let (core_compute_tot_term_type :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (513)) (Prims.of_int (25))
-                 (Prims.of_int (513)) (Prims.of_int (51)))))
+                 (Prims.of_int (512)) (Prims.of_int (25))
+                 (Prims.of_int (512)) (Prims.of_int (51)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (512)) (Prims.of_int (36))
-                 (Prims.of_int (515)) (Prims.of_int (40)))))
+                 (Prims.of_int (511)) (Prims.of_int (36))
+                 (Prims.of_int (514)) (Prims.of_int (40)))))
         (Obj.magic (core_compute_term_type g t))
         (fun uu___ ->
            (fun uu___ ->
@@ -4940,13 +4942,13 @@ let (is_non_informative :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (521)) (Prims.of_int (21))
-                 (Prims.of_int (521)) (Prims.of_int (89)))))
+                 (Prims.of_int (520)) (Prims.of_int (21))
+                 (Prims.of_int (520)) (Prims.of_int (89)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                 (Prims.of_int (520)) (Prims.of_int (28))
-                 (Prims.of_int (523)) (Prims.of_int (6)))))
+                 (Prims.of_int (519)) (Prims.of_int (28))
+                 (Prims.of_int (522)) (Prims.of_int (6)))))
         (Obj.magic
            (catch_all
               (fun uu___ ->
@@ -4962,13 +4964,13 @@ let (is_non_informative :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (522)) (Prims.of_int (2))
-                                (Prims.of_int (522)) (Prims.of_int (21)))))
+                                (Prims.of_int (521)) (Prims.of_int (2))
+                                (Prims.of_int (521)) (Prims.of_int (21)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                (Prims.of_int (521)) (Prims.of_int (6))
-                                (Prims.of_int (521)) (Prims.of_int (10)))))
+                                (Prims.of_int (520)) (Prims.of_int (6))
+                                (Prims.of_int (520)) (Prims.of_int (10)))))
                        (Obj.magic
                           (FStar_Tactics_V2_Builtins.log_issues issues))
                        (fun uu___1 ->
@@ -4990,13 +4992,13 @@ let (check_subtyping :
                (FStar_Sealed.seal
                   (Obj.magic
                      (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                        (Prims.of_int (527)) (Prims.of_int (20))
-                        (Prims.of_int (527)) (Prims.of_int (47)))))
+                        (Prims.of_int (526)) (Prims.of_int (20))
+                        (Prims.of_int (526)) (Prims.of_int (47)))))
                (FStar_Sealed.seal
                   (Obj.magic
                      (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                        (Prims.of_int (526)) (Prims.of_int (35))
-                        (Prims.of_int (535)) (Prims.of_int (47)))))
+                        (Prims.of_int (525)) (Prims.of_int (35))
+                        (Prims.of_int (534)) (Prims.of_int (47)))))
                (Obj.magic (rtb_check_subtyping g t1 t2))
                (fun uu___1 ->
                   (fun uu___1 ->
@@ -5008,17 +5010,17 @@ let (check_subtyping :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (528))
+                                       (Prims.of_int (527))
                                        (Prims.of_int (2))
-                                       (Prims.of_int (528))
+                                       (Prims.of_int (527))
                                        (Prims.of_int (21)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Checker.Pure.fst"
-                                       (Prims.of_int (529))
+                                       (Prims.of_int (528))
                                        (Prims.of_int (2))
-                                       (Prims.of_int (535))
+                                       (Prims.of_int (534))
                                        (Prims.of_int (47)))))
                               (Obj.magic
                                  (FStar_Tactics_V2_Builtins.log_issues issues))
@@ -5038,17 +5040,17 @@ let (check_subtyping :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Pure.fst"
-                                                         (Prims.of_int (534))
+                                                         (Prims.of_int (533))
                                                          (Prims.of_int (10))
-                                                         (Prims.of_int (535))
+                                                         (Prims.of_int (534))
                                                          (Prims.of_int (47)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "Pulse.Checker.Pure.fst"
-                                                         (Prims.of_int (533))
+                                                         (Prims.of_int (532))
                                                          (Prims.of_int (4))
-                                                         (Prims.of_int (535))
+                                                         (Prims.of_int (534))
                                                          (Prims.of_int (47)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_Effect.tac_bind
@@ -5056,17 +5058,17 @@ let (check_subtyping :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Pure.fst"
-                                                               (Prims.of_int (534))
+                                                               (Prims.of_int (533))
                                                                (Prims.of_int (12))
-                                                               (Prims.of_int (535))
+                                                               (Prims.of_int (534))
                                                                (Prims.of_int (46)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "Pulse.Checker.Pure.fst"
-                                                               (Prims.of_int (534))
+                                                               (Prims.of_int (533))
                                                                (Prims.of_int (10))
-                                                               (Prims.of_int (535))
+                                                               (Prims.of_int (534))
                                                                (Prims.of_int (47)))))
                                                       (Obj.magic
                                                          (FStar_Tactics_Effect.tac_bind
@@ -5074,17 +5076,17 @@ let (check_subtyping :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (46)))))
                                                             (FStar_Sealed.seal
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (534))
+                                                                    (Prims.of_int (533))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (46)))))
                                                             (Obj.magic
                                                                (FStar_Tactics_Effect.tac_bind
@@ -5092,17 +5094,17 @@ let (check_subtyping :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (21)))))
                                                                   (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (46)))))
                                                                   (Obj.magic
                                                                     (Pulse_PP.pp
@@ -5118,17 +5120,17 @@ let (check_subtyping :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (46)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -5136,17 +5138,17 @@ let (check_subtyping :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Pure.fst"
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (26))
-                                                                    (Prims.of_int (535))
+                                                                    (Prims.of_int (534))
                                                                     (Prims.of_int (46)))))
                                                                     (Obj.magic
                                                                     (Pulse_PP.pp
@@ -5206,13 +5208,13 @@ let (check_equiv :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (540)) (Prims.of_int (4))
-                   (Prims.of_int (540)) (Prims.of_int (56)))))
+                   (Prims.of_int (539)) (Prims.of_int (4))
+                   (Prims.of_int (539)) (Prims.of_int (56)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                   (Prims.of_int (538)) (Prims.of_int (25))
-                   (Prims.of_int (542)) (Prims.of_int (5)))))
+                   (Prims.of_int (537)) (Prims.of_int (25))
+                   (Prims.of_int (541)) (Prims.of_int (5)))))
           (Obj.magic
              (Pulse_Typing_Util.check_equiv_now (Pulse_Typing.elab_env g) t1
                 t2))
@@ -5225,13 +5227,13 @@ let (check_equiv :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (541)) (Prims.of_int (2))
-                                  (Prims.of_int (541)) (Prims.of_int (21)))))
+                                  (Prims.of_int (540)) (Prims.of_int (2))
+                                  (Prims.of_int (540)) (Prims.of_int (21)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "Pulse.Checker.Pure.fst"
-                                  (Prims.of_int (539)) (Prims.of_int (6))
-                                  (Prims.of_int (539)) (Prims.of_int (9)))))
+                                  (Prims.of_int (538)) (Prims.of_int (6))
+                                  (Prims.of_int (538)) (Prims.of_int (9)))))
                          (Obj.magic
                             (FStar_Tactics_V2_Builtins.log_issues issues))
                          (fun uu___1 ->

--- a/src/ocaml/plugin/generated/Pulse_Main.ml
+++ b/src/ocaml/plugin/generated/Pulse_Main.ml
@@ -2869,9 +2869,10 @@ let (main :
                                          uu___3))) uu___2))) uu___1)
 let (check_pulse_core :
   (unit ->
-     (Pulse_Syntax_Base.decl,
-       (Prims.string * FStar_Range.range) FStar_Pervasives_Native.option)
-       FStar_Pervasives.either)
+     ((Pulse_Syntax_Base.decl,
+        (Prims.string * FStar_Range.range) FStar_Pervasives_Native.option)
+        FStar_Pervasives.either,
+       unit) FStar_Tactics_Effect.tac_repr)
     -> FStar_Reflection_Typing.dsl_tac_t)
   =
   fun as_decl ->
@@ -2946,8 +2947,7 @@ let (check_pulse_core :
                              (FStar_Range.mk_range "Pulse.Main.fst"
                                 (Prims.of_int (296)) (Prims.of_int (6))
                                 (Prims.of_int (312)) (Prims.of_int (36)))))
-                       (FStar_Tactics_Effect.lift_div_tac
-                          (fun uu___2 -> as_decl ()))
+                       (Obj.magic (as_decl ()))
                        (fun uu___2 ->
                           (fun uu___2 ->
                              match uu___2 with
@@ -3116,9 +3116,14 @@ let (check_pulse :
                   | (env, expected_t) ->
                       check_pulse_core
                         (fun uu___1 ->
-                           PulseSyntaxExtension_ASTBuilder.parse_pulse env
-                             namespaces module_abbrevs content file_name line
-                             col) (env, expected_t)
+                           (fun uu___1 ->
+                              Obj.magic
+                                (FStar_Tactics_Effect.lift_div_tac
+                                   (fun uu___2 ->
+                                      PulseSyntaxExtension_ASTBuilder.parse_pulse
+                                        env namespaces module_abbrevs content
+                                        file_name line col))) uu___1)
+                        (env, expected_t)
 let _ =
   FStar_Tactics_Native.register_tactic "Pulse.Main.check_pulse"
     (Prims.of_int (9))
@@ -3175,9 +3180,13 @@ let check_pulse_after_desugar : 'a . 'a -> FStar_Reflection_Typing.dsl_tac_t
       | (env, expected_t) ->
           check_pulse_core
             (fun uu___1 ->
-               FStar_Pervasives.Inl
-                 (Pulse_RuntimeUtils.unembed_pulse_decl decl))
-            (env, expected_t)
+               (fun uu___1 ->
+                  Obj.magic
+                    (FStar_Tactics_Effect.lift_div_tac
+                       (fun uu___2 ->
+                          FStar_Pervasives.Inl
+                            (Pulse_RuntimeUtils.unembed_pulse_decl decl))))
+                 uu___1) (env, expected_t)
 let _ =
   FStar_Tactics_Native.register_tactic "Pulse.Main.check_pulse_after_desugar"
     (Prims.of_int (4))

--- a/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
@@ -29,6 +29,7 @@ module R = FStar.Compiler.Range
 module BU = FStar.Compiler.Util
 module P =  FStar.Syntax.Print
 module LR = PulseSyntaxExtension.TransformRValues
+
 open FStar.Class.Show
 open FStar.Class.HasRange
 open FStar.Class.Monad
@@ -36,6 +37,12 @@ open FStar.Ident
 open FStar.List.Tot
 open PulseSyntaxExtension.Err
 open PulseSyntaxExtension.Env
+
+let close_st_term_bvs (e:SW.st_term) (xs:list SW.bv) : SW.st_term = 
+  SW.close_st_term_n e (L.map SW.index_of_bv xs)
+
+let close_comp_bvs  (e:SW.comp) (xs:list SW.bv) : SW.comp = 
+  SW.close_comp_n e (L.map SW.index_of_bv xs)
 
 let rec fold_right1 (f : 'a -> 'a -> 'a) (l : list 'a) : 'a =
   match l with
@@ -753,6 +760,10 @@ and desugar_decl (env:env_t)
     let bs'' = init @ [last] in
     return (A.mk_term (A.Product (bs'', res_t)) r A.Expr)
   in
+  let close_st_term_binders qbs body =
+    let bvs = List.Tot.map (fun (_, _, b) -> b) qbs in
+    close_st_term_bvs body bvs
+  in
   match d with
   | Sugar.FnDefn { id; is_rec; binders; ascription=Inl ascription; measure; body=Inl body; range } ->
     let! env, bs, bvs = desugar_binders env binders in
@@ -781,6 +792,7 @@ and desugar_decl (env:env_t)
     in
     let! body = desugar_stmt env body in
     let! qbs = map2 faux bs bvs in
+    let body = close_st_term_binders qbs body in
     return (SW.fn_defn range id is_rec qbs comp meas body)
 
   | Sugar.FnDefn { id; is_rec=false; binders; ascription=Inr ascription; measure=None; body=Inr body; range } ->
@@ -792,12 +804,14 @@ and desugar_decl (env:env_t)
     in
     let! body = desugar_lambda env body in
     let! qbs = map2 faux bs bvs in
+    let body = close_st_term_binders qbs body in
     return (SW.fn_defn range id false qbs comp None body)
 
   | Sugar.FnDecl { id; binders; ascription=Inl ascription; range } ->
     let! env, bs, bvs = desugar_binders env binders in
     let! comp = desugar_computation_type env ascription in
     let! qbs = map2 faux bs bvs in
+    let comp = close_comp_bvs comp (List.Tot.map (fun (_,_,bv) -> bv) qbs) in
     return (SW.fn_decl range id qbs comp)
 
 let reinitialize_env (dsenv:D.env)

--- a/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
+++ b/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
@@ -110,6 +110,7 @@ val close_term (t:term) (v:var) : term
 val close_st_term (t:st_term) (v:var) : st_term
 val close_st_term_n (t:st_term) (vs:list var) : st_term
 val close_comp (t:comp) (v:var) : comp
+val close_comp_n (t:comp) (vs:list var) : comp
 val comp_pre (c:comp) : term
 val comp_res (c:comp) : term
 val comp_post (c:comp) : term


### PR DESCRIPTION
PulseSyntaxExtension.Desugar: Was missing an closing substitution on the binders of FnDefn/FnDecl
Pulse.Syntax.Naming: Map opening substitutions to FStar.Syntax.Syntax.DB substitutions to preserve ranges

Previously:
```
let id (#a:Type) (x y:a) = x

[@@expect_failure]
fn test3 (x:nat) (y:bool)
requires emp
returns z:nat
ensures emp
{
    id x y
}
```

This would report a typing error on `y`, but it would point to the binder `y:bool`.
Now, it correctly points to the usage site.
