### PR TITLE
Introduce --ext 'pulse:trace' to print contexts before every step

### DIFF
--- a/src/checker/Pulse.Checker.Bind.fst
+++ b/src/checker/Pulse.Checker.Bind.fst
@@ -28,7 +28,7 @@ module P = Pulse.Syntax.Printer
 module Metatheory = Pulse.Typing.Metatheory
 module PS = Pulse.Checker.Prover.Substs
 module Abs = Pulse.Checker.Abs
-
+module RU = Pulse.RuntimeUtils
 
 #push-options "--z3rlimit_factor 4 --split_queries no"
 let check_bind_fn
@@ -72,8 +72,8 @@ let check_bind
   (res_ppname:ppname)
   (t:st_term {Tm_Bind? t.term})
   (check:check_t)
-  : T.Tac (checker_result_t g ctxt post_hint) =
-
+  : T.Tac (checker_result_t g ctxt post_hint)
+=
   let g = Pulse.Typing.Env.push_context g "check_bind" t.range in
 
   debug_prover g (fun _ ->
@@ -130,7 +130,6 @@ let check_bind
     checker_result_for_st_typing d res_ppname
   )
 
-
 let check_tot_bind
   (g:env)
   (pre:term)
@@ -139,8 +138,8 @@ let check_tot_bind
   (res_ppname:ppname)
   (t:st_term { Tm_TotBind? t.term })
   (check:check_t)
-  : T.Tac (checker_result_t g pre post_hint) =
-
+  : T.Tac (checker_result_t g pre post_hint)
+=
   let g = Pulse.Typing.Env.push_context g "check_tot_bind" t.range in
 
   if None? post_hint

--- a/src/checker/Pulse.Checker.fst
+++ b/src/checker/Pulse.Checker.fst
@@ -137,6 +137,29 @@ let rec transform_to_unary_intro_exists (g:env) (t:term) (ws:list term)
 
     | _ -> fail g (Some t_rng) "intro exists with non-existential"
 
+let trace (t:st_term) (g:env) (pre:term) (rng:range) : T.Tac unit =
+  let trace_opt = T.ext_getv "pulse:trace" = "1" in
+  if trace_opt then begin
+    (* If we're running interactively, print out the context
+    and environment. *)
+    let open FStar.Stubs.Pprint in
+    let open Pulse.PP in
+    let pre = T.norm_well_typed_term (elab_env g) [Pervasives.unascribe; primops; iota] pre in
+    let msg = [
+      text "Trace";
+      prefix 2 1 (text "Just before checking:")
+        (pp t);
+      text "Current context:" ^^
+        indent (pp <| canon_slprop_print pre)
+    ] in
+    (* This tweaks the range to go to the beginning of the line. *)
+    let rng =
+      let (f, l1, c1, l2, c2) = FStar.Range.explode (T.unseal rng) in
+      FStar.Range.mk_range f l1 0 l1 2
+    in
+    info_doc_env g (Some rng) msg
+  end
+
 #push-options "--z3rlimit_factor 4 --fuel 0 --ifuel 1"
 let rec check
   (g0:env)
@@ -152,6 +175,8 @@ let rec check
     let (| g, pre, pre_typing, k_elim_pure |) = 
       Pulse.Checker.Prover.elim_exists_and_pure pre0_typing 
     in
+
+    trace t g pre t.range;
   
     if RU.debug_at_level (fstar_env g) "pulse.checker" then
       T.print (Printf.sprintf "At %s{\nerr context:\n>%s\n\n{\n\tenv=%s\ncontext:\n%s,\n\nst_term: %s}}\n"

--- a/src/ocaml/plugin/generated/Pulse_Checker.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker.ml
@@ -444,6 +444,391 @@ let rec (transform_to_unary_intro_exists :
                            (Pulse_Typing_Env.fail g
                               (FStar_Pervasives_Native.Some t_rng)
                               "intro exists with non-existential"))) uu___)
