### PR TITLE
Setting the error bound

### DIFF
--- a/share/pulse/examples/bug-reports/error-messages/Bug.DesugaringError.fst.expected
+++ b/share/pulse/examples/bug-reports/error-messages/Bug.DesugaringError.fst.expected
@@ -23,6 +23,7 @@
 * Error 189 at Bug.DesugaringError.fst(31,9-31,10):
   - Expected expression of type Prims.nat got expression y of type Prims.bool
   - Raised within Tactics.refl_instantiate_implicits
+  - See also Bug.DesugaringError.fst(31,4-31,10)
 
 >>]
 >> Got issues: [

--- a/src/checker/Pulse.Checker.fst
+++ b/src/checker/Pulse.Checker.fst
@@ -175,7 +175,8 @@ let rec check
   (res_ppname:ppname)
   (t:st_term)
 : T.Tac (checker_result_t g0 pre0 post_hint)
-= if Pulse.Checker.AssertWithBinders.handle_head_immediately t
+= RU.with_error_bound #(checker_result_t g0 pre0 post_hint) t.range <| fun () ->
+  if Pulse.Checker.AssertWithBinders.handle_head_immediately t
   then Pulse.Checker.AssertWithBinders.check g0 pre0 pre0_typing post_hint res_ppname t check
   else (
     let (| g, pre, pre_typing, k_elim_pure |) = 

--- a/src/checker/Pulse.RuntimeUtils.fsti
+++ b/src/checker/Pulse.RuntimeUtils.fsti
@@ -20,6 +20,7 @@ module T = FStar.Tactics
 type context = FStar.Sealed.Inhabited.sealed #(list (string & option range)) []
 val extend_context (tag:string) (r:option range) (ctx:context) : context
 val with_context (c:context) (f:unit -> T.Tac 'a) : T.Tac 'a
+val with_error_bound (r:Range.range) (f:unit -> T.Tac 'a) : T.Tac 'a
 val with_extv (k v : string) (f:unit -> T.Tac 'a) : T.Tac 'a
 val disable_admit_smt_queries (f:unit -> T.Tac 'a) : T.Tac 'a
 val print_context (c:context) : T.Tac string

--- a/src/ocaml/plugin/Pulse_RuntimeUtils.ml
+++ b/src/ocaml/plugin/Pulse_RuntimeUtils.ml
@@ -21,6 +21,9 @@ let rec with_context (c:context) (f: unit -> 'a utac) : 'a utac =
     | sr::tl ->
       with_context tl (fun _ ps ->
       FStar_Errors.with_ctx (ctxt_elt_as_string sr) (fun _ -> f () ps)) ps
+let with_error_bound (r:FStar_Range.range) (f: unit -> 'a utac) : 'a utac =
+  fun ps ->
+    FStar_Errors.with_error_bound r (fun _ -> f () ps)
 let disable_admit_smt_queries (f: unit -> 'a utac) : 'a utac =
   fun ps ->
     FStar_Options.with_saved_options (fun _ ->

--- a/src/ocaml/plugin/generated/Pulse_Checker.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker.ml
@@ -927,116 +927,124 @@ let rec (check : Pulse_Checker_Base.check_t) =
         fun post_hint ->
           fun res_ppname ->
             fun t ->
-              if Pulse_Checker_AssertWithBinders.handle_head_immediately t
-              then
-                Pulse_Checker_AssertWithBinders.check g0 pre0 () post_hint
-                  res_ppname t check
-              else
-                (let uu___1 =
-                   Pulse_Checker_Prover.elim_exists_and_pure g0 pre0 () in
-                 FStar_Tactics_Effect.tac_bind
-                   (FStar_Sealed.seal
-                      (Obj.magic
-                         (FStar_Range.mk_range "Pulse.Checker.fst"
-                            (Prims.of_int (182)) (Prims.of_int (6))
-                            (Prims.of_int (182)) (Prims.of_int (59)))))
-                   (FStar_Sealed.seal
-                      (Obj.magic
-                         (FStar_Range.mk_range "Pulse.Checker.fst"
-                            (Prims.of_int (180)) (Prims.of_int (7))
-                            (Prims.of_int (321)) (Prims.of_int (3)))))
-                   (Obj.magic uu___1)
-                   (fun uu___2 ->
-                      (fun uu___2 ->
-                         match uu___2 with
-                         | FStar_Pervasives.Mkdtuple4
-                             (g, pre, pre_typing, k_elim_pure) ->
-                             let uu___3 =
-                               maybe_trace t g pre t.Pulse_Syntax_Base.range1 in
-                             Obj.magic
-                               (FStar_Tactics_Effect.tac_bind
-                                  (FStar_Sealed.seal
-                                     (Obj.magic
-                                        (FStar_Range.mk_range
-                                           "Pulse.Checker.fst"
-                                           (Prims.of_int (185))
-                                           (Prims.of_int (4))
-                                           (Prims.of_int (185))
-                                           (Prims.of_int (31)))))
-                                  (FStar_Sealed.seal
-                                     (Obj.magic
-                                        (FStar_Range.mk_range
-                                           "Pulse.Checker.fst"
-                                           (Prims.of_int (187))
-                                           (Prims.of_int (4))
-                                           (Prims.of_int (320))
-                                           (Prims.of_int (52)))))
-                                  (Obj.magic uu___3)
-                                  (fun uu___4 ->
-                                     (fun uu___4 ->
-                                        let uu___5 =
-                                          if
-                                            Pulse_RuntimeUtils.debug_at_level
-                                              (Pulse_Typing_Env.fstar_env g)
-                                              "pulse.checker"
-                                          then
-                                            Obj.magic
-                                              (Obj.repr
-                                                 (let uu___6 =
-                                                    let uu___7 =
-                                                      Pulse_Syntax_Printer.st_term_to_string
-                                                        t in
-                                                    FStar_Tactics_Effect.tac_bind
-                                                      (FStar_Sealed.seal
-                                                         (Obj.magic
-                                                            (FStar_Range.mk_range
-                                                               "Pulse.Checker.fst"
-                                                               (Prims.of_int (193))
-                                                               (Prims.of_int (16))
-                                                               (Prims.of_int (193))
-                                                               (Prims.of_int (58)))))
-                                                      (FStar_Sealed.seal
-                                                         (Obj.magic
-                                                            (FStar_Range.mk_range
-                                                               "Pulse.Checker.fst"
-                                                               (Prims.of_int (188))
-                                                               (Prims.of_int (14))
-                                                               (Prims.of_int (193))
-                                                               (Prims.of_int (59)))))
-                                                      (Obj.magic uu___7)
-                                                      (fun uu___8 ->
-                                                         (fun uu___8 ->
-                                                            let uu___9 =
-                                                              let uu___10 =
-                                                                Pulse_Syntax_Printer.term_to_string
-                                                                  pre in
-                                                              FStar_Tactics_Effect.tac_bind
-                                                                (FStar_Sealed.seal
-                                                                   (Obj.magic
-                                                                    (FStar_Range.mk_range
+              Pulse_RuntimeUtils.with_error_bound t.Pulse_Syntax_Base.range1
+                (fun uu___ ->
+                   if
+                     Pulse_Checker_AssertWithBinders.handle_head_immediately
+                       t
+                   then
+                     Pulse_Checker_AssertWithBinders.check g0 pre0 ()
+                       post_hint res_ppname t check
+                   else
+                     (let uu___2 =
+                        Pulse_Checker_Prover.elim_exists_and_pure g0 pre0 () in
+                      FStar_Tactics_Effect.tac_bind
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range "Pulse.Checker.fst"
+                                 (Prims.of_int (183)) (Prims.of_int (6))
+                                 (Prims.of_int (183)) (Prims.of_int (59)))))
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range "Pulse.Checker.fst"
+                                 (Prims.of_int (181)) (Prims.of_int (7))
+                                 (Prims.of_int (322)) (Prims.of_int (3)))))
+                        (Obj.magic uu___2)
+                        (fun uu___3 ->
+                           (fun uu___3 ->
+                              match uu___3 with
+                              | FStar_Pervasives.Mkdtuple4
+                                  (g, pre, pre_typing, k_elim_pure) ->
+                                  let uu___4 =
+                                    maybe_trace t g pre
+                                      t.Pulse_Syntax_Base.range1 in
+                                  Obj.magic
+                                    (FStar_Tactics_Effect.tac_bind
+                                       (FStar_Sealed.seal
+                                          (Obj.magic
+                                             (FStar_Range.mk_range
+                                                "Pulse.Checker.fst"
+                                                (Prims.of_int (186))
+                                                (Prims.of_int (4))
+                                                (Prims.of_int (186))
+                                                (Prims.of_int (31)))))
+                                       (FStar_Sealed.seal
+                                          (Obj.magic
+                                             (FStar_Range.mk_range
+                                                "Pulse.Checker.fst"
+                                                (Prims.of_int (188))
+                                                (Prims.of_int (4))
+                                                (Prims.of_int (321))
+                                                (Prims.of_int (52)))))
+                                       (Obj.magic uu___4)
+                                       (fun uu___5 ->
+                                          (fun uu___5 ->
+                                             let uu___6 =
+                                               if
+                                                 Pulse_RuntimeUtils.debug_at_level
+                                                   (Pulse_Typing_Env.fstar_env
+                                                      g) "pulse.checker"
+                                               then
+                                                 Obj.magic
+                                                   (Obj.repr
+                                                      (let uu___7 =
+                                                         let uu___8 =
+                                                           Pulse_Syntax_Printer.st_term_to_string
+                                                             t in
+                                                         FStar_Tactics_Effect.tac_bind
+                                                           (FStar_Sealed.seal
+                                                              (Obj.magic
+                                                                 (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (192))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (192))
-                                                                    (Prims.of_int (57)))))
-                                                                (FStar_Sealed.seal
-                                                                   (Obj.magic
+                                                                    (Prims.of_int (194))
+                                                                    (Prims.of_int (58)))))
+                                                           (FStar_Sealed.seal
+                                                              (Obj.magic
+                                                                 (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (189))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (194))
+                                                                    (Prims.of_int (59)))))
+                                                           (Obj.magic uu___8)
+                                                           (fun uu___9 ->
+                                                              (fun uu___9 ->
+                                                                 let uu___10
+                                                                   =
+                                                                   let uu___11
+                                                                    =
+                                                                    Pulse_Syntax_Printer.term_to_string
+                                                                    pre in
+                                                                   FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (188))
-                                                                    (Prims.of_int (14))
                                                                     (Prims.of_int (193))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (57)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (189))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (59)))))
-                                                                (Obj.magic
-                                                                   uu___10)
-                                                                (fun uu___11
-                                                                   ->
-                                                                   (fun
-                                                                    uu___11
+                                                                    (Obj.magic
+                                                                    uu___11)
+                                                                    (fun
+                                                                    uu___12
                                                                     ->
-                                                                    let uu___12
-                                                                    =
+                                                                    (fun
+                                                                    uu___12
+                                                                    ->
                                                                     let uu___13
+                                                                    =
+                                                                    let uu___14
                                                                     =
                                                                     Pulse_Typing_Env.env_to_string
                                                                     g in
@@ -1045,29 +1053,29 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (192))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (191))
+                                                                    (Prims.of_int (192))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (188))
+                                                                    (Prims.of_int (189))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
-                                                                    uu___13)
+                                                                    uu___14)
                                                                     (fun
-                                                                    uu___14
+                                                                    uu___15
                                                                     ->
                                                                     (fun
-                                                                    uu___14
+                                                                    uu___15
                                                                     ->
-                                                                    let uu___15
-                                                                    =
                                                                     let uu___16
+                                                                    =
+                                                                    let uu___17
                                                                     =
                                                                     Pulse_RuntimeUtils.print_context
                                                                     (Pulse_Typing_Env.get_context
@@ -1077,29 +1085,29 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (190))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (190))
+                                                                    (Prims.of_int (191))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (188))
+                                                                    (Prims.of_int (189))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
-                                                                    uu___16)
+                                                                    uu___17)
                                                                     (fun
-                                                                    uu___17
+                                                                    uu___18
                                                                     ->
                                                                     (fun
-                                                                    uu___17
+                                                                    uu___18
                                                                     ->
-                                                                    let uu___18
-                                                                    =
                                                                     let uu___19
+                                                                    =
+                                                                    let uu___20
                                                                     =
                                                                     FStar_Tactics_V2_Builtins.range_to_string
                                                                     t.Pulse_Syntax_Base.range1 in
@@ -1108,9 +1116,9 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (189))
+                                                                    (Prims.of_int (190))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (189))
+                                                                    (Prims.of_int (190))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1121,13 +1129,13 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Prims.of_int (124))
                                                                     (Prims.of_int (44)))))
                                                                     (Obj.magic
-                                                                    uu___19)
+                                                                    uu___20)
                                                                     (fun
-                                                                    uu___20
+                                                                    uu___21
                                                                     ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___21
+                                                                    uu___22
                                                                     ->
                                                                     fun x ->
                                                                     fun x1 ->
@@ -1140,7 +1148,7 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Prims.strcat
                                                                     "At "
                                                                     (Prims.strcat
-                                                                    uu___20
+                                                                    uu___21
                                                                     "{\nerr context:\n>"))
                                                                     (Prims.strcat
                                                                     x
@@ -1159,247 +1167,252 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (188))
+                                                                    (Prims.of_int (189))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (188))
+                                                                    (Prims.of_int (189))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
-                                                                    uu___18)
-                                                                    (fun
-                                                                    uu___19
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    uu___19)
                                                                     (fun
                                                                     uu___20
                                                                     ->
-                                                                    uu___19
-                                                                    uu___17))))
-                                                                    uu___17) in
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___21
+                                                                    ->
+                                                                    uu___20
+                                                                    uu___18))))
+                                                                    uu___18) in
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (188))
+                                                                    (Prims.of_int (189))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (188))
+                                                                    (Prims.of_int (189))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
-                                                                    uu___15)
-                                                                    (fun
-                                                                    uu___16
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    uu___16)
                                                                     (fun
                                                                     uu___17
                                                                     ->
-                                                                    uu___16
-                                                                    uu___14))))
-                                                                    uu___14) in
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___18
+                                                                    ->
+                                                                    uu___17
+                                                                    uu___15))))
+                                                                    uu___15) in
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (188))
+                                                                    (Prims.of_int (189))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (188))
+                                                                    (Prims.of_int (189))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
-                                                                    uu___12)
-                                                                    (fun
-                                                                    uu___13
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    uu___13)
                                                                     (fun
                                                                     uu___14
                                                                     ->
-                                                                    uu___13
-                                                                    uu___11))))
-                                                                    uu___11) in
-                                                            Obj.magic
-                                                              (FStar_Tactics_Effect.tac_bind
-                                                                 (FStar_Sealed.seal
-                                                                    (
-                                                                    Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.fst"
-                                                                    (Prims.of_int (188))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (193))
-                                                                    (Prims.of_int (59)))))
-                                                                 (FStar_Sealed.seal
-                                                                    (
-                                                                    Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.fst"
-                                                                    (Prims.of_int (188))
-                                                                    (Prims.of_int (14))
-                                                                    (Prims.of_int (193))
-                                                                    (Prims.of_int (59)))))
-                                                                 (Obj.magic
-                                                                    uu___9)
-                                                                 (fun uu___10
-                                                                    ->
                                                                     FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___15
+                                                                    ->
+                                                                    uu___14
+                                                                    uu___12))))
+                                                                    uu___12) in
+                                                                 Obj.magic
+                                                                   (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (189))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (194))
+                                                                    (Prims.of_int (59)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (189))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (194))
+                                                                    (Prims.of_int (59)))))
+                                                                    (Obj.magic
+                                                                    uu___10)
                                                                     (fun
                                                                     uu___11
                                                                     ->
-                                                                    uu___10
-                                                                    uu___8))))
-                                                           uu___8) in
-                                                  FStar_Tactics_Effect.tac_bind
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "Pulse.Checker.fst"
-                                                             (Prims.of_int (188))
-                                                             (Prims.of_int (14))
-                                                             (Prims.of_int (193))
-                                                             (Prims.of_int (59)))))
-                                                    (FStar_Sealed.seal
-                                                       (Obj.magic
-                                                          (FStar_Range.mk_range
-                                                             "Pulse.Checker.fst"
-                                                             (Prims.of_int (188))
-                                                             (Prims.of_int (6))
-                                                             (Prims.of_int (193))
-                                                             (Prims.of_int (59)))))
-                                                    (Obj.magic uu___6)
-                                                    (fun uu___7 ->
-                                                       (fun uu___7 ->
-                                                          Obj.magic
-                                                            (FStar_Tactics_V2_Builtins.print
-                                                               uu___7))
-                                                         uu___7)))
-                                          else
-                                            Obj.magic
-                                              (Obj.repr
-                                                 (FStar_Tactics_Effect.lift_div_tac
-                                                    (fun uu___7 -> ()))) in
-                                        Obj.magic
-                                          (FStar_Tactics_Effect.tac_bind
-                                             (FStar_Sealed.seal
-                                                (Obj.magic
-                                                   (FStar_Range.mk_range
-                                                      "Pulse.Checker.fst"
-                                                      (Prims.of_int (187))
-                                                      (Prims.of_int (4))
-                                                      (Prims.of_int (193))
-                                                      (Prims.of_int (59)))))
-                                             (FStar_Sealed.seal
-                                                (Obj.magic
-                                                   (FStar_Range.mk_range
-                                                      "Pulse.Checker.fst"
-                                                      (Prims.of_int (193))
-                                                      (Prims.of_int (60))
-                                                      (Prims.of_int (320))
-                                                      (Prims.of_int (52)))))
-                                             (Obj.magic uu___5)
-                                             (fun uu___6 ->
-                                                (fun uu___6 ->
-                                                   let uu___7 =
-                                                     let uu___8 =
-                                                       Obj.magic
-                                                         (FStar_Tactics_Effect.lift_div_tac
-                                                            (fun uu___9 ->
-                                                               Pulse_Checker_Pure.push_context
-                                                                 (Pulse_Syntax_Printer.tag_of_st_term
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___12
+                                                                    ->
+                                                                    uu___11
+                                                                    uu___9))))
+                                                                uu___9) in
+                                                       FStar_Tactics_Effect.tac_bind
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Checker.fst"
+                                                                  (Prims.of_int (189))
+                                                                  (Prims.of_int (14))
+                                                                  (Prims.of_int (194))
+                                                                  (Prims.of_int (59)))))
+                                                         (FStar_Sealed.seal
+                                                            (Obj.magic
+                                                               (FStar_Range.mk_range
+                                                                  "Pulse.Checker.fst"
+                                                                  (Prims.of_int (189))
+                                                                  (Prims.of_int (6))
+                                                                  (Prims.of_int (194))
+                                                                  (Prims.of_int (59)))))
+                                                         (Obj.magic uu___7)
+                                                         (fun uu___8 ->
+                                                            (fun uu___8 ->
+                                                               Obj.magic
+                                                                 (FStar_Tactics_V2_Builtins.print
+                                                                    uu___8))
+                                                              uu___8)))
+                                               else
+                                                 Obj.magic
+                                                   (Obj.repr
+                                                      (FStar_Tactics_Effect.lift_div_tac
+                                                         (fun uu___8 -> ()))) in
+                                             Obj.magic
+                                               (FStar_Tactics_Effect.tac_bind
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "Pulse.Checker.fst"
+                                                           (Prims.of_int (188))
+                                                           (Prims.of_int (4))
+                                                           (Prims.of_int (194))
+                                                           (Prims.of_int (59)))))
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "Pulse.Checker.fst"
+                                                           (Prims.of_int (194))
+                                                           (Prims.of_int (60))
+                                                           (Prims.of_int (321))
+                                                           (Prims.of_int (52)))))
+                                                  (Obj.magic uu___6)
+                                                  (fun uu___7 ->
+                                                     (fun uu___7 ->
+                                                        let uu___8 =
+                                                          let uu___9 =
+                                                            Obj.magic
+                                                              (FStar_Tactics_Effect.lift_div_tac
+                                                                 (fun uu___10
+                                                                    ->
+                                                                    Pulse_Checker_Pure.push_context
+                                                                    (Pulse_Syntax_Printer.tag_of_st_term
                                                                     t)
-                                                                 t.Pulse_Syntax_Base.range1
-                                                                 g)) in
-                                                     FStar_Tactics_Effect.tac_bind
-                                                       (FStar_Sealed.seal
-                                                          (Obj.magic
-                                                             (FStar_Range.mk_range
-                                                                "Pulse.Checker.fst"
-                                                                (Prims.of_int (196))
-                                                                (Prims.of_int (14))
-                                                                (Prims.of_int (196))
-                                                                (Prims.of_int (57)))))
-                                                       (FStar_Sealed.seal
-                                                          (Obj.magic
-                                                             (FStar_Range.mk_range
-                                                                "Pulse.Checker.fst"
-                                                                (Prims.of_int (197))
-                                                                (Prims.of_int (6))
-                                                                (Prims.of_int (316))
-                                                                (Prims.of_int (50)))))
-                                                       (Obj.magic uu___8)
-                                                       (fun uu___9 ->
-                                                          (fun g1 ->
-                                                             match t.Pulse_Syntax_Base.term1
-                                                             with
-                                                             | Pulse_Syntax_Base.Tm_Return
-                                                                 uu___9 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                    t.Pulse_Syntax_Base.range1
+                                                                    g)) in
+                                                          FStar_Tactics_Effect.tac_bind
+                                                            (FStar_Sealed.seal
+                                                               (Obj.magic
+                                                                  (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (197))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (197))
+                                                                    (Prims.of_int (57)))))
+                                                            (FStar_Sealed.seal
+                                                               (Obj.magic
+                                                                  (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (50)))))
+                                                            (Obj.magic uu___9)
+                                                            (fun uu___10 ->
+                                                               (fun g1 ->
+                                                                  match 
+                                                                    t.Pulse_Syntax_Base.term1
+                                                                  with
+                                                                  | Pulse_Syntax_Base.Tm_Return
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (Pulse_Checker_Return.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                             | Pulse_Syntax_Base.Tm_Abs
-                                                                 uu___9 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                  | Pulse_Syntax_Base.Tm_Abs
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (FStar_Tactics_V2_Derived.fail
                                                                     "Tm_Abs check should not have been called in the checker"))
-                                                             | Pulse_Syntax_Base.Tm_STApp
-                                                                 uu___9 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                  | Pulse_Syntax_Base.Tm_STApp
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (Pulse_Checker_STApp.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t))
-                                                             | Pulse_Syntax_Base.Tm_ElimExists
-                                                                 uu___9 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                  | Pulse_Syntax_Base.Tm_ElimExists
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (Pulse_Checker_Exists.check_elim_exists
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t))
-                                                             | Pulse_Syntax_Base.Tm_IntroExists
-                                                                 {
-                                                                   Pulse_Syntax_Base.p5
+                                                                  | Pulse_Syntax_Base.Tm_IntroExists
+                                                                    {
+                                                                    Pulse_Syntax_Base.p5
                                                                     = p;
-                                                                   Pulse_Syntax_Base.witnesses
+                                                                    Pulse_Syntax_Base.witnesses
                                                                     =
                                                                     witnesses;_}
-                                                                 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
-                                                                    (let uu___9
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (let uu___10
                                                                     =
                                                                     instantiate_unknown_witnesses
                                                                     g1 t in
@@ -1408,27 +1421,27 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (217))
+                                                                    (Prims.of_int (218))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (217))
+                                                                    (Prims.of_int (218))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (217))
+                                                                    (Prims.of_int (218))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
-                                                                    uu___9)
+                                                                    uu___10)
                                                                     (fun
-                                                                    uu___10
+                                                                    uu___11
                                                                     ->
                                                                     (fun
-                                                                    uu___10
+                                                                    uu___11
                                                                     ->
-                                                                    match uu___10
+                                                                    match uu___11
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.Some
@@ -1453,7 +1466,7 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (t.Pulse_Syntax_Base.range1))
                                                                     "intro exists with empty witnesses")
                                                                     | 
