### PR TITLE
Fail with a proper range

### DIFF
--- a/src/checker/Pulse.Typing.Env.fst
+++ b/src/checker/Pulse.Typing.Env.fst
@@ -403,7 +403,7 @@ let fail_doc_env (#a:Type) (with_env:bool) (g:env) (r:option range) (msg:list Pp
   in
   let issue = FStar.Issue.mk_issue_doc "Error" msg (Some r) None (ctxt_to_list g) in
   T.log_issues [issue];
-  T.fail "Pulse checker failed"
+  T.fail_at "Pulse checker failed" (Some r)
 
 let warn_doc (g:env) (r:option range) (msg:list Pprint.document) : T.Tac unit =
   let r = get_range g r in

--- a/src/ocaml/plugin/generated/Pulse_Typing_Env.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_Env.ml
@@ -1202,7 +1202,7 @@ let fail_doc_env :
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Typing.Env.fst"
                      (Prims.of_int (393)) (Prims.of_int (26))
-                     (Prims.of_int (406)) (Prims.of_int (31)))))
+                     (Prims.of_int (406)) (Prims.of_int (43)))))
             (Obj.magic (get_range g r))
             (fun uu___ ->
                (fun r1 ->
@@ -1217,7 +1217,7 @@ let fail_doc_env :
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Typing.Env.fst"
                                 (Prims.of_int (403)) (Prims.of_int (4))
-                                (Prims.of_int (406)) (Prims.of_int (31)))))
+                                (Prims.of_int (406)) (Prims.of_int (43)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
@@ -1411,7 +1411,7 @@ let fail_doc_env :
                                            (Prims.of_int (405))
                                            (Prims.of_int (2))
                                            (Prims.of_int (406))
-                                           (Prims.of_int (31)))))
+                                           (Prims.of_int (43)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
                                         (FStar_Sealed.seal
@@ -1459,14 +1459,16 @@ let fail_doc_env :
                                                       (Prims.of_int (406))
                                                       (Prims.of_int (2))
                                                       (Prims.of_int (406))
-                                                      (Prims.of_int (31)))))
+                                                      (Prims.of_int (43)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.log_issues
                                                    [issue]))
                                              (fun uu___ ->
-                                                FStar_Tactics_V2_Derived.fail
-                                                  "Pulse checker failed")))
-                                       uu___))) uu___))) uu___)
+                                                FStar_Tactics_V2_Derived.fail_at
+                                                  "Pulse checker failed"
+                                                  (FStar_Pervasives_Native.Some
+                                                     r1)))) uu___))) uu___)))
+                 uu___)
 let fail_doc :
   'a .
     env ->


### PR DESCRIPTION
Now that we have fail_at from Nik, we can localize the "Pulse
checker failed" error instead of highlighting a huge range.