+let (trace :
+  Pulse_Syntax_Base.st_term ->
+    Pulse_Typing_Env.env ->
+      Pulse_Syntax_Base.term ->
+        Pulse_Syntax_Base.range -> (unit, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun t ->
+    fun g ->
+      fun pre ->
+        fun rng ->
+          FStar_Tactics_Effect.tac_bind
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "Pulse.Checker.fst"
+                     (Prims.of_int (141)) (Prims.of_int (18))
+                     (Prims.of_int (141)) (Prims.of_int (48)))))
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "Pulse.Checker.fst"
+                     (Prims.of_int (142)) (Prims.of_int (2))
+                     (Prims.of_int (161)) (Prims.of_int (5)))))
+            (Obj.magic
+               (FStar_Tactics_Effect.tac_bind
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range "Pulse.Checker.fst"
+                           (Prims.of_int (141)) (Prims.of_int (18))
+                           (Prims.of_int (141)) (Prims.of_int (42)))))
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range "Pulse.Checker.fst"
+                           (Prims.of_int (141)) (Prims.of_int (18))
+                           (Prims.of_int (141)) (Prims.of_int (48)))))
+                  (Obj.magic
+                     (FStar_Tactics_V2_Builtins.ext_getv "pulse:trace"))
+                  (fun uu___ ->
+                     FStar_Tactics_Effect.lift_div_tac
+                       (fun uu___1 -> uu___ = "1"))))
+            (fun uu___ ->
+               (fun trace_opt ->
+                  if trace_opt
+                  then
+                    Obj.magic
+                      (Obj.repr
+                         (FStar_Tactics_Effect.tac_bind
+                            (FStar_Sealed.seal
+                               (Obj.magic
+                                  (FStar_Range.mk_range "Pulse.Checker.fst"
+                                     (Prims.of_int (147)) (Prims.of_int (14))
+                                     (Prims.of_int (147)) (Prims.of_int (91)))))
+                            (FStar_Sealed.seal
+                               (Obj.magic
+                                  (FStar_Range.mk_range "Pulse.Checker.fst"
+                                     (Prims.of_int (147)) (Prims.of_int (94))
+                                     (Prims.of_int (160)) (Prims.of_int (33)))))
+                            (Obj.magic
+                               (FStar_Tactics_V2_Builtins.norm_well_typed_term
+                                  (Pulse_Typing.elab_env g)
+                                  [FStar_Pervasives.unascribe;
+                                  FStar_Pervasives.primops;
+                                  FStar_Pervasives.iota] pre))
+                            (fun uu___ ->
+                               (fun pre1 ->
+                                  Obj.magic
+                                    (FStar_Tactics_Effect.tac_bind
+                                       (FStar_Sealed.seal
+                                          (Obj.magic
+                                             (FStar_Range.mk_range
+                                                "Pulse.Checker.fst"
+                                                (Prims.of_int (148))
+                                                (Prims.of_int (14))
+                                                (Prims.of_int (154))
+                                                (Prims.of_int (5)))))
+                                       (FStar_Sealed.seal
+                                          (Obj.magic
+                                             (FStar_Range.mk_range
+                                                "Pulse.Checker.fst"
+                                                (Prims.of_int (154))
+                                                (Prims.of_int (8))
+                                                (Prims.of_int (160))
+                                                (Prims.of_int (33)))))
+                                       (Obj.magic
+                                          (FStar_Tactics_Effect.tac_bind
+                                             (FStar_Sealed.seal
+                                                (Obj.magic
+                                                   (FStar_Range.mk_range
+                                                      "Pulse.Checker.fst"
+                                                      (Prims.of_int (148))
+                                                      (Prims.of_int (14))
+                                                      (Prims.of_int (154))
+                                                      (Prims.of_int (5)))))
+                                             (FStar_Sealed.seal
+                                                (Obj.magic
+                                                   (FStar_Range.mk_range
+                                                      "Pulse.Checker.fst"
+                                                      (Prims.of_int (148))
+                                                      (Prims.of_int (14))
+                                                      (Prims.of_int (154))
+                                                      (Prims.of_int (5)))))
+                                             (Obj.magic
+                                                (FStar_Tactics_Effect.tac_bind
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "Pulse.Checker.fst"
+                                                            (Prims.of_int (150))
+                                                            (Prims.of_int (6))
+                                                            (Prims.of_int (151))
+                                                            (Prims.of_int (14)))))
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "Pulse.Checker.fst"
+                                                            (Prims.of_int (148))
+                                                            (Prims.of_int (14))
+                                                            (Prims.of_int (154))
+                                                            (Prims.of_int (5)))))
+                                                   (Obj.magic
+                                                      (FStar_Tactics_Effect.tac_bind
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Checker.fst"
+                                                                  (Prims.of_int (151))
+                                                                  (Prims.of_int (8))
+                                                                  (Prims.of_int (151))
+                                                                  (Prims.of_int (14)))))
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Checker.fst"
+                                                                  (Prims.of_int (150))
+                                                                  (Prims.of_int (6))
+                                                                  (Prims.of_int (151))
+                                                                  (Prims.of_int (14)))))
+                                                         (Obj.magic
+                                                            (Pulse_PP.pp
+                                                               Pulse_PP.printable_st_term
+                                                               t))
+                                                         (fun uu___ ->
+                                                            FStar_Tactics_Effect.lift_div_tac
+                                                              (fun uu___1 ->
+                                                                 FStar_Pprint.prefix
+                                                                   (Prims.of_int (2))
+                                                                   Prims.int_one
+                                                                   (Pulse_PP.text
+                                                                    "Just before checking:")
+                                                                   uu___))))
+                                                   (fun uu___ ->
+                                                      (fun uu___ ->
+                                                         Obj.magic
+                                                           (FStar_Tactics_Effect.tac_bind
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (148))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (5)))))
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (148))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (5)))))
+                                                              (Obj.magic
+                                                                 (FStar_Tactics_Effect.tac_bind
+                                                                    (
+                                                                    FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (45)))))
+                                                                    (
+                                                                    FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (148))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (5)))))
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (45)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (45)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (45)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (45)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (22))
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (44)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (45)))))
+                                                                    (Obj.magic
+                                                                    (Pulse_Syntax_Pure.canon_slprop_print
+                                                                    pre1))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    Obj.magic
+                                                                    (Pulse_PP.pp
+                                                                    Pulse_PP.printable_term
+                                                                    uu___1))
+                                                                    uu___1)))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    Pulse_PP.indent
+                                                                    uu___1))))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    (Pulse_PP.text
+                                                                    "Current context:")
+                                                                    uu___1))))
+                                                                    (
+                                                                    fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    [uu___1]))))
+                                                              (fun uu___1 ->
+                                                                 FStar_Tactics_Effect.lift_div_tac
+                                                                   (fun
+                                                                    uu___2 ->
+                                                                    uu___ ::
+                                                                    uu___1))))
+                                                        uu___)))
+                                             (fun uu___ ->
+                                                FStar_Tactics_Effect.lift_div_tac
+                                                  (fun uu___1 ->
+                                                     (Pulse_PP.text "Trace")
+                                                     :: uu___))))
+                                       (fun uu___ ->
+                                          (fun msg ->
+                                             Obj.magic
+                                               (FStar_Tactics_Effect.tac_bind
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "Pulse.Checker.fst"
+                                                           (Prims.of_int (156))
+                                                           (Prims.of_int (13))
+                                                           (Prims.of_int (158))
+                                                           (Prims.of_int (38)))))
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "Pulse.Checker.fst"
+                                                           (Prims.of_int (160))
+                                                           (Prims.of_int (4))
+                                                           (Prims.of_int (160))
+                                                           (Prims.of_int (33)))))
+                                                  (Obj.magic
+                                                     (FStar_Tactics_Effect.tac_bind
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Checker.fst"
+                                                                 (Prims.of_int (157))
+                                                                 (Prims.of_int (32))
+                                                                 (Prims.of_int (157))
+                                                                 (Prims.of_int (66)))))
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "Pulse.Checker.fst"
+                                                                 (Prims.of_int (156))
+                                                                 (Prims.of_int (13))
+                                                                 (Prims.of_int (158))
+                                                                 (Prims.of_int (38)))))
+                                                        (Obj.magic
+                                                           (FStar_Tactics_Effect.tac_bind
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (52))
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (66)))))
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (32))
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (66)))))
+                                                              (Obj.magic
+                                                                 (FStar_Tactics_Unseal.unseal
+                                                                    rng))
+                                                              (fun uu___ ->
+                                                                 FStar_Tactics_Effect.lift_div_tac
+                                                                   (fun
+                                                                    uu___1 ->
+                                                                    FStar_Range.explode
+                                                                    uu___))))
+                                                        (fun uu___ ->
+                                                           FStar_Tactics_Effect.lift_div_tac
+                                                             (fun uu___1 ->
+                                                                match uu___
+                                                                with
+                                                                | (f, l1, c1,
+                                                                   l2, c2) ->
+                                                                    FStar_Range.mk_range
+                                                                    f l1
+                                                                    Prims.int_zero
+                                                                    l1
+                                                                    (Prims.of_int (2))))))
+                                                  (fun uu___ ->
+                                                     (fun rng1 ->
+                                                        Obj.magic
+                                                          (Pulse_Typing_Env.info_doc_env
+                                                             g
+                                                             (FStar_Pervasives_Native.Some
+                                                                rng1) msg))
+                                                       uu___))) uu___)))
+                                 uu___)))
+                  else
+                    Obj.magic
+                      (Obj.repr
+                         (FStar_Tactics_Effect.lift_div_tac
+                            (fun uu___1 -> ())))) uu___)
 let rec (check : Pulse_Checker_Base.check_t) =
   fun g0 ->
     fun pre0 ->