-                                                                    uu___11::[]
+                                                                    uu___12::[]
                                                                     ->
                                                                     Obj.magic
                                                                     (Pulse_Checker_Exists.check_intro_exists
@@ -1463,9 +1476,9 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     t
                                                                     FStar_Pervasives_Native.None)
                                                                     | 
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
-                                                                    let uu___12
+                                                                    let uu___13
                                                                     =
                                                                     transform_to_unary_intro_exists
                                                                     g1 p
@@ -1476,22 +1489,22 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (57)))))
                                                                     (Obj.magic
-                                                                    uu___12)
+                                                                    uu___13)
                                                                     (fun
-                                                                    uu___13
+                                                                    uu___14
                                                                     ->
                                                                     (fun t1
                                                                     ->
@@ -1501,40 +1514,42 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     post_hint
                                                                     res_ppname
                                                                     t1))
-                                                                    uu___13))))
-                                                                    uu___10)))
-                                                             | Pulse_Syntax_Base.Tm_Bind
-                                                                 uu___9 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                    uu___14))))
+                                                                    uu___11)))
+                                                                  | Pulse_Syntax_Base.Tm_Bind
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (Pulse_Checker_Bind.check_bind
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                             | Pulse_Syntax_Base.Tm_TotBind
-                                                                 uu___9 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                  | Pulse_Syntax_Base.Tm_TotBind
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (Pulse_Checker_Bind.check_tot_bind
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                             | Pulse_Syntax_Base.Tm_If
-                                                                 {
-                                                                   Pulse_Syntax_Base.b1
+                                                                  | Pulse_Syntax_Base.Tm_If
+                                                                    {
+                                                                    Pulse_Syntax_Base.b1
                                                                     = b;
-                                                                   Pulse_Syntax_Base.then_
+                                                                    Pulse_Syntax_Base.then_
                                                                     = e1;
-                                                                   Pulse_Syntax_Base.else_
+                                                                    Pulse_Syntax_Base.else_
                                                                     = e2;
-                                                                   Pulse_Syntax_Base.post1
+                                                                    Pulse_Syntax_Base.post1
                                                                     = post_if;_}
-                                                                 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
-                                                                    (let uu___9
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (let uu___10
                                                                     =
                                                                     match 
                                                                     (post_if,
@@ -1548,7 +1563,7 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.repr
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___10
+                                                                    uu___11
                                                                     -> p)))
                                                                     | 
                                                                     (FStar_Pervasives_Native.Some
@@ -1569,9 +1584,9 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     q) ->
                                                                     Obj.magic
                                                                     (Obj.repr
-                                                                    (let uu___10
+                                                                    (let uu___11
                                                                     =
-                                                                    let uu___11
+                                                                    let uu___12
                                                                     =
                                                                     Pulse_Syntax_Printer.term_to_string
                                                                     p in
@@ -1580,29 +1595,29 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
-                                                                    uu___11)
+                                                                    uu___12)
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
-                                                                    let uu___13
-                                                                    =
                                                                     let uu___14
+                                                                    =
+                                                                    let uu___15
                                                                     =
                                                                     Pulse_Syntax_Printer.term_to_string
                                                                     q.Pulse_Typing.post in
@@ -1611,9 +1626,9 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (249))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1624,20 +1639,20 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Prims.of_int (124))
                                                                     (Prims.of_int (44)))))
                                                                     (Obj.magic
-                                                                    uu___14)
+                                                                    uu___15)
                                                                     (fun
-                                                                    uu___15
+                                                                    uu___16
                                                                     ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___16
+                                                                    uu___17
                                                                     ->
                                                                     fun x ->
                                                                     Prims.strcat
                                                                     (Prims.strcat
                                                                     "Multiple annotated postconditions---remove one of them.\nThe context expects the postcondition "
                                                                     (Prims.strcat
-                                                                    uu___15
+                                                                    uu___16
                                                                     ",\nbut this conditional was annotated with postcondition "))
                                                                     (Prims.strcat
                                                                     x ""))) in
