### PR TITLE
Tick order

### DIFF
--- a/share/pulse/examples/Test.GenOrder.fst
+++ b/share/pulse/examples/Test.GenOrder.fst
@@ -1,0 +1,19 @@
+
+module Test.GenOrder
+
+#lang-pulse
+open Pulse
+
+assume val foo : int -> int -> slprop
+
+fn flip ()
+  requires foo 'x 'y
+  ensures  foo 'y 'x
+{ admit(); }
+
+fn test ()
+  requires foo 1 2
+  ensures  foo 2 1
+{
+  flip () #1 #2;
+}

--- a/src/ocaml/plugin/generated/PulseSyntaxExtension_Env.ml
+++ b/src/ocaml/plugin/generated/PulseSyntaxExtension_Env.ml
@@ -262,7 +262,7 @@ let (free_vars_comp :
               c.PulseSyntaxExtension_Sugar.postcondition in
           FStar_List_Tot_Base.op_At uu___2 uu___3 in
         FStar_List_Tot_Base.op_At uu___ uu___1 in
-      FStar_Compiler_List.deduplicate FStar_Ident.ident_equals ids
+      FStar_Class_Ord.dedup FStar_Syntax_Syntax.ord_ident ids
 let (pat_vars :
   FStar_Parser_AST.pattern ->
     FStar_Ident.ident Prims.list PulseSyntaxExtension_Err.err)

--- a/src/syntax_extension/PulseSyntaxExtension.Env.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.Env.fst
@@ -154,7 +154,14 @@ let free_vars_comp (env:env_t) (c:Sugar.computation_type)
         free_vars_term env c.return_type @
         free_vars_slprop (fst (push_bv env c.return_name)) c.postcondition
     in
-    L.deduplicate Ident.ident_equals ids
+    (* NOTE: We use this particular dedup function since it favors
+    occurrences on the left, so `dedup [1;2;1]` is `[1;2]`  instaed of `[2;1]`.
+    This is important for something like
+      requires foo 'x 'y
+      ensures  bar 'x
+    which elaborates to implicit arguments for `x` and `y`, and they should
+    be in that order, i.e. textual order. *)
+    FStar.Class.Ord.dedup ids
 
 let pat_vars (p:A.pattern)
   : err (list ident)


### PR DESCRIPTION
Arguments for ticked variables were not necessarily in textual order, due to the deduplication being right-biased. This PR fixes it so
```
fn flip ()
  requires foo 'x 'y
  ensures  foo 'y 'x
{ admit(); }

fn test ()
  requires foo 1 2
  ensures  foo 2 1
{
  flip () #1 #2;
}
```
now works, since the arguments are `(#x #y : _)` instead of `(#y #x : _)`.