@@ -460,13 +845,13 @@ let rec (check : Pulse_Checker_Base.check_t) =
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.fst"
-                           (Prims.of_int (153)) (Prims.of_int (6))
-                           (Prims.of_int (153)) (Prims.of_int (59)))))
+                           (Prims.of_int (176)) (Prims.of_int (6))
+                           (Prims.of_int (176)) (Prims.of_int (59)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.fst"
-                           (Prims.of_int (151)) (Prims.of_int (7))
-                           (Prims.of_int (290)) (Prims.of_int (3)))))
+                           (Prims.of_int (174)) (Prims.of_int (7))
+                           (Prims.of_int (315)) (Prims.of_int (3)))))
                   (Obj.magic
                      (Pulse_Checker_Prover.elim_exists_and_pure g0 pre0 ()))
                   (fun uu___1 ->
@@ -480,125 +865,148 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Checker.fst"
-                                          (Prims.of_int (156))
+                                          (Prims.of_int (179))
                                           (Prims.of_int (4))
-                                          (Prims.of_int (162))
-                                          (Prims.of_int (59)))))
+                                          (Prims.of_int (179))
+                                          (Prims.of_int (25)))))
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Checker.fst"
-                                          (Prims.of_int (162))
-                                          (Prims.of_int (60))
-                                          (Prims.of_int (289))
+                                          (Prims.of_int (181))
+                                          (Prims.of_int (4))
+                                          (Prims.of_int (314))
                                           (Prims.of_int (52)))))