@@ -1647,65 +1662,65 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
-                                                                    uu___13)
-                                                                    (fun
-                                                                    uu___14
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    uu___14)
                                                                     (fun
                                                                     uu___15
                                                                     ->
-                                                                    uu___14
-                                                                    uu___12))))
-                                                                    uu___12) in
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___16
+                                                                    ->
+                                                                    uu___15
+                                                                    uu___13))))
+                                                                    uu___13) in
                                                                     FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (244))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
-                                                                    uu___10)
+                                                                    uu___11)
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     Obj.magic
                                                                     (Pulse_Typing_Env.fail
                                                                     g1
                                                                     (FStar_Pervasives_Native.Some
                                                                     (t.Pulse_Syntax_Base.range1))
-                                                                    uu___11))
-                                                                    uu___11)))
+                                                                    uu___12))
+                                                                    uu___12)))
                                                                     | 
-                                                                    (uu___10,
-                                                                    uu___11)
+                                                                    (uu___11,
+                                                                    uu___12)
                                                                     ->
                                                                     Obj.magic
                                                                     (Obj.repr
@@ -1719,26 +1734,26 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (237))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (97)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (256))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
-                                                                    uu___9)
+                                                                    uu___10)
                                                                     (fun
-                                                                    uu___10
+                                                                    uu___11
                                                                     ->
                                                                     (fun post
                                                                     ->
-                                                                    let uu___10
+                                                                    let uu___11
                                                                     =
                                                                     Pulse_Checker_If.check
                                                                     g1 pre ()
@@ -1752,28 +1767,28 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (258))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (256))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
-                                                                    uu___10)
-                                                                    (fun
-                                                                    uu___11
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    uu___11)
                                                                     (fun
                                                                     uu___12
                                                                     ->
-                                                                    match uu___11
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___13
+                                                                    ->
+                                                                    match uu___12
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives.Mkdtuple5
@@ -1785,29 +1800,30 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (x, t1,
                                                                     pre',
                                                                     g11, k)))))
