### PR TITLE
Support more pulse in pulse2rust

### DIFF
--- a/pulse2rust/Makefile
+++ b/pulse2rust/Makefile
@@ -1,12 +1,20 @@
+.PHONY: all
 all: build
 	+$(MAKE) test
 
-build: extract
+.PHONY: build
+build: rustlib extract
 	export OCAMLPATH=$(FSTAR_HOME)/lib && cd src/ocaml && dune build
 	cp -f src/_build/default/ocaml/main.exe .
 
+.PHONY: rustlib
+rustlib:
+	cd src/ocaml && cargo build && cp target/debug/librustast_bindings.a ./librustast_bindings.a
+
+.PHONY: extract
 extract:
 	+$(MAKE) -C src extract
 
+.PHONY: test
 test:
 	+$(MAKE) -C tests/

--- a/pulse2rust/dpe/src/generated/dpe.rs
+++ b/pulse2rust/dpe/src/generated/dpe.rs
@@ -29,7 +29,7 @@ pub fn run_stt<A>(post: (), f: A) -> A {
     panic!()
 }
 pub fn sid_hash(s: super::dpe::sid_t) -> usize {
-    s.into()
+    s as usize
 }
 pub const fn initialize_global_state(
     uu___: (),

--- a/pulse2rust/dpe/src/generated/evercrypt_gen.rs
+++ b/pulse2rust/dpe/src/generated/evercrypt_gen.rs
@@ -12,14 +12,6 @@ pub struct evercrypt {
         msg: *mut u8,
         signature: *mut u8,
     ) -> bool,
-    pub EverCrypt_HMAC_compute: unsafe extern "C" fn(
-        a: Spec_Hash_Definitions_hash_alg,
-        x0: *mut u8,
-        x1: *mut u8,
-        x2: u32,
-        x3: *mut u8,
-        x4: u32,
-    ),
     pub EverCrypt_Hash_Incremental_hash_len:
         unsafe extern "C" fn(a: Spec_Hash_Definitions_hash_alg) -> u32,
     pub EverCrypt_Hash_Incremental_hash: unsafe extern "C" fn(
@@ -27,6 +19,14 @@ pub struct evercrypt {
         output: *mut u8,
         input: *mut u8,
         input_len: u32,
+    ),
+    pub EverCrypt_HMAC_compute: unsafe extern "C" fn(
+        a: Spec_Hash_Definitions_hash_alg,
+        x0: *mut u8,
+        x1: *mut u8,
+        x2: u32,
+        x3: *mut u8,
+        x4: u32,
     ),
 }
 impl evercrypt {
@@ -49,21 +49,21 @@ impl evercrypt {
         let EverCrypt_Ed25519_verify = __library
             .get(b"EverCrypt_Ed25519_verify\0")
             .map(|sym| *sym)?;
-        let EverCrypt_HMAC_compute = __library.get(b"EverCrypt_HMAC_compute\0").map(|sym| *sym)?;
         let EverCrypt_Hash_Incremental_hash_len = __library
             .get(b"EverCrypt_Hash_Incremental_hash_len\0")
             .map(|sym| *sym)?;
         let EverCrypt_Hash_Incremental_hash = __library
             .get(b"EverCrypt_Hash_Incremental_hash\0")
             .map(|sym| *sym)?;
+        let EverCrypt_HMAC_compute = __library.get(b"EverCrypt_HMAC_compute\0").map(|sym| *sym)?;
         Ok(evercrypt {
             __library,
             EverCrypt_AutoConfig2_init,
             EverCrypt_Ed25519_sign,
             EverCrypt_Ed25519_verify,
-            EverCrypt_HMAC_compute,
             EverCrypt_Hash_Incremental_hash_len,
             EverCrypt_Hash_Incremental_hash,
+            EverCrypt_HMAC_compute,
         })
     }
     pub unsafe fn EverCrypt_AutoConfig2_init(&self) {
@@ -87,17 +87,6 @@ impl evercrypt {
     ) -> bool {
         (self.EverCrypt_Ed25519_verify)(public_key, msg_len, msg, signature)
     }
-    pub unsafe fn EverCrypt_HMAC_compute(
-        &self,
-        a: Spec_Hash_Definitions_hash_alg,
-        x0: *mut u8,
-        x1: *mut u8,
-        x2: u32,
-        x3: *mut u8,
-        x4: u32,
-    ) {
-        (self.EverCrypt_HMAC_compute)(a, x0, x1, x2, x3, x4)
-    }
     pub unsafe fn EverCrypt_Hash_Incremental_hash_len(
         &self,
         a: Spec_Hash_Definitions_hash_alg,
@@ -112,5 +101,16 @@ impl evercrypt {
         input_len: u32,
     ) {
         (self.EverCrypt_Hash_Incremental_hash)(a, output, input, input_len)
+    }
+    pub unsafe fn EverCrypt_HMAC_compute(
+        &self,
+        a: Spec_Hash_Definitions_hash_alg,
+        x0: *mut u8,
+        x1: *mut u8,
+        x2: u32,
+        x3: *mut u8,
+        x4: u32,
+    ) {
+        (self.EverCrypt_HMAC_compute)(a, x0, x1, x2, x3, x4)
     }
 }

--- a/pulse2rust/src/Pulse2Rust.Extract.fst
+++ b/pulse2rust/src/Pulse2Rust.Extract.fst
@@ -506,6 +506,27 @@ and extract_mlexpr (g:env) (e:S.mlexpr) : expr =
     when S.string_of_mlpath p = "FStar.SizeT.uint16_to_sizet" ->
     mk_method_call (extract_mlexpr g e) "into" []
 
+  | S.MLE_App ({expr=S.MLE_Name p}, [e])
+    when S.string_of_mlpath p = "FStar.Int.Cast.uint16_to_uint8" ||
+         S.string_of_mlpath p = "FStar.Int.Cast.uint32_to_uint8" ||
+         S.string_of_mlpath p = "FStar.Int.Cast.uint64_to_uint8" ->
+    mk_cast (extract_mlexpr g e) (mk_scalar_typ "u8")
+  | S.MLE_App ({expr=S.MLE_Name p}, [e])
+    when S.string_of_mlpath p = "FStar.Int.Cast.uint8_to_uint16" ||
+         S.string_of_mlpath p = "FStar.Int.Cast.uint32_to_uint16" ||
+         S.string_of_mlpath p = "FStar.Int.Cast.uint64_to_uint16" ->
+    mk_cast (extract_mlexpr g e) (mk_scalar_typ "u16")
+  | S.MLE_App ({expr=S.MLE_Name p}, [e])
+    when S.string_of_mlpath p = "FStar.Int.Cast.uint8_to_uint32" ||
+         S.string_of_mlpath p = "FStar.Int.Cast.uint16_to_uint32" ||
+         S.string_of_mlpath p = "FStar.Int.Cast.uint64_to_uint32" ->
+    mk_cast (extract_mlexpr g e) (mk_scalar_typ "u32")
+  | S.MLE_App ({expr=S.MLE_Name p}, [e])
+    when S.string_of_mlpath p = "FStar.Int.Cast.uint8_to_uint64" ||
+         S.string_of_mlpath p = "FStar.Int.Cast.uint16_to_uint64" ||
+         S.string_of_mlpath p = "FStar.Int.Cast.uint32_to_uint64" ->
+    mk_cast (extract_mlexpr g e) (mk_scalar_typ "u64")
+
   | S.MLE_Var x -> mk_expr_path_singl (varname x)
   | S.MLE_Name p ->
     if should_extract_mlpath_with_symbol g (fst p)

--- a/pulse2rust/src/Pulse2Rust.Extract.fst
+++ b/pulse2rust/src/Pulse2Rust.Extract.fst
@@ -504,7 +504,7 @@ and extract_mlexpr (g:env) (e:S.mlexpr) : expr =
     extract_mlexpr g e
   | S.MLE_App ({expr=S.MLE_Name p}, [e])
     when S.string_of_mlpath p = "FStar.SizeT.uint16_to_sizet" ->
-    mk_method_call (extract_mlexpr g e) "into" []
+    mk_cast (extract_mlexpr g e) (mk_scalar_typ "usize")
 
   | S.MLE_App ({expr=S.MLE_Name p}, [e])
     when S.string_of_mlpath p = "FStar.Int.Cast.uint16_to_uint8" ||

--- a/pulse2rust/src/Pulse2Rust.Extract.fst
+++ b/pulse2rust/src/Pulse2Rust.Extract.fst
@@ -544,8 +544,9 @@ and extract_mlexpr (g:env) (e:S.mlexpr) : expr =
     mk_call (mk_expr_path (["std"; "boxed"; "Box"; "new"])) [e]
 
 
-  | S.MLE_App ({expr=S.MLE_TApp ({expr=S.MLE_Name p}, [_])}, [e; i; _; _])
+  | S.MLE_App ({expr=S.MLE_TApp ({expr=S.MLE_Name p}, [_])}, e::i::_)
     when S.string_of_mlpath p = "Pulse.Lib.Array.Core.op_Array_Access" ||
+         S.string_of_mlpath p = "Pulse.Lib.Array.Core.pts_to_range_index" ||
          S.string_of_mlpath p = "Pulse.Lib.Vec.op_Array_Access" ||
          S.string_of_mlpath p = "Pulse.Lib.Vec.read_ref" ->
 
@@ -553,6 +554,7 @@ and extract_mlexpr (g:env) (e:S.mlexpr) : expr =
 
   | S.MLE_App ({expr=S.MLE_TApp ({expr=S.MLE_Name p}, [_])}, e1::e2::e3::_)
     when S.string_of_mlpath p = "Pulse.Lib.Array.Core.op_Array_Assignment" ||
+         S.string_of_mlpath p = "Pulse.Lib.Array.Core.pts_to_range_upd" ||
          S.string_of_mlpath p = "Pulse.Lib.Vec.op_Array_Assignment" ||
          S.string_of_mlpath p = "Pulse.Lib.Vec.write_ref" ->
 

--- a/pulse2rust/src/Pulse2Rust.Extract.fst
+++ b/pulse2rust/src/Pulse2Rust.Extract.fst
@@ -273,56 +273,96 @@ let extract_top_level_sig
 //
 let is_binop (s:string) : option binop =
   if s = "Prims.op_Addition" ||
+     s = "FStar.UInt8.add" ||
      s = "FStar.UInt16.add" ||
      s = "FStar.UInt32.add" ||
+     s = "FStar.UInt64.add" ||
      s = "FStar.SizeT.add"
   then Some Add
   else if s = "Prims.op_Subtraction" ||
           s = "FStar.SizeT.sub" ||
+          s = "FStar.UInt8.sub" ||
           s = "FStar.UInt16.sub" ||
-          s = "FStar.UInt32.sub"
+          s = "FStar.UInt32.sub" ||
+          s = "FStar.UInt64.sub"
   then Some Sub
   else if s = "Prims.op_Multiply" ||
           s = "FStar.Mul.op_Star" ||
+          s = "FStar.UInt8.mul" ||
           s = "FStar.UInt16.mul" ||
           s = "FStar.UInt32.mul" ||
           s = "FStar.UInt32.op_Star_Hat" ||
+          s = "FStar.UInt64.mul" ||
           s = "FStar.SizeT.mul" ||
           s = "FStar.SizeT.op_Star_Hat"
   then Some Mul
   else if s = "Prims.op_disEquality"
   then Some Ne
   else if s = "Prims.op_LessThanOrEqual" ||
+          s = "FStar.UInt8.lte" ||
           s = "FStar.UInt16.lte" ||
           s = "FStar.UInt32.lte" ||
+          s = "FStar.UInt64.lte" ||
           s = "FStar.SizeT.lte"
   then Some Le
   else if s = "Prims.op_LessThan" ||
+          s = "FStar.UInt8.lt" ||
           s = "FStar.UInt16.lt" ||
           s = "FStar.UInt32.lt" ||
+          s = "FStar.UInt64.lt" ||
           s = "FStar.SizeT.lt"
   then Some Lt
   else if s = "Prims.op_GreaterThanOrEqual" ||
+          s = "FStar.UInt8.gte" ||
           s = "FStar.UInt16.gte" ||
           s = "FStar.UInt32.gte" ||
+          s = "FStar.UInt64.gte" ||
           s = "FStar.SizeT.gte"
   then Some Ge
   else if s = "Prims.op_GreaterThan" ||
+          s = "FStar.UInt8.gt" ||
           s = "FStar.UInt16.gt" ||
           s = "FStar.UInt32.gt" ||
+          s = "FStar.UInt64.gt" ||
           s = "FStar.SizeT.gt"
   then Some Gt
   else if s = "Prims.op_Equality"
   then Some Eq
   else if s = "Prims.rem" ||
+          s = "FStar.UInt8.rem" ||
           s = "FStar.UInt16.rem" ||
           s = "FStar.UInt32.rem" ||
+          s = "FStar.UInt64.rem" ||
           s = "FStar.SizeT.rem"
   then Some Rem
   else if s = "Prims.op_AmpAmp"
   then Some And
   else if s = "Prims.op_BarBar"
   then Some Or
+  else if
+    s = "FStar.UInt8.shift_left" ||
+    s = "FStar.UInt16.shift_left" ||
+    s = "FStar.UInt32.shift_left" ||
+    s = "FStar.UInt64.shift_left"
+  then Some Shl
+  else if
+    s = "FStar.UInt8.shift_right" ||
+    s = "FStar.UInt16.shift_right" ||
+    s = "FStar.UInt32.shift_right" ||
+    s = "FStar.UInt64.shift_right"
+  then Some Shr
+  else if
+    s = "FStar.UInt8.logor" ||
+    s = "FStar.UInt16.logor" ||
+    s = "FStar.UInt32.logor" ||
+    s = "FStar.UInt64.logor"
+  then Some BitOr
+  else if
+    s = "FStar.UInt8.logand" ||
+    s = "FStar.UInt16.logand" ||
+    s = "FStar.UInt32.logand" ||
+    s = "FStar.UInt64.logand"
+  then Some BitAnd
   else None
 
 let extract_mlconstant_to_lit (c:S.mlconstant) : lit =

--- a/pulse2rust/src/Pulse2Rust.Extract.fst
+++ b/pulse2rust/src/Pulse2Rust.Extract.fst
@@ -378,6 +378,9 @@ let rec extract_mlpattern_to_pat (g:env) (p:S.mlpattern) : env & pat =
     let g, ps = fold_left_map extract_mlpattern_to_pat g (List.map snd fs) in
     g,
     mk_pat_struct (List.last p) (zip (List.map fst fs) ps)
+  | S.MLP_Tuple ps ->
+    let g, ps = fold_left_map extract_mlpattern_to_pat g ps in
+    g, mk_pat_tuple ps
   | _ -> fail_nyi (format1 "mlpattern_to_pat %s" (S.mlpattern_to_string p))
 
 //

--- a/pulse2rust/src/Pulse2Rust.Extract.fst
+++ b/pulse2rust/src/Pulse2Rust.Extract.fst
@@ -539,12 +539,14 @@ and extract_mlexpr (g:env) (e:S.mlexpr) : expr =
 
   | S.MLE_App ({expr=S.MLE_TApp ({expr=S.MLE_Name p}, _)}, [e])
     when S.string_of_mlpath p = "Pulse.Lib.Pervasives.tfst" ||
+         S.string_of_mlpath p = "FStar.Pervasives.Native.__proj__Mktuple2__item___1" ||
          S.string_of_mlpath p = "FStar.Pervasives.Native.fst" ||
          S.string_of_mlpath p = "FStar.Pervasives.dfst" ->
     let e = extract_mlexpr g e in
     mk_expr_field_unnamed e 0
   | S.MLE_App ({expr=S.MLE_TApp ({expr=S.MLE_Name p}, _)}, [e])
     when S.string_of_mlpath p = "Pulse.Lib.Pervasives.tsnd" ||
+         S.string_of_mlpath p = "FStar.Pervasives.Native.__proj__Mktuple2__item___2" ||
          S.string_of_mlpath p = "FStar.Pervasives.Native.snd" ||
          S.string_of_mlpath p = "FStar.Pervasives.dsnd" ->
     let e = extract_mlexpr g e in

--- a/pulse2rust/src/Pulse2Rust.Rust.Syntax.fst
+++ b/pulse2rust/src/Pulse2Rust.Rust.Syntax.fst
@@ -183,6 +183,12 @@ let mk_method_call (receiver:expr) (name:string) (args:list expr) : expr =
     expr_method_call_args = args;
   }
 
+let mk_cast (e:expr) (ty:typ) : expr =
+  Expr_cast {
+    expr_cast_expr = e;
+    expr_cast_type = ty;
+  }
+
 let mk_new_mutex (e:expr) =
   mk_call
     (mk_expr_path ["std"; "sync"; "Mutex"; "new"])

--- a/pulse2rust/src/Pulse2Rust.Rust.Syntax.fsti
+++ b/pulse2rust/src/Pulse2Rust.Rust.Syntax.fsti
@@ -111,6 +111,7 @@ and expr =
   | Expr_struct of expr_struct
   | Expr_tuple of list expr
   | Expr_method_call of expr_method_call
+  | Expr_cast of expr_cast
 
 and expr_bin = {
   expr_bin_left : expr;
@@ -189,6 +190,11 @@ and expr_method_call = {
   expr_method_call_receiver : expr;
   expr_method_call_name : string;
   expr_method_call_args : list expr;
+}
+
+and expr_cast = {
+  expr_cast_expr : expr;
+  expr_cast_type : typ;
 }
 
 and local_stmt = {
@@ -351,6 +357,7 @@ val mk_expr_struct (path:list string) (fields:list (string & expr)) : expr
 val mk_expr_tuple (l:list expr) : expr
 val mk_mem_replace (t:typ) (e:expr) (new_v:expr) : expr
 val mk_method_call (receiver:expr) (name:string) (args:list expr) : expr
+val mk_cast (e:expr) (ty:typ) : expr
 
 val mk_new_mutex (e:expr) : expr
 val mk_lock_mutex (e:expr) : expr

--- a/pulse2rust/src/Pulse2Rust.Rust.Syntax.fsti
+++ b/pulse2rust/src/Pulse2Rust.Rust.Syntax.fsti
@@ -49,6 +49,10 @@ type binop =
   | And
   | Or
   | Mul
+  | Shr
+  | Shl
+  | BitAnd
+  | BitOr
 
 type unop =
   | Deref

--- a/pulse2rust/src/Pulse2Rust.fst
+++ b/pulse2rust/src/Pulse2Rust.fst
@@ -179,7 +179,8 @@ let extract (files:list string) (odir:string) (libs:string) : unit =
   //
   let all_modules = topsort_all d [] in
   // print1 "all_modules: %s\n" (String.concat " " all_modules);
-  let root_module::_ = all_modules in
+  let root_module = file_to_module_name (let root_file::_ = files in root_file) in
+  // print1 "root_module: %s\n" root_module;
   let reachable_defs = collect_reachable_defs d root_module in
   let external_libs = FStar.Compiler.Util.split libs "," |> List.map trim_string in
   let g = empty_env external_libs d all_modules reachable_defs in

--- a/pulse2rust/src/ocaml/.gitignore
+++ b/pulse2rust/src/ocaml/.gitignore
@@ -1,0 +1,3 @@
+/librustast_bindings.a
+/Cargo.lock
+/target

--- a/pulse2rust/src/ocaml/Cargo.toml
+++ b/pulse2rust/src/ocaml/Cargo.toml
@@ -15,4 +15,4 @@ ocaml-interop = "0.9.2"
 syn = { version="2.0.29", features=["full", "derive"] }
 proc-macro2 = "1.0.66"
 quote = "1.0.33"
-prettyplease = "0.2.16"
+prettyplease = "0.2.22"

--- a/pulse2rust/src/ocaml/dune
+++ b/pulse2rust/src/ocaml/dune
@@ -1,15 +1,5 @@
 (include_subdirs unqualified)
 
-(rule
- (targets librustast_bindings.a)
- (deps (source_tree .))
- (action
-  (no-infer
-   (progn
-    (run cargo build)
-    (run cp target/debug/librustast_bindings.a ./librustast_bindings.a)
-   ))))
-
 (executable
  (name main)
  (libraries batteries fstar.lib menhirLib)

--- a/pulse2rust/src/ocaml/generated/Pulse2Rust.ml
+++ b/pulse2rust/src/ocaml/generated/Pulse2Rust.ml
@@ -262,46 +262,44 @@ let (extract :
       fun libs ->
         let d = read_all_ast_files files in
         let all_modules = Pulse2Rust_Deps.topsort_all d [] in
-        let uu___ = all_modules in
+        let root_module =
+          file_to_module_name
+            (let uu___ = files in
+             match uu___ with | root_file::uu___1 -> root_file) in
+        let reachable_defs = collect_reachable_defs d root_module in
+        let external_libs =
+          FStar_Compiler_List.map FStar_Compiler_Util.trim_string
+            (FStar_Compiler_Util.split libs ",") in
+        let g =
+          Pulse2Rust_Env.empty_env external_libs d all_modules reachable_defs in
+        let uu___ =
+          FStar_Compiler_List.fold_left
+            (fun uu___1 ->
+               fun f ->
+                 match uu___1 with
+                 | (g1, all_rust_files) ->
+                     let uu___2 =
+                       let uu___3 = FStar_Compiler_Util.smap_try_find d f in
+                       FStar_Compiler_Util.must uu___3 in
+                     (match uu___2 with
+                      | (uu___3, bs, ds) ->
+                          let uu___4 = extract_one g1 f bs ds in
+                          (match uu___4 with
+                           | (s, g2) ->
+                               let rust_fname =
+                                 let uu___5 = rust_file_name f in
+                                 FStar_Compiler_Util.concat_dir_filename odir
+                                   uu___5 in
+                               let rust_f =
+                                 FStar_Compiler_Util.open_file_for_writing
+                                   rust_fname in
+                               (FStar_Compiler_Util.append_to_file rust_f
+                                  header;
+                                FStar_Compiler_Util.append_to_file rust_f s;
+                                FStar_Compiler_Util.close_out_channel rust_f;
+                                (g2, (rust_fname :: all_rust_files))))))
+            (g, []) all_modules in
         match uu___ with
-        | root_module::uu___1 ->
-            let reachable_defs = collect_reachable_defs d root_module in
-            let external_libs =
-              FStar_Compiler_List.map FStar_Compiler_Util.trim_string
-                (FStar_Compiler_Util.split libs ",") in
-            let g =
-              Pulse2Rust_Env.empty_env external_libs d all_modules
-                reachable_defs in
-            let uu___2 =
-              FStar_Compiler_List.fold_left
-                (fun uu___3 ->
-                   fun f ->
-                     match uu___3 with
-                     | (g1, all_rust_files) ->
-                         let uu___4 =
-                           let uu___5 = FStar_Compiler_Util.smap_try_find d f in
-                           FStar_Compiler_Util.must uu___5 in
-                         (match uu___4 with
-                          | (uu___5, bs, ds) ->
-                              let uu___6 = extract_one g1 f bs ds in
-                              (match uu___6 with
-                               | (s, g2) ->
-                                   let rust_fname =
-                                     let uu___7 = rust_file_name f in
-                                     FStar_Compiler_Util.concat_dir_filename
-                                       odir uu___7 in
-                                   let rust_f =
-                                     FStar_Compiler_Util.open_file_for_writing
-                                       rust_fname in
-                                   (FStar_Compiler_Util.append_to_file rust_f
-                                      header;
-                                    FStar_Compiler_Util.append_to_file rust_f
-                                      s;
-                                    FStar_Compiler_Util.close_out_channel
-                                      rust_f;
-                                    (g2, (rust_fname :: all_rust_files))))))
-                (g, []) all_modules in
-            (match uu___2 with
-             | (uu___3, all_rust_files) ->
-                 FStar_Compiler_Util.print1 "\n\nExtracted: %s\n\n"
-                   (FStar_Compiler_String.concat " " all_rust_files))
+        | (uu___1, all_rust_files) ->
+            FStar_Compiler_Util.print1 "\n\nExtracted: %s\n\n"
+              (FStar_Compiler_String.concat " " all_rust_files)

--- a/pulse2rust/src/ocaml/generated/Pulse2Rust_Extract.ml
+++ b/pulse2rust/src/ocaml/generated/Pulse2Rust_Extract.ml
@@ -773,7 +773,8 @@ and (extract_mlexpr :
           let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu___2 = "FStar.SizeT.uint16_to_sizet" ->
           let uu___2 = extract_mlexpr g e1 in
-          Pulse2Rust_Rust_Syntax.mk_method_call uu___2 "into" []
+          let uu___3 = Pulse2Rust_Rust_Syntax.mk_scalar_typ "usize" in
+          Pulse2Rust_Rust_Syntax.mk_cast uu___2 uu___3
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =

--- a/pulse2rust/src/ocaml/generated/Pulse2Rust_Extract.ml
+++ b/pulse2rust/src/ocaml/generated/Pulse2Rust_Extract.ml
@@ -953,19 +953,22 @@ and (extract_mlexpr :
                 uu___2::[]);
              FStar_Extraction_ML_Syntax.mlty = uu___3;
              FStar_Extraction_ML_Syntax.loc = uu___4;_},
-           e1::i::uu___5::uu___6::[])
+           e1::i::uu___5)
           when
-          ((let uu___7 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-            uu___7 = "Pulse.Lib.Array.Core.op_Array_Access") ||
-             (let uu___7 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu___7 = "Pulse.Lib.Vec.op_Array_Access"))
+          (((let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___6 = "Pulse.Lib.Array.Core.op_Array_Access") ||
+              (let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+               uu___6 = "Pulse.Lib.Array.Core.pts_to_range_index"))
+             ||
+             (let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___6 = "Pulse.Lib.Vec.op_Array_Access"))
             ||
-            (let uu___7 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu___7 = "Pulse.Lib.Vec.read_ref")
+            (let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___6 = "Pulse.Lib.Vec.read_ref")
           ->
-          let uu___7 = extract_mlexpr g e1 in
-          let uu___8 = extract_mlexpr g i in
-          Pulse2Rust_Rust_Syntax.mk_expr_index uu___7 uu___8
+          let uu___6 = extract_mlexpr g e1 in
+          let uu___7 = extract_mlexpr g i in
+          Pulse2Rust_Rust_Syntax.mk_expr_index uu___6 uu___7
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -980,8 +983,11 @@ and (extract_mlexpr :
              FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::e2::e3::uu___5)
           when
-          ((let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-            uu___6 = "Pulse.Lib.Array.Core.op_Array_Assignment") ||
+          (((let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___6 = "Pulse.Lib.Array.Core.op_Array_Assignment") ||
+              (let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+               uu___6 = "Pulse.Lib.Array.Core.pts_to_range_upd"))
+             ||
              (let uu___6 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
               uu___6 = "Pulse.Lib.Vec.op_Array_Assignment"))
             ||

--- a/pulse2rust/src/ocaml/generated/Pulse2Rust_Extract.ml
+++ b/pulse2rust/src/ocaml/generated/Pulse2Rust_Extract.ml
@@ -561,6 +561,13 @@ let rec (extract_mlpattern_to_pat :
                    FStar_Compiler_List.zip uu___4 ps in
                  Pulse2Rust_Rust_Syntax.mk_pat_struct uu___2 uu___3 in
                (g1, uu___1))
+      | FStar_Extraction_ML_Syntax.MLP_Tuple ps ->
+          let uu___ =
+            FStar_Compiler_List.fold_left_map extract_mlpattern_to_pat g ps in
+          (match uu___ with
+           | (g1, ps1) ->
+               let uu___1 = Pulse2Rust_Rust_Syntax.mk_pat_tuple ps1 in
+               (g1, uu___1))
       | uu___ ->
           let uu___1 =
             let uu___2 = FStar_Extraction_ML_Syntax.mlpattern_to_string p in

--- a/pulse2rust/src/ocaml/generated/Pulse2Rust_Extract.ml
+++ b/pulse2rust/src/ocaml/generated/Pulse2Rust_Extract.ml
@@ -774,6 +774,82 @@ and (extract_mlexpr :
           uu___2 = "FStar.SizeT.uint16_to_sizet" ->
           let uu___2 = extract_mlexpr g e1 in
           Pulse2Rust_Rust_Syntax.mk_method_call uu___2 "into" []
+      | FStar_Extraction_ML_Syntax.MLE_App
+          ({
+             FStar_Extraction_ML_Syntax.expr =
+               FStar_Extraction_ML_Syntax.MLE_Name p;
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
+           e1::[])
+          when
+          ((let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+            uu___2 = "FStar.Int.Cast.uint16_to_uint8") ||
+             (let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___2 = "FStar.Int.Cast.uint32_to_uint8"))
+            ||
+            (let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___2 = "FStar.Int.Cast.uint64_to_uint8")
+          ->
+          let uu___2 = extract_mlexpr g e1 in
+          let uu___3 = Pulse2Rust_Rust_Syntax.mk_scalar_typ "u8" in
+          Pulse2Rust_Rust_Syntax.mk_cast uu___2 uu___3
+      | FStar_Extraction_ML_Syntax.MLE_App
+          ({
+             FStar_Extraction_ML_Syntax.expr =
+               FStar_Extraction_ML_Syntax.MLE_Name p;
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
+           e1::[])
+          when
+          ((let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+            uu___2 = "FStar.Int.Cast.uint8_to_uint16") ||
+             (let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___2 = "FStar.Int.Cast.uint32_to_uint16"))
+            ||
+            (let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___2 = "FStar.Int.Cast.uint64_to_uint16")
+          ->
+          let uu___2 = extract_mlexpr g e1 in
+          let uu___3 = Pulse2Rust_Rust_Syntax.mk_scalar_typ "u16" in
+          Pulse2Rust_Rust_Syntax.mk_cast uu___2 uu___3
+      | FStar_Extraction_ML_Syntax.MLE_App
+          ({
+             FStar_Extraction_ML_Syntax.expr =
+               FStar_Extraction_ML_Syntax.MLE_Name p;
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
+           e1::[])
+          when
+          ((let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+            uu___2 = "FStar.Int.Cast.uint8_to_uint32") ||
+             (let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___2 = "FStar.Int.Cast.uint16_to_uint32"))
+            ||
+            (let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___2 = "FStar.Int.Cast.uint64_to_uint32")
+          ->
+          let uu___2 = extract_mlexpr g e1 in
+          let uu___3 = Pulse2Rust_Rust_Syntax.mk_scalar_typ "u32" in
+          Pulse2Rust_Rust_Syntax.mk_cast uu___2 uu___3
+      | FStar_Extraction_ML_Syntax.MLE_App
+          ({
+             FStar_Extraction_ML_Syntax.expr =
+               FStar_Extraction_ML_Syntax.MLE_Name p;
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
+           e1::[])
+          when
+          ((let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+            uu___2 = "FStar.Int.Cast.uint8_to_uint64") ||
+             (let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___2 = "FStar.Int.Cast.uint16_to_uint64"))
+            ||
+            (let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___2 = "FStar.Int.Cast.uint32_to_uint64")
+          ->
+          let uu___2 = extract_mlexpr g e1 in
+          let uu___3 = Pulse2Rust_Rust_Syntax.mk_scalar_typ "u64" in
+          Pulse2Rust_Rust_Syntax.mk_cast uu___2 uu___3
       | FStar_Extraction_ML_Syntax.MLE_Var x ->
           let uu___ = varname x in
           Pulse2Rust_Rust_Syntax.mk_expr_path_singl uu___

--- a/pulse2rust/src/ocaml/generated/Pulse2Rust_Extract.ml
+++ b/pulse2rust/src/ocaml/generated/Pulse2Rust_Extract.ml
@@ -376,22 +376,28 @@ let (is_binop :
   =
   fun s ->
     if
-      (((s = "Prims.op_Addition") || (s = "FStar.UInt16.add")) ||
-         (s = "FStar.UInt32.add"))
+      (((((s = "Prims.op_Addition") || (s = "FStar.UInt8.add")) ||
+           (s = "FStar.UInt16.add"))
+          || (s = "FStar.UInt32.add"))
+         || (s = "FStar.UInt64.add"))
         || (s = "FStar.SizeT.add")
     then FStar_Pervasives_Native.Some Pulse2Rust_Rust_Syntax.Add
     else
       if
-        (((s = "Prims.op_Subtraction") || (s = "FStar.SizeT.sub")) ||
-           (s = "FStar.UInt16.sub"))
-          || (s = "FStar.UInt32.sub")
+        (((((s = "Prims.op_Subtraction") || (s = "FStar.SizeT.sub")) ||
+             (s = "FStar.UInt8.sub"))
+            || (s = "FStar.UInt16.sub"))
+           || (s = "FStar.UInt32.sub"))
+          || (s = "FStar.UInt64.sub")
       then FStar_Pervasives_Native.Some Pulse2Rust_Rust_Syntax.Sub
       else
         if
-          ((((((s = "Prims.op_Multiply") || (s = "FStar.Mul.op_Star")) ||
-                (s = "FStar.UInt16.mul"))
-               || (s = "FStar.UInt32.mul"))
-              || (s = "FStar.UInt32.op_Star_Hat"))
+          ((((((((s = "Prims.op_Multiply") || (s = "FStar.Mul.op_Star")) ||
+                  (s = "FStar.UInt8.mul"))
+                 || (s = "FStar.UInt16.mul"))
+                || (s = "FStar.UInt32.mul"))
+               || (s = "FStar.UInt32.op_Star_Hat"))
+              || (s = "FStar.UInt64.mul"))
              || (s = "FStar.SizeT.mul"))
             || (s = "FStar.SizeT.op_Star_Hat")
         then FStar_Pervasives_Native.Some Pulse2Rust_Rust_Syntax.Mul
@@ -400,27 +406,36 @@ let (is_binop :
           then FStar_Pervasives_Native.Some Pulse2Rust_Rust_Syntax.Ne
           else
             if
-              (((s = "Prims.op_LessThanOrEqual") || (s = "FStar.UInt16.lte"))
-                 || (s = "FStar.UInt32.lte"))
+              (((((s = "Prims.op_LessThanOrEqual") || (s = "FStar.UInt8.lte"))
+                   || (s = "FStar.UInt16.lte"))
+                  || (s = "FStar.UInt32.lte"))
+                 || (s = "FStar.UInt64.lte"))
                 || (s = "FStar.SizeT.lte")
             then FStar_Pervasives_Native.Some Pulse2Rust_Rust_Syntax.Le
             else
               if
-                (((s = "Prims.op_LessThan") || (s = "FStar.UInt16.lt")) ||
-                   (s = "FStar.UInt32.lt"))
+                (((((s = "Prims.op_LessThan") || (s = "FStar.UInt8.lt")) ||
+                     (s = "FStar.UInt16.lt"))
+                    || (s = "FStar.UInt32.lt"))
+                   || (s = "FStar.UInt64.lt"))
                   || (s = "FStar.SizeT.lt")
               then FStar_Pervasives_Native.Some Pulse2Rust_Rust_Syntax.Lt
               else
                 if
-                  (((s = "Prims.op_GreaterThanOrEqual") ||
-                      (s = "FStar.UInt16.gte"))
-                     || (s = "FStar.UInt32.gte"))
+                  (((((s = "Prims.op_GreaterThanOrEqual") ||
+                        (s = "FStar.UInt8.gte"))
+                       || (s = "FStar.UInt16.gte"))
+                      || (s = "FStar.UInt32.gte"))
+                     || (s = "FStar.UInt64.gte"))
                     || (s = "FStar.SizeT.gte")
                 then FStar_Pervasives_Native.Some Pulse2Rust_Rust_Syntax.Ge
                 else
                   if
-                    (((s = "Prims.op_GreaterThan") || (s = "FStar.UInt16.gt"))
-                       || (s = "FStar.UInt32.gt"))
+                    (((((s = "Prims.op_GreaterThan") ||
+                          (s = "FStar.UInt8.gt"))
+                         || (s = "FStar.UInt16.gt"))
+                        || (s = "FStar.UInt32.gt"))
+                       || (s = "FStar.UInt64.gt"))
                       || (s = "FStar.SizeT.gt")
                   then FStar_Pervasives_Native.Some Pulse2Rust_Rust_Syntax.Gt
                   else
@@ -429,8 +444,10 @@ let (is_binop :
                       FStar_Pervasives_Native.Some Pulse2Rust_Rust_Syntax.Eq
                     else
                       if
-                        (((s = "Prims.rem") || (s = "FStar.UInt16.rem")) ||
-                           (s = "FStar.UInt32.rem"))
+                        (((((s = "Prims.rem") || (s = "FStar.UInt8.rem")) ||
+                             (s = "FStar.UInt16.rem"))
+                            || (s = "FStar.UInt32.rem"))
+                           || (s = "FStar.UInt64.rem"))
                           || (s = "FStar.SizeT.rem")
                       then
                         FStar_Pervasives_Native.Some
@@ -445,7 +462,43 @@ let (is_binop :
                           then
                             FStar_Pervasives_Native.Some
                               Pulse2Rust_Rust_Syntax.Or
-                          else FStar_Pervasives_Native.None
+                          else
+                            if
+                              (((s = "FStar.UInt8.shift_left") ||
+                                  (s = "FStar.UInt16.shift_left"))
+                                 || (s = "FStar.UInt32.shift_left"))
+                                || (s = "FStar.UInt64.shift_left")
+                            then
+                              FStar_Pervasives_Native.Some
+                                Pulse2Rust_Rust_Syntax.Shl
+                            else
+                              if
+                                (((s = "FStar.UInt8.shift_right") ||
+                                    (s = "FStar.UInt16.shift_right"))
+                                   || (s = "FStar.UInt32.shift_right"))
+                                  || (s = "FStar.UInt64.shift_right")
+                              then
+                                FStar_Pervasives_Native.Some
+                                  Pulse2Rust_Rust_Syntax.Shr
+                              else
+                                if
+                                  (((s = "FStar.UInt8.logor") ||
+                                      (s = "FStar.UInt16.logor"))
+                                     || (s = "FStar.UInt32.logor"))
+                                    || (s = "FStar.UInt64.logor")
+                                then
+                                  FStar_Pervasives_Native.Some
+                                    Pulse2Rust_Rust_Syntax.BitOr
+                                else
+                                  if
+                                    (((s = "FStar.UInt8.logand") ||
+                                        (s = "FStar.UInt16.logand"))
+                                       || (s = "FStar.UInt32.logand"))
+                                      || (s = "FStar.UInt64.logand")
+                                  then
+                                    FStar_Pervasives_Native.Some
+                                      Pulse2Rust_Rust_Syntax.BitAnd
+                                  else FStar_Pervasives_Native.None
 let (extract_mlconstant_to_lit :
   FStar_Extraction_ML_Syntax.mlconstant -> Pulse2Rust_Rust_Syntax.lit) =
   fun c ->

--- a/pulse2rust/src/ocaml/generated/Pulse2Rust_Extract.ml
+++ b/pulse2rust/src/ocaml/generated/Pulse2Rust_Extract.ml
@@ -889,8 +889,11 @@ and (extract_mlexpr :
              FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::[])
           when
-          ((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-            uu___5 = "Pulse.Lib.Pervasives.tfst") ||
+          (((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "Pulse.Lib.Pervasives.tfst") ||
+              (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+               uu___5 = "FStar.Pervasives.Native.__proj__Mktuple2__item___1"))
+             ||
              (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
               uu___5 = "FStar.Pervasives.Native.fst"))
             ||
@@ -913,8 +916,11 @@ and (extract_mlexpr :
              FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::[])
           when
-          ((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-            uu___5 = "Pulse.Lib.Pervasives.tsnd") ||
+          (((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+             uu___5 = "Pulse.Lib.Pervasives.tsnd") ||
+              (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+               uu___5 = "FStar.Pervasives.Native.__proj__Mktuple2__item___2"))
+             ||
              (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
               uu___5 = "FStar.Pervasives.Native.snd"))
             ||

--- a/pulse2rust/src/ocaml/generated/Pulse2Rust_Rust_Syntax.ml
+++ b/pulse2rust/src/ocaml/generated/Pulse2Rust_Rust_Syntax.ml
@@ -162,6 +162,7 @@ and expr =
   | Expr_struct of expr_struct 
   | Expr_tuple of expr Prims.list 
   | Expr_method_call of expr_method_call 
+  | Expr_cast of expr_cast 
 and expr_bin =
   {
   expr_bin_left: expr ;
@@ -217,6 +218,9 @@ and expr_method_call =
   expr_method_call_receiver: expr ;
   expr_method_call_name: Prims.string ;
   expr_method_call_args: expr Prims.list }
+and expr_cast = {
+  expr_cast_expr: expr ;
+  expr_cast_type: typ }
 and local_stmt =
   {
   local_stmt_pat: pat FStar_Pervasives_Native.option ;
@@ -397,6 +401,11 @@ let (uu___is_Expr_method_call : expr -> Prims.bool) =
     match projectee with | Expr_method_call _0 -> true | uu___ -> false
 let (__proj__Expr_method_call__item___0 : expr -> expr_method_call) =
   fun projectee -> match projectee with | Expr_method_call _0 -> _0
+let (uu___is_Expr_cast : expr -> Prims.bool) =
+  fun projectee ->
+    match projectee with | Expr_cast _0 -> true | uu___ -> false
+let (__proj__Expr_cast__item___0 : expr -> expr_cast) =
+  fun projectee -> match projectee with | Expr_cast _0 -> _0
 let (__proj__Mkexpr_bin__item__expr_bin_left : expr_bin -> expr) =
   fun projectee ->
     match projectee with
@@ -550,6 +559,14 @@ let (__proj__Mkexpr_method_call__item__expr_method_call_args :
     match projectee with
     | { expr_method_call_receiver; expr_method_call_name;
         expr_method_call_args;_} -> expr_method_call_args
+let (__proj__Mkexpr_cast__item__expr_cast_expr : expr_cast -> expr) =
+  fun projectee ->
+    match projectee with
+    | { expr_cast_expr; expr_cast_type;_} -> expr_cast_expr
+let (__proj__Mkexpr_cast__item__expr_cast_type : expr_cast -> typ) =
+  fun projectee ->
+    match projectee with
+    | { expr_cast_expr; expr_cast_type;_} -> expr_cast_type
 let (__proj__Mklocal_stmt__item__local_stmt_pat :
   local_stmt -> pat FStar_Pervasives_Native.option) =
   fun projectee ->
@@ -1069,6 +1086,8 @@ let (mk_method_call : expr -> Prims.string -> expr Prims.list -> expr) =
             expr_method_call_name = name;
             expr_method_call_args = args
           }
+let (mk_cast : expr -> typ -> expr) =
+  fun e -> fun ty -> Expr_cast { expr_cast_expr = e; expr_cast_type = ty }
 let (mk_new_mutex : expr -> expr) =
   fun e ->
     let uu___ = mk_expr_path ["std"; "sync"; "Mutex"; "new"] in

--- a/pulse2rust/src/ocaml/generated/Pulse2Rust_Rust_Syntax.ml
+++ b/pulse2rust/src/ocaml/generated/Pulse2Rust_Rust_Syntax.ml
@@ -68,6 +68,10 @@ type binop =
   | And 
   | Or 
   | Mul 
+  | Shr 
+  | Shl 
+  | BitAnd 
+  | BitOr 
 let (uu___is_Add : binop -> Prims.bool) =
   fun projectee -> match projectee with | Add -> true | uu___ -> false
 let (uu___is_Sub : binop -> Prims.bool) =
@@ -92,6 +96,14 @@ let (uu___is_Or : binop -> Prims.bool) =
   fun projectee -> match projectee with | Or -> true | uu___ -> false
 let (uu___is_Mul : binop -> Prims.bool) =
   fun projectee -> match projectee with | Mul -> true | uu___ -> false
+let (uu___is_Shr : binop -> Prims.bool) =
+  fun projectee -> match projectee with | Shr -> true | uu___ -> false
+let (uu___is_Shl : binop -> Prims.bool) =
+  fun projectee -> match projectee with | Shl -> true | uu___ -> false
+let (uu___is_BitAnd : binop -> Prims.bool) =
+  fun projectee -> match projectee with | BitAnd -> true | uu___ -> false
+let (uu___is_BitOr : binop -> Prims.bool) =
+  fun projectee -> match projectee with | BitOr -> true | uu___ -> false
 type unop =
   | Deref 
 let (uu___is_Deref : unop -> Prims.bool) = fun projectee -> true

--- a/pulse2rust/src/ocaml/rust/src/lib.rs
+++ b/pulse2rust/src/ocaml/rust/src/lib.rs
@@ -3,6 +3,7 @@ use ocaml_interop::{
     ToOCaml,
 };
 use proc_macro2::Span;
+use quote::ToTokens;
 use syn::{
     punctuated::Punctuated, token::Brace, token::Colon, token::Comma, token::Eq, token::Let,
     token::Mut, token::Paren, token::Pub, token::RArrow, token::Ref, token::Semi, Block, Generics,
@@ -1867,8 +1868,9 @@ fn to_syn_file(f: &File) -> syn::File {
 
 fn file_to_syn_string(f: &File) -> String {
     let f: syn::File = to_syn_file(f);
+    // The to_token_stream() function adds parentheses where necessary, see also syn::fixup::FixupContext
+    let f = syn::parse2(f.to_token_stream()).unwrap();
     prettyplease::unparse(&f)
-    // quote::quote!(#f).to_string()
 }
 
 // fn fn_to_syn_string(f: &Fn) -> String {

--- a/pulse2rust/src/ocaml/rust/src/lib.rs
+++ b/pulse2rust/src/ocaml/rust/src/lib.rs
@@ -47,6 +47,10 @@ enum BinOp {
     And,
     Or,
     Mul,
+    Shr,
+    Shl,
+    BitAnd,
+    BitOr,
 }
 
 enum UnOp {
@@ -356,7 +360,11 @@ impl_from_ocaml_variant! {
       BinOp::Rem,
       BinOp::And,
       BinOp::Or,
-      BinOp::Mul
+      BinOp::Mul,
+      BinOp::Shr,
+      BinOp::Shl,
+      BinOp::BitAnd,
+      BinOp::BitOr,
   }
 }
 
@@ -789,6 +797,18 @@ fn to_syn_binop(op: &BinOp) -> syn::BinOp {
             spans: [Span::call_site(), Span::call_site()],
         }),
         BinOp::Mul => syn::BinOp::Mul(syn::token::Star {
+            spans: [Span::call_site()],
+        }),
+        BinOp::Shr => syn::BinOp::Shr(syn::token::Shr {
+            spans: [Span::call_site(), Span::call_site()],
+        }),
+        BinOp::Shl => syn::BinOp::Shl(syn::token::Shl {
+            spans: [Span::call_site(), Span::call_site()],
+        }),
+        BinOp::BitAnd => syn::BinOp::BitAnd(syn::token::And {
+            spans: [Span::call_site()],
+        }),
+        BinOp::BitOr => syn::BinOp::BitOr(syn::token::Or {
             spans: [Span::call_site()],
         }),
     }
@@ -1849,6 +1869,10 @@ impl fmt::Display for BinOp {
             BinOp::And => "&&",
             BinOp::Or => "||",
             BinOp::Mul => "*",
+            BinOp::Shr => ">>",
+            BinOp::Shl => "<<",
+            BinOp::BitAnd => "&",
+            BinOp::BitOr => "|",
         };
         write!(f, "{}", s)
     }


### PR DESCRIPTION
Various updates to pulse2rust.  Newly supported functions:
 - bit operations (shifts, or, and)
 - `x._1`
 - `FStar.Int.Cast.*`
 - `pts_to_range_index`

Also fixes #219.  Thanks to @aseemr for pointing me in the right direction!