-                                 (if
-                                    Pulse_RuntimeUtils.debug_at_level
-                                      (Pulse_Typing_Env.fstar_env g)
-                                      "pulse.checker"
-                                  then
-                                    Obj.magic
-                                      (Obj.repr
+                                 (Obj.magic
+                                    (trace t g pre t.Pulse_Syntax_Base.range1))
+                                 (fun uu___2 ->
+                                    (fun uu___2 ->
+                                       Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Checker.fst"
-                                                     (Prims.of_int (157))
-                                                     (Prims.of_int (14))
-                                                     (Prims.of_int (162))
+                                                     (Prims.of_int (181))
+                                                     (Prims.of_int (4))
+                                                     (Prims.of_int (187))
                                                      (Prims.of_int (59)))))
                                             (FStar_Sealed.seal
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "Pulse.Checker.fst"
-                                                     (Prims.of_int (157))
-                                                     (Prims.of_int (6))
-                                                     (Prims.of_int (162))
-                                                     (Prims.of_int (59)))))
-                                            (Obj.magic
-                                               (FStar_Tactics_Effect.tac_bind
-                                                  (FStar_Sealed.seal
-                                                     (Obj.magic
-                                                        (FStar_Range.mk_range
-                                                           "Pulse.Checker.fst"
-                                                           (Prims.of_int (162))
-                                                           (Prims.of_int (16))
-                                                           (Prims.of_int (162))
-                                                           (Prims.of_int (58)))))
-                                                  (FStar_Sealed.seal
-                                                     (Obj.magic
-                                                        (FStar_Range.mk_range
-                                                           "Pulse.Checker.fst"
-                                                           (Prims.of_int (157))
-                                                           (Prims.of_int (14))
-                                                           (Prims.of_int (162))
-                                                           (Prims.of_int (59)))))
-                                                  (Obj.magic
-                                                     (Pulse_Syntax_Printer.st_term_to_string
-                                                        t))
-                                                  (fun uu___2 ->
-                                                     (fun uu___2 ->
-                                                        Obj.magic
+                                                     (Prims.of_int (187))
+                                                     (Prims.of_int (60))
+                                                     (Prims.of_int (314))
+                                                     (Prims.of_int (52)))))
+                                            (if
+                                               Pulse_RuntimeUtils.debug_at_level
+                                                 (Pulse_Typing_Env.fstar_env
+                                                    g) "pulse.checker"
+                                             then
+                                               Obj.magic
+                                                 (Obj.repr
+                                                    (FStar_Tactics_Effect.tac_bind
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Checker.fst"
+                                                                (Prims.of_int (182))
+                                                                (Prims.of_int (14))
+                                                                (Prims.of_int (187))
+                                                                (Prims.of_int (59)))))
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Checker.fst"
+                                                                (Prims.of_int (182))
+                                                                (Prims.of_int (6))
+                                                                (Prims.of_int (187))
+                                                                (Prims.of_int (59)))))
+                                                       (Obj.magic
                                                           (FStar_Tactics_Effect.tac_bind
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (157))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (162))
-                                                                    (Prims.of_int (59)))))
+                                                                    (Prims.of_int (187))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (187))
+                                                                    (Prims.of_int (58)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (187))
                                                                     (Prims.of_int (59)))))
                                                              (Obj.magic
-                                                                (FStar_Tactics_Effect.tac_bind
-                                                                   (FStar_Sealed.seal
+                                                                (Pulse_Syntax_Printer.st_term_to_string
+                                                                   t))
+                                                             (fun uu___3 ->
+                                                                (fun uu___3
+                                                                   ->
+                                                                   Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (161))
-                                                                    (Prims.of_int (16))
-                                                                    (Prims.of_int (161))
-                                                                    (Prims.of_int (57)))))
-                                                                   (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (187))
                                                                     (Prims.of_int (59)))))
-                                                                   (Obj.magic
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (187))
+                                                                    (Prims.of_int (59)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (186))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (186))
+                                                                    (Prims.of_int (57)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (187))
+                                                                    (Prims.of_int (59)))))
+                                                                    (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
                                                                     pre))
-                                                                   (fun
-                                                                    uu___3 ->
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
+                                                                    (fun
+                                                                    uu___4 ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (187))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (187))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -606,42 +1014,42 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (185))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (185))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (187))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
                                                                     (Pulse_Typing_Env.env_to_string
                                                                     g))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (187))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (187))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -649,43 +1057,43 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (184))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (184))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (187))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
                                                                     (Pulse_RuntimeUtils.print_context
                                                                     (Pulse_Typing_Env.get_context
                                                                     g)))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (187))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (187))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -693,9 +1101,9 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (158))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (158))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -709,10 +1117,10 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (FStar_Tactics_V2_Builtins.range_to_string
                                                                     t.Pulse_Syntax_Base.range1))
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___7 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___7 ->
+                                                                    uu___8 ->
                                                                     fun x ->
                                                                     fun x1 ->
                                                                     fun x2 ->
@@ -724,7 +1132,7 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Prims.strcat
                                                                     "At "
                                                                     (Prims.strcat
-                                                                    uu___6
+                                                                    uu___7
                                                                     "{\nerr context:\n>"))
                                                                     (Prims.strcat
                                                                     x
@@ -737,6 +1145,14 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     ",\n\nst_term: "))
                                                                     (Prims.strcat
                                                                     x3 "}}\n")))))
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    uu___7
+                                                                    uu___6))))
+                                                                    uu___6)))
                                                                     (fun
                                                                     uu___6 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
@@ -760,144 +1176,142 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     uu___5 ->
                                                                     uu___4
                                                                     uu___3))))