-                                                                    uu___10)))
-                                                             | Pulse_Syntax_Base.Tm_While
-                                                                 uu___9 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                    uu___11)))
+                                                                  | Pulse_Syntax_Base.Tm_While
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (Pulse_Checker_While.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                             | Pulse_Syntax_Base.Tm_Match
-                                                                 {
-                                                                   Pulse_Syntax_Base.sc
+                                                                  | Pulse_Syntax_Base.Tm_Match
+                                                                    {
+                                                                    Pulse_Syntax_Base.sc
                                                                     = sc;
-                                                                   Pulse_Syntax_Base.returns_
+                                                                    Pulse_Syntax_Base.returns_
                                                                     =
                                                                     post_match;
-                                                                   Pulse_Syntax_Base.brs
+                                                                    Pulse_Syntax_Base.brs
                                                                     = brs;_}
-                                                                 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
-                                                                    (let uu___9
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (let uu___10
                                                                     =
                                                                     match 
                                                                     (post_match,
@@ -1821,7 +1837,7 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.repr
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___10
+                                                                    uu___11
                                                                     -> p)))
                                                                     | 
                                                                     (FStar_Pervasives_Native.Some
@@ -1842,9 +1858,9 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     q) ->
                                                                     Obj.magic
                                                                     (Obj.repr
-                                                                    (let uu___10
+                                                                    (let uu___11
                                                                     =
-                                                                    let uu___11
+                                                                    let uu___12
                                                                     =
                                                                     Pulse_Syntax_Printer.term_to_string
                                                                     p in
@@ -1853,29 +1869,29 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (274))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
-                                                                    uu___11)
+                                                                    uu___12)
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___13
                                                                     ->
-                                                                    let uu___13
-                                                                    =
                                                                     let uu___14
+                                                                    =
+                                                                    let uu___15
                                                                     =
                                                                     Pulse_Syntax_Printer.term_to_string
                                                                     q.Pulse_Typing.post in
@@ -1884,9 +1900,9 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1897,20 +1913,20 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Prims.of_int (124))
                                                                     (Prims.of_int (44)))))
                                                                     (Obj.magic
-                                                                    uu___14)
+                                                                    uu___15)
                                                                     (fun
-                                                                    uu___15
+                                                                    uu___16
                                                                     ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___16
+                                                                    uu___17
                                                                     ->
                                                                     fun x ->
                                                                     Prims.strcat
                                                                     (Prims.strcat
                                                                     "Multiple annotated postconditions---remove one of them.\nThe context expects the postcondition "
                                                                     (Prims.strcat
-                                                                    uu___15
+                                                                    uu___16
                                                                     ",\nbut this conditional was annotated with postcondition "))
                                                                     (Prims.strcat
                                                                     x ""))) in
