### PR TITLE
Revert "Extraction: mark everything CInline"

### DIFF
--- a/src/ocaml/plugin/Pulse_Extract_CompilerLib.ml
+++ b/src/ocaml/plugin/Pulse_Extract_CompilerLib.ml
@@ -85,12 +85,6 @@ let mle_name (x:mlpath) : mlexpr =
     as_expr (ML.MLE_Name x)
 
 let mle_let (x:mlletbinding) (b:mlexpr) : mlexpr =
-    (* Set the CInline attribute on *every* letbinding. This makes
-       generated C code much more compact.
-       See https://github.com/FStarLang/karamel/pull/470 *)
-    let flavors, lbs = x in
-    let lbs = lbs |> List.map (fun lb -> { lb with ML.mllb_meta = CInline :: lb.ML.mllb_meta }) in
-    let x = (flavors, lbs) in
     as_expr (ML.MLE_Let (x, b))
     
 let mle_app (x:mlexpr) (args:mlexpr list) : mlexpr =


### PR DESCRIPTION
See https://github.com/FStarLang/karamel/issues/478. Revert until it is fixed, and we should add an option anyway.

This reverts commit 3a7730d98b619449e228c99fd33872042c3f666f.