-                                                                    uu___3)))
-                                                             (fun uu___3 ->
-                                                                FStar_Tactics_Effect.lift_div_tac
-                                                                  (fun uu___4
-                                                                    ->
-                                                                    uu___3
-                                                                    uu___2))))
-                                                       uu___2)))
-                                            (fun uu___2 ->
-                                               (fun uu___2 ->
+                                                                  uu___3)))
+                                                       (fun uu___3 ->
+                                                          (fun uu___3 ->
+                                                             Obj.magic
+                                                               (FStar_Tactics_V2_Builtins.print
+                                                                  uu___3))
+                                                            uu___3)))
+                                             else
+                                               Obj.magic
+                                                 (Obj.repr
+                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                       (fun uu___4 -> ()))))
+                                            (fun uu___3 ->
+                                               (fun uu___3 ->
                                                   Obj.magic
-                                                    (FStar_Tactics_V2_Builtins.print
-                                                       uu___2)) uu___2)))
-                                  else
-                                    Obj.magic
-                                      (Obj.repr
-                                         (FStar_Tactics_Effect.lift_div_tac
-                                            (fun uu___3 -> ()))))
-                                 (fun uu___2 ->
-                                    (fun uu___2 ->
-                                       Obj.magic
-                                         (FStar_Tactics_Effect.tac_bind
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Checker.fst"
-                                                     (Prims.of_int (164))
-                                                     (Prims.of_int (46))
-                                                     (Prims.of_int (285))
-                                                     (Prims.of_int (50)))))
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "Pulse.Checker.fst"
-                                                     (Prims.of_int (286))
-                                                     (Prims.of_int (6))
-                                                     (Prims.of_int (289))
-                                                     (Prims.of_int (52)))))
-                                            (Obj.magic
-                                               (FStar_Tactics_Effect.tac_bind
-                                                  (FStar_Sealed.seal
-                                                     (Obj.magic
-                                                        (FStar_Range.mk_range
-                                                           "Pulse.Checker.fst"
-                                                           (Prims.of_int (165))
-                                                           (Prims.of_int (14))
-                                                           (Prims.of_int (165))
-                                                           (Prims.of_int (57)))))
-                                                  (FStar_Sealed.seal
-                                                     (Obj.magic
-                                                        (FStar_Range.mk_range
-                                                           "Pulse.Checker.fst"
-                                                           (Prims.of_int (166))
-                                                           (Prims.of_int (6))
-                                                           (Prims.of_int (285))
-                                                           (Prims.of_int (50)))))
-                                                  (FStar_Tactics_Effect.lift_div_tac
-                                                     (fun uu___3 ->
-                                                        Pulse_Checker_Pure.push_context
-                                                          (Pulse_Syntax_Printer.tag_of_st_term
-                                                             t)
-                                                          t.Pulse_Syntax_Base.range1
-                                                          g))
-                                                  (fun uu___3 ->
-                                                     (fun g1 ->
-                                                        match t.Pulse_Syntax_Base.term1
-                                                        with
-                                                        | Pulse_Syntax_Base.Tm_Return
-                                                            uu___3 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (Pulse_Checker_Return.check
+                                                    (FStar_Tactics_Effect.tac_bind
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Checker.fst"
+                                                                (Prims.of_int (189))
+                                                                (Prims.of_int (46))
+                                                                (Prims.of_int (310))
+                                                                (Prims.of_int (50)))))
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "Pulse.Checker.fst"
+                                                                (Prims.of_int (311))
+                                                                (Prims.of_int (6))
+                                                                (Prims.of_int (314))
+                                                                (Prims.of_int (52)))))
+                                                       (Obj.magic
+                                                          (FStar_Tactics_Effect.tac_bind
+                                                             (FStar_Sealed.seal
+                                                                (Obj.magic
+                                                                   (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (190))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (190))
+                                                                    (Prims.of_int (57)))))
+                                                             (FStar_Sealed.seal
+                                                                (Obj.magic
+                                                                   (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (310))
+                                                                    (Prims.of_int (50)))))
+                                                             (FStar_Tactics_Effect.lift_div_tac
+                                                                (fun uu___4
+                                                                   ->
+                                                                   Pulse_Checker_Pure.push_context
+                                                                    (Pulse_Syntax_Printer.tag_of_st_term
+                                                                    t)
+                                                                    t.Pulse_Syntax_Base.range1
+                                                                    g))
+                                                             (fun uu___4 ->
+                                                                (fun g1 ->
+                                                                   match 
+                                                                    t.Pulse_Syntax_Base.term1
+                                                                   with
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_Return
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (Pulse_Checker_Return.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                        | Pulse_Syntax_Base.Tm_Abs
-                                                            uu___3 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (FStar_Tactics_V2_Derived.fail
-                                                                    "Tm_Abs check should not have been called in the checker"))
-                                                        | Pulse_Syntax_Base.Tm_STApp
-                                                            uu___3 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (Pulse_Checker_STApp.check
-                                                                    g1 pre ()
-                                                                    post_hint
-                                                                    res_ppname
-                                                                    t))
-                                                        | Pulse_Syntax_Base.Tm_ElimExists
-                                                            uu___3 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (Pulse_Checker_Exists.check_elim_exists
-                                                                    g1 pre ()
-                                                                    post_hint
-                                                                    res_ppname
-                                                                    t))
-                                                        | Pulse_Syntax_Base.Tm_IntroExists
-                                                            {
-                                                              Pulse_Syntax_Base.p5
-                                                                = p;
-                                                              Pulse_Syntax_Base.witnesses
-                                                                = witnesses;_}
-                                                            ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (FStar_Tactics_Effect.tac_bind
-                                                                    (
-                                                                    FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.fst"
-                                                                    (Prims.of_int (186))
-                                                                    (Prims.of_int (15))
-                                                                    (Prims.of_int (186))
-                                                                    (Prims.of_int (48)))))
-                                                                    (
-                                                                    FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.fst"
-                                                                    (Prims.of_int (186))
-                                                                    (Prims.of_int (8))
-                                                                    (Prims.of_int (196))
-                                                                    (Prims.of_int (58)))))
-                                                                    (
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_Abs
+                                                                    uu___4 ->
                                                                     Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_V2_Derived.fail
+                                                                    "Tm_Abs check should not have been called in the checker"))
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_STApp
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (Pulse_Checker_STApp.check
+                                                                    g1 pre ()
+                                                                    post_hint
+                                                                    res_ppname
+                                                                    t))
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_ElimExists
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (Pulse_Checker_Exists.check_elim_exists
+                                                                    g1 pre ()
+                                                                    post_hint
+                                                                    res_ppname
+                                                                    t))
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_IntroExists
+                                                                    {
+                                                                    Pulse_Syntax_Base.p5
+                                                                    = p;
+                                                                    Pulse_Syntax_Base.witnesses
+                                                                    =
+                                                                    witnesses;_}
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (48)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (211))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (221))
+                                                                    (Prims.of_int (58)))))
+                                                                    (Obj.magic
                                                                     (instantiate_unknown_witnesses
                                                                     g1 t))
-                                                                    (
-                                                                    fun
-                                                                    uu___3 ->
                                                                     (fun
-                                                                    uu___3 ->
-                                                                    match uu___3
+                                                                    uu___4 ->
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    match uu___4
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.Some
@@ -922,7 +1336,7 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (t.Pulse_Syntax_Base.range1))
                                                                     "intro exists with empty witnesses")
                                                                     | 