@@ -1920,65 +1936,65 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (274))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (274))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
-                                                                    uu___13)
-                                                                    (fun
-                                                                    uu___14
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    uu___14)
                                                                     (fun
                                                                     uu___15
                                                                     ->
-                                                                    uu___14
-                                                                    uu___12))))
-                                                                    uu___12) in
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___16
+                                                                    ->
+                                                                    uu___15
+                                                                    uu___13))))
+                                                                    uu___13) in
                                                                     FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (274))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (273))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (39)))))
                                                                     (Obj.magic
-                                                                    uu___10)
+                                                                    uu___11)
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
                                                                     Obj.magic
                                                                     (Pulse_Typing_Env.fail
                                                                     g1
                                                                     (FStar_Pervasives_Native.Some
                                                                     (t.Pulse_Syntax_Base.range1))
-                                                                    uu___11))
-                                                                    uu___11)))
+                                                                    uu___12))
+                                                                    uu___12)))
                                                                     | 
-                                                                    (uu___10,
-                                                                    uu___11)
+                                                                    (uu___11,
+                                                                    uu___12)
                                                                     ->
                                                                     Obj.magic
                                                                     (Obj.repr
@@ -1992,26 +2008,26 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (266))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (97)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
-                                                                    uu___9)
+                                                                    uu___10)
                                                                     (fun
-                                                                    uu___10
+                                                                    uu___11
                                                                     ->
                                                                     (fun post
                                                                     ->
-                                                                    let uu___10
+                                                                    let uu___11
                                                                     =
                                                                     Pulse_Checker_Match.check
                                                                     g1 pre ()
@@ -2025,28 +2041,28 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (286))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (286))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (67)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.fst"
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
-                                                                    uu___10)
-                                                                    (fun
-                                                                    uu___11
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    uu___11)
                                                                     (fun
                                                                     uu___12
                                                                     ->
-                                                                    match uu___11
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___13
+                                                                    ->
+                                                                    match uu___12
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives.Mkdtuple5
@@ -2058,118 +2074,131 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     (x, ty,
                                                                     pre',
                                                                     g11, k)))))
-                                                                    uu___10)))
-                                                             | Pulse_Syntax_Base.Tm_ProofHintWithBinders
-                                                                 uu___9 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                    uu___11)))
+                                                                  | Pulse_Syntax_Base.Tm_ProofHintWithBinders
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (Pulse_Checker_AssertWithBinders.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                             | Pulse_Syntax_Base.Tm_WithLocal
-                                                                 uu___9 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                  | Pulse_Syntax_Base.Tm_WithLocal
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (Pulse_Checker_WithLocal.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                             | Pulse_Syntax_Base.Tm_WithLocalArray
-                                                                 uu___9 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                  | Pulse_Syntax_Base.Tm_WithLocalArray
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (Pulse_Checker_WithLocalArray.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                             | Pulse_Syntax_Base.Tm_Par
-                                                                 uu___9 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                  | Pulse_Syntax_Base.Tm_Par
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (Pulse_Checker_Par.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                             | Pulse_Syntax_Base.Tm_IntroPure
-                                                                 uu___9 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                  | Pulse_Syntax_Base.Tm_IntroPure
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (Pulse_Checker_IntroPure.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t))
-                                                             | Pulse_Syntax_Base.Tm_Admit
-                                                                 uu___9 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                  | Pulse_Syntax_Base.Tm_Admit
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (Pulse_Checker_Admit.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t))
-                                                             | Pulse_Syntax_Base.Tm_Unreachable
-                                                                 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                  | Pulse_Syntax_Base.Tm_Unreachable
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (Pulse_Checker_Unreachable.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t))
-                                                             | Pulse_Syntax_Base.Tm_Rewrite
-                                                                 uu___9 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                  | Pulse_Syntax_Base.Tm_Rewrite
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (Pulse_Checker_Rewrite.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t))
-                                                             | Pulse_Syntax_Base.Tm_WithInv
-                                                                 uu___9 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                  | Pulse_Syntax_Base.Tm_WithInv
+                                                                    uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (Pulse_Checker_WithInv.check
                                                                     g1 pre ()
                                                                     post_hint
                                                                     res_ppname
                                                                     t check))