-                                                                    uu___4::[]
+                                                                    uu___5::[]
                                                                     ->
                                                                     Obj.magic
                                                                     (Pulse_Checker_Exists.check_intro_exists
@@ -932,31 +1346,31 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     t
                                                                     FStar_Pervasives_Native.None)
                                                                     | 
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (220))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (220))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (196))
+                                                                    (Prims.of_int (221))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (196))
+                                                                    (Prims.of_int (221))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
                                                                     (transform_to_unary_intro_exists
                                                                     g1 p
                                                                     witnesses))
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     (fun t1
                                                                     ->
                                                                     Obj.magic
@@ -965,60 +1379,60 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     post_hint
                                                                     res_ppname
                                                                     t1))
-                                                                    uu___5))))
-                                                                    uu___3)))
-                                                        | Pulse_Syntax_Base.Tm_Bind
-                                                            uu___3 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (Pulse_Checker_Bind.check_bind
+                                                                    uu___6))))
+                                                                    uu___4)))
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_Bind
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (Pulse_Checker_Bind.check_bind
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                        | Pulse_Syntax_Base.Tm_TotBind
-                                                            uu___3 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (Pulse_Checker_Bind.check_tot_bind
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_TotBind
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (Pulse_Checker_Bind.check_tot_bind
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                        | Pulse_Syntax_Base.Tm_If
-                                                            {
-                                                              Pulse_Syntax_Base.b1
-                                                                = b;
-                                                              Pulse_Syntax_Base.then_
-                                                                = e1;
-                                                              Pulse_Syntax_Base.else_
-                                                                = e2;
-                                                              Pulse_Syntax_Base.post1
-                                                                = post_if;_}
-                                                            ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (FStar_Tactics_Effect.tac_bind
-                                                                    (
-                                                                    FStar_Sealed.seal
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_If
+                                                                    {
+                                                                    Pulse_Syntax_Base.b1
+                                                                    = b;
+                                                                    Pulse_Syntax_Base.then_
+                                                                    = e1;
+                                                                    Pulse_Syntax_Base.else_
+                                                                    = e2;
+                                                                    Pulse_Syntax_Base.post1
+                                                                    = post_if;_}
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (205))
+                                                                    (Prims.of_int (230))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (97)))))
-                                                                    (
-                                                                    FStar_Sealed.seal
+                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (31)))))
-                                                                    (
-                                                                    match 
+                                                                    (match 
                                                                     (post_if,
                                                                     post_hint)
                                                                     with
@@ -1030,7 +1444,7 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.repr
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     p)))
                                                                     | 
                                                                     (FStar_Pervasives_Native.Some
@@ -1056,17 +1470,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (218))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (212))
+                                                                    (Prims.of_int (237))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (218))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1074,42 +1488,42 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (218))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (218))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (218))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
                                                                     p))
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (218))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (218))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1117,9 +1531,9 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (217))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (217))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1133,41 +1547,41 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Pulse_Syntax_Printer.term_to_string
                                                                     q.Pulse_Typing.post))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     fun x ->
                                                                     Prims.strcat
                                                                     (Prims.strcat
                                                                     "Multiple annotated postconditions---remove one of them.\nThe context expects the postcondition "
                                                                     (Prims.strcat
-                                                                    uu___4
+                                                                    uu___5
                                                                     ",\nbut this conditional was annotated with postcondition "))
                                                                     (Prims.strcat
                                                                     x "")))))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___5 ->
-                                                                    uu___4
-                                                                    uu___3))))
-                                                                    uu___3)))
+                                                                    uu___6 ->
+                                                                    uu___5
+                                                                    uu___4))))
+                                                                    uu___4)))
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     Obj.magic
                                                                     (Pulse_Typing_Env.fail
                                                                     g1
                                                                     (FStar_Pervasives_Native.Some
                                                                     (t.Pulse_Syntax_Base.range1))
-                                                                    uu___3))
-                                                                    uu___3)))
+                                                                    uu___4))
+                                                                    uu___4)))
                                                                     | 
-                                                                    (uu___3,
-                                                                    uu___4)
+                                                                    (uu___4,
+                                                                    uu___5)
                                                                     ->
                                                                     Obj.magic
                                                                     (Obj.repr
@@ -1176,9 +1590,8 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (FStar_Pervasives_Native.Some
                                                                     (t.Pulse_Syntax_Base.range1))
                                                                     "Pulse cannot yet infer a postcondition for a non-tail conditional statement;\nEither annotate this `if` with `returns` clause; or rewrite your code to use a tail conditional")))
-                                                                    (
-                                                                    fun
-                                                                    uu___3 ->
+                                                                    (fun
+                                                                    uu___4 ->
                                                                     (fun post
                                                                     ->
                                                                     Obj.magic
@@ -1187,17 +1600,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_If.check
@@ -1207,11 +1620,11 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     b e1 e2
                                                                     check))
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___4 ->
-                                                                    match uu___3
+                                                                    uu___5 ->
+                                                                    match uu___4
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives.Mkdtuple5
@@ -1223,48 +1636,48 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (x, t1,
                                                                     pre',
                                                                     g11, k)))))
-                                                                    uu___3)))
-                                                        | Pulse_Syntax_Base.Tm_While
-                                                            uu___3 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (Pulse_Checker_While.check
+                                                                    uu___4)))
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_While
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (Pulse_Checker_While.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                        | Pulse_Syntax_Base.Tm_Match
-                                                            {
-                                                              Pulse_Syntax_Base.sc
-                                                                = sc;
-                                                              Pulse_Syntax_Base.returns_
-                                                                = post_match;
-                                                              Pulse_Syntax_Base.brs
-                                                                = brs;_}
-                                                            ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (FStar_Tactics_Effect.tac_bind
-                                                                    (
-                                                                    FStar_Sealed.seal
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_Match
+                                                                    {
+                                                                    Pulse_Syntax_Base.sc
+                                                                    = sc;
+                                                                    Pulse_Syntax_Base.returns_
+                                                                    =
+                                                                    post_match;
+                                                                    Pulse_Syntax_Base.brs
+                                                                    = brs;_}
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (260))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (277))
                                                                     (Prims.of_int (97)))))