-                                                             | uu___9 ->
-                                                                 Obj.magic
-                                                                   (Obj.repr
+                                                                  | uu___10
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Obj.repr
                                                                     (FStar_Tactics_V2_Derived.fail
                                                                     "Checker form not implemented")))
-                                                            uu___9) in
-                                                   Obj.magic
-                                                     (FStar_Tactics_Effect.tac_bind
-                                                        (FStar_Sealed.seal
-                                                           (Obj.magic
-                                                              (FStar_Range.mk_range
-                                                                 "Pulse.Checker.fst"
-                                                                 (Prims.of_int (195))
-                                                                 (Prims.of_int (46))
-                                                                 (Prims.of_int (316))
-                                                                 (Prims.of_int (50)))))
-                                                        (FStar_Sealed.seal
-                                                           (Obj.magic
-                                                              (FStar_Range.mk_range
-                                                                 "Pulse.Checker.fst"
-                                                                 (Prims.of_int (317))
-                                                                 (Prims.of_int (6))
-                                                                 (Prims.of_int (320))
-                                                                 (Prims.of_int (52)))))
-                                                        (Obj.magic uu___7)
-                                                        (fun r ->
-                                                           FStar_Tactics_Effect.lift_div_tac
-                                                             (fun uu___8 ->
-                                                                match r with
-                                                                | FStar_Pervasives.Mkdtuple5
+                                                                 uu___10) in
+                                                        Obj.magic
+                                                          (FStar_Tactics_Effect.tac_bind
+                                                             (FStar_Sealed.seal
+                                                                (Obj.magic
+                                                                   (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (196))
+                                                                    (Prims.of_int (46))
+                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (50)))))
+                                                             (FStar_Sealed.seal
+                                                                (Obj.magic
+                                                                   (FStar_Range.mk_range
+                                                                    "Pulse.Checker.fst"
+                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (321))
+                                                                    (Prims.of_int (52)))))
+                                                             (Obj.magic
+                                                                uu___8)
+                                                             (fun r ->
+                                                                FStar_Tactics_Effect.lift_div_tac
+                                                                  (fun uu___9
+                                                                    ->
+                                                                    match r
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives.Mkdtuple5
                                                                     (x, g1,
                                                                     t1, pre',
                                                                     k) ->
@@ -2183,4 +2212,5 @@ let rec (check : Pulse_Checker_Base.check_t) =
                                                                     pre')
                                                                     k_elim_pure
                                                                     k))))))
-                                                  uu___6))) uu___4))) uu___2))
+                                                       uu___7))) uu___5)))
+                             uu___3)))


### PR DESCRIPTION
This PR prevents error reporting from highlighting an entire decl or reporting problems in another file by using F*'s error bound feature (https://github.com/FStarLang/FStar/pull/3487). The checker will now set the error bound to the st_term being checked, so no errors can escape it.