-                                                                    (
-                                                                    FStar_Sealed.seal
+                                                                    (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (256))
+                                                                    (Prims.of_int (281))
                                                                     (Prims.of_int (32)))))
-                                                                    (
-                                                                    match 
+                                                                    (match 
                                                                     (post_match,
                                                                     post_hint)
                                                                     with
@@ -1276,7 +1689,7 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.repr
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     p)))
                                                                     | 
                                                                     (FStar_Pervasives_Native.Some
@@ -1302,17 +1715,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (266))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1320,42 +1733,42 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (Pulse_Syntax_Printer.term_to_string
                                                                     p))
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (247))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1363,9 +1776,9 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (271))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (271))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1379,41 +1792,41 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Pulse_Syntax_Printer.term_to_string
                                                                     q.Pulse_Typing.post))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     fun x ->
                                                                     Prims.strcat
                                                                     (Prims.strcat
                                                                     "Multiple annotated postconditions---remove one of them.\nThe context expects the postcondition "
                                                                     (Prims.strcat
-                                                                    uu___4
+                                                                    uu___5
                                                                     ",\nbut this conditional was annotated with postcondition "))
                                                                     (Prims.strcat
                                                                     x "")))))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___5 ->
-                                                                    uu___4
-                                                                    uu___3))))
-                                                                    uu___3)))
+                                                                    uu___6 ->
+                                                                    uu___5
+                                                                    uu___4))))
+                                                                    uu___4)))
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     Obj.magic
                                                                     (Pulse_Typing_Env.fail
                                                                     g1
                                                                     (FStar_Pervasives_Native.Some
                                                                     (t.Pulse_Syntax_Base.range1))
-                                                                    uu___3))
-                                                                    uu___3)))
+                                                                    uu___4))
+                                                                    uu___4)))
                                                                     | 
-                                                                    (uu___3,
-                                                                    uu___4)
+                                                                    (uu___4,
+                                                                    uu___5)
                                                                     ->
                                                                     Obj.magic
                                                                     (Obj.repr
@@ -1422,9 +1835,8 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (FStar_Pervasives_Native.Some
                                                                     (t.Pulse_Syntax_Base.range1))
                                                                     "Pulse cannot yet infer a postcondition for a non-tail conditional statement;\nEither annotate this `if` with `returns` clause; or rewrite your code to use a tail conditional")))
-                                                                    (
-                                                                    fun
-                                                                    uu___3 ->
+                                                                    (fun
+                                                                    uu___4 ->
                                                                     (fun post
                                                                     ->
                                                                     Obj.magic
@@ -1433,17 +1845,17 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (280))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (280))
                                                                     (Prims.of_int (67)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (256))
+                                                                    (Prims.of_int (281))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
                                                                     (Pulse_Checker_Match.check
@@ -1453,11 +1865,11 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     sc brs
                                                                     check))
                                                                     (fun
-                                                                    uu___3 ->
+                                                                    uu___4 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___4 ->
-                                                                    match uu___3
+                                                                    uu___5 ->
+                                                                    match uu___4
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives.Mkdtuple5
@@ -1469,107 +1881,121 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (x, ty,
                                                                     pre',
                                                                     g11, k)))))
-                                                                    uu___3)))
-                                                        | Pulse_Syntax_Base.Tm_ProofHintWithBinders
-                                                            uu___3 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (Pulse_Checker_AssertWithBinders.check
+                                                                    uu___4)))
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_ProofHintWithBinders
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (Pulse_Checker_AssertWithBinders.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                        | Pulse_Syntax_Base.Tm_WithLocal
-                                                            uu___3 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (Pulse_Checker_WithLocal.check
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_WithLocal
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (Pulse_Checker_WithLocal.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                        | Pulse_Syntax_Base.Tm_WithLocalArray
-                                                            uu___3 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (Pulse_Checker_WithLocalArray.check
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_WithLocalArray
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (Pulse_Checker_WithLocalArray.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                        | Pulse_Syntax_Base.Tm_Par
-                                                            uu___3 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (Pulse_Checker_Par.check
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_Par
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (Pulse_Checker_Par.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                        | Pulse_Syntax_Base.Tm_IntroPure
-                                                            uu___3 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (Pulse_Checker_IntroPure.check
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_IntroPure
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (Pulse_Checker_IntroPure.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t))
-                                                        | Pulse_Syntax_Base.Tm_Admit
-                                                            uu___3 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (Pulse_Checker_Admit.check
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_Admit
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (Pulse_Checker_Admit.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t))
-                                                        | Pulse_Syntax_Base.Tm_Unreachable
-                                                            ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (Pulse_Checker_Unreachable.check
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_Unreachable
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (Pulse_Checker_Unreachable.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t))
-                                                        | Pulse_Syntax_Base.Tm_Rewrite
-                                                            uu___3 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (Pulse_Checker_Rewrite.check
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_Rewrite
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (Pulse_Checker_Rewrite.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t))
-                                                        | Pulse_Syntax_Base.Tm_WithInv
-                                                            uu___3 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (Pulse_Checker_WithInv.check
+                                                                   | 
+                                                                   Pulse_Syntax_Base.Tm_WithInv
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (Pulse_Checker_WithInv.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                        | uu___3 ->
-                                                            Obj.magic
-                                                              (Obj.repr
-                                                                 (FStar_Tactics_V2_Derived.fail
+                                                                   | 
+                                                                   uu___4 ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_V2_Derived.fail
                                                                     "Checker form not implemented")))
-                                                       uu___3)))
-                                            (fun r ->
-                                               FStar_Tactics_Effect.lift_div_tac
-                                                 (fun uu___3 ->
-                                                    match r with
-                                                    | FStar_Pervasives.Mkdtuple5
-                                                        (x, g1, t1, pre', k)
-                                                        ->
-                                                        FStar_Pervasives.Mkdtuple5
-                                                          (x, g1, t1, pre',
-                                                            (Pulse_Checker_Base.k_elab_trans
-                                                               g0 g g1 pre0
-                                                               pre
-                                                               (FStar_Pervasives.dfst
-                                                                  pre')
-                                                               k_elim_pure k))))))
-                                      uu___2))) uu___1)
+                                                                  uu___4)))
+                                                       (fun r ->
+                                                          FStar_Tactics_Effect.lift_div_tac
+                                                            (fun uu___4 ->
+                                                               match r with
+                                                               | FStar_Pervasives.Mkdtuple5
+                                                                   (x, g1,
+                                                                    t1, pre',
+                                                                    k)
+                                                                   ->
+                                                                   FStar_Pervasives.Mkdtuple5
+                                                                    (x, g1,
+                                                                    t1, pre',
+                                                                    (Pulse_Checker_Base.k_elab_trans
+                                                                    g0 g g1
+                                                                    pre0 pre
+                                                                    (FStar_Pervasives.dfst
+                                                                    pre')
+                                                                    k_elim_pure
+                                                                    k))))))
+                                                 uu___3))) uu___2))) uu___1)

--- a/src/ocaml/plugin/generated/Pulse_Checker_Bind.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Bind.ml
@@ -1166,13 +1166,13 @@ let (check_tot_bind :
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Bind.fst"
-                           (Prims.of_int (144)) (Prims.of_int (10))
-                           (Prims.of_int (144)) (Prims.of_int (66)))))
+                           (Prims.of_int (143)) (Prims.of_int (10))
+                           (Prims.of_int (143)) (Prims.of_int (66)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Bind.fst"
-                           (Prims.of_int (146)) (Prims.of_int (2))
-                           (Prims.of_int (162)) (Prims.of_int (3)))))
+                           (Prims.of_int (145)) (Prims.of_int (2))
+                           (Prims.of_int (161)) (Prims.of_int (3)))))
                   (FStar_Tactics_Effect.lift_div_tac
                      (fun uu___ ->
                         Pulse_Typing_Env.push_context g "check_tot_bind"
@@ -1185,16 +1185,16 @@ let (check_tot_bind :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Bind.fst"
-                                      (Prims.of_int (146)) (Prims.of_int (2))
-                                      (Prims.of_int (147))
+                                      (Prims.of_int (145)) (Prims.of_int (2))
+                                      (Prims.of_int (146))
                                       (Prims.of_int (93)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Checker.Bind.fst"
-                                      (Prims.of_int (147))
+                                      (Prims.of_int (146))
                                       (Prims.of_int (94))
-                                      (Prims.of_int (162)) (Prims.of_int (3)))))
+                                      (Prims.of_int (161)) (Prims.of_int (3)))))
                              (if
                                 FStar_Pervasives_Native.uu___is_None
                                   post_hint
@@ -1218,17 +1218,17 @@ let (check_tot_bind :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Bind.fst"
-                                                 (Prims.of_int (150))
+                                                 (Prims.of_int (149))
                                                  (Prims.of_int (50))
-                                                 (Prims.of_int (150))
+                                                 (Prims.of_int (149))
                                                  (Prims.of_int (56)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Checker.Bind.fst"
-                                                 (Prims.of_int (147))
+                                                 (Prims.of_int (146))
                                                  (Prims.of_int (94))
-                                                 (Prims.of_int (162))
+                                                 (Prims.of_int (161))
                                                  (Prims.of_int (3)))))
                                         (FStar_Tactics_Effect.lift_div_tac
                                            (fun uu___1 ->
@@ -1251,17 +1251,17 @@ let (check_tot_bind :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Bind.fst"
-                                                                (Prims.of_int (151))
+                                                                (Prims.of_int (150))
                                                                 (Prims.of_int (8))
-                                                                (Prims.of_int (151))
+                                                                (Prims.of_int (150))
                                                                 (Prims.of_int (55)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Checker.Bind.fst"
-                                                                (Prims.of_int (151))
+                                                                (Prims.of_int (150))
                                                                 (Prims.of_int (2))
-                                                                (Prims.of_int (162))
+                                                                (Prims.of_int (161))
                                                                 (Prims.of_int (3)))))
                                                        (Obj.magic
                                                           (Pulse_Checker_Base.is_stateful_application
@@ -1278,17 +1278,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (152))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (152))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (153))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (153))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1331,17 +1331,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (158))
+                                                                    (Prims.of_int (157))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (158))
+                                                                    (Prims.of_int (157))
                                                                     (Prims.of_int (85)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (158))
+                                                                    (Prims.of_int (157))
                                                                     (Prims.of_int (88))
-                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1366,17 +1366,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (107)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (159))
+                                                                    (Prims.of_int (158))
                                                                     (Prims.of_int (112))
-                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1402,17 +1402,17 @@ let (check_tot_bind :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (159))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (159))
                                                                     (Prims.of_int (63)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Bind.fst"
-                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (160))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun


### PR DESCRIPTION
This is not polished at all, but I find it quite useful already.