### PR TITLE
Making `pts_to` a method

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.AVLTree.fst
+++ b/lib/pulse/lib/Pulse.Lib.AVLTree.fst
@@ -97,7 +97,7 @@ ensures
 }
 
 
-let is_tree_cases #t x ft
+let is_tree_cases #t (x : option (ref (node t))) ft
 = match x with
   | None -> pure (ft == T.Leaf)
   | Some v -> 

--- a/lib/pulse/lib/Pulse.Lib.Array.Core.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Array.Core.fsti
@@ -17,6 +17,7 @@
 module Pulse.Lib.Array.Core
 open FStar.Tactics.V2
 open Pulse.Lib.Core
+open Pulse.Class.PtsTo
 open PulseCore.FractionalPermission
 open FStar.Ghost
 module SZ = FStar.SizeT
@@ -34,6 +35,16 @@ type larray t (n:nat) = a:array t { length a == n }
 val is_full_array (#a:Type u#0) (x:array a) : prop
 
 val pts_to (#a:Type u#0) (x:array a) (#[exact (`1.0R)] p:perm) (s: Seq.seq a) : slprop
+
+[@@pulse_unfold]
+instance has_pts_to_array (a:Type u#0) : has_pts_to (array a) (Seq.seq a) = {
+  pts_to = pts_to;
+}
+[@@pulse_unfold]
+instance has_pts_to_larray (a:Type u#0) (n : nat) : has_pts_to (larray a n) (Seq.seq a) = {
+  pts_to = pts_to;
+}
+
 
 val pts_to_is_slprop2 (#a:Type) (x:array a) (p:perm) (s:Seq.seq a)
   : Lemma (is_slprop2 (pts_to x #p s))

--- a/lib/pulse/lib/Pulse.Lib.Array.fst
+++ b/lib/pulse/lib/Pulse.Lib.Array.fst
@@ -20,6 +20,7 @@ module PM = Pulse.Main
 open Pulse.Lib.Core
 open Pulse.Lib.Reference
 open Pulse.Lib.Array.Core
+open Pulse.Class.PtsTo
 open FStar.Ghost
 module US = FStar.SizeT
 module U8 = FStar.UInt8
@@ -47,9 +48,9 @@ fn compare (#t:eqtype) (l:US.t) (a1 a2:larray t (US.v l)) (#p1 #p2:perm)
       (v1 = v2) } 
     else { false } )
   invariant b. exists* (vi:US.t). ( 
-    R.pts_to i vi **
-    A.pts_to a1 #p1 's1 **
-    A.pts_to a2 #p2 's2 **
+    pts_to i vi **
+    pts_to a1 #p1 's1 **
+    pts_to a2 #p2 's2 **
     pure (vi <= l
        /\ (b == (vi < l && Seq.index 's1 (US.v vi) = Seq.index 's2 (US.v vi)))
        /\ (forall (i:nat). i < US.v vi ==> Seq.index 's1 i == Seq.index 's2 i)))
@@ -62,15 +63,13 @@ fn compare (#t:eqtype) (l:US.t) (a1 a2:larray t (US.v l)) (#p1 #p2:perm)
   res
 }
 
-
- 
 fn memcpy_l (#t:eqtype) (l:US.t) (src dst:(a:array t { US.v l <= A.length a }))
            (#p:perm) (#src0 #dst0:Ghost.erased (Seq.seq t))
-  requires A.pts_to src #p src0 **
-           A.pts_to dst dst0
+  requires pts_to src #p src0 **
+           pts_to dst dst0
   returns _:squash (Seq.length src0 == A.length src /\ Seq.length dst0 == A.length dst)
-  ensures A.pts_to src #p src0 **
-          A.pts_to dst (Seq.append (Seq.slice src0 0 (US.v l))
+  ensures pts_to src #p src0 **
+          pts_to dst (Seq.append (Seq.slice src0 0 (US.v l))
                                    (Seq.slice dst0 (US.v l) (A.length dst)))
 {
   pts_to_len src #p #src0;
@@ -78,9 +77,9 @@ fn memcpy_l (#t:eqtype) (l:US.t) (src dst:(a:array t { US.v l <= A.length a }))
   let mut i = 0sz;
   while (let vi = !i; (vi < l) )
   invariant b. exists* (vi:US.t) (s:Seq.seq t). ( 
-    R.pts_to i vi **
-    A.pts_to src #p src0 **
-    A.pts_to dst s **
+    pts_to i vi **
+    pts_to src #p src0 **
+    pts_to dst s **
     pure (vi <= l
        /\ Seq.length s == Seq.length dst0
        /\ (b == (vi < l))
@@ -90,11 +89,11 @@ fn memcpy_l (#t:eqtype) (l:US.t) (src dst:(a:array t { US.v l <= A.length a }))
   {
     let vi = !i;
     let x = src.(vi);
-    with s. assert (A.pts_to dst s);
+    with s. assert (pts_to dst s);
     (dst.(vi) <- x);
     i := vi + 1sz;
   };
-  with s. assert (A.pts_to dst s);
+  with s. assert (pts_to dst s);
   assert_ (pure (Seq.equal s (Seq.append (Seq.slice src0 0 (US.v l))
                                          (Seq.slice dst0 (US.v l) (A.length dst)))));
   ()
@@ -114,7 +113,7 @@ fn memcpy
           pts_to dst src0
 {
   memcpy_l l src dst;
-  with s. assert (A.pts_to dst s);
+  with s. assert (pts_to dst s);
   assert_ (pure (Seq.equal s src0));
   ()
 }
@@ -122,17 +121,17 @@ fn memcpy
 
 
 fn fill (#t:Type0) (l:US.t) (a:larray t (US.v l)) (v:t)
-  requires A.pts_to a 's
+  requires pts_to a 's
   ensures exists* (s:Seq.seq t).
-    A.pts_to a s **
+    pts_to a s **
     pure (s `Seq.equal` Seq.create (US.v l) v)
 {
   pts_to_len a #1.0R #'s;
   let mut i = 0sz;
   while (let vi = !i; (vi < l))
   invariant b. exists* (vi:US.t) (s:Seq.seq t). ( 
-    R.pts_to i vi **
-    A.pts_to a s **
+    pts_to i vi **
+    pts_to a s **
     pure (vi <= l
         /\ Seq.length s == US.v l
         /\ (b == (vi < l))
@@ -147,9 +146,9 @@ fn fill (#t:Type0) (l:US.t) (a:larray t (US.v l)) (v:t)
 
 
 fn zeroize (l:US.t) (a:larray U8.t (US.v l))
-  requires A.pts_to a 's
+  requires pts_to a 's
   ensures exists* (s:Seq.seq U8.t).
-    A.pts_to a s **
+    pts_to a s **
     pure (s `Seq.equal` Seq.create (US.v l) 0uy)
 {
   pts_to_len a #1.0R #'s;

--- a/lib/pulse/lib/Pulse.Lib.Array.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Array.fsti
@@ -23,6 +23,7 @@ include Pulse.Lib.Array.Core
 module SZ = FStar.SizeT
 module Seq = FStar.Seq
 module U8 = FStar.UInt8
+open Pulse.Class.PtsTo
 
 val compare
         (#t:eqtype)

--- a/lib/pulse/lib/Pulse.Lib.ArraySwap.fst
+++ b/lib/pulse/lib/Pulse.Lib.ArraySwap.fst
@@ -126,7 +126,7 @@ fn array_swap_aux(#t: Type0) (a: A.array t) (lb: SZ.t) (rb: SZ.t) (mb: (mb: SZ.t
     while (let i = !pi; ((i `SZ.sub` lb) `size_lt` d))
     invariant b . exists* s i . (
       A.pts_to_range a (Ghost.reveal (SZ.v lb)) (Ghost.reveal (SZ.v rb)) s **
-      R.pts_to pi i **
+      pts_to pi i **
       pure (
         SZ.v i >= SZ.v lb /\
         SZ.v i < SZ.v rb /\
@@ -140,9 +140,9 @@ fn array_swap_aux(#t: Type0) (a: A.array t) (lb: SZ.t) (rb: SZ.t) (mb: (mb: SZ.t
       while (let j = !pj; (j `size_lt` (size_sub q 1sz ())))
       invariant b . exists* s j idx . (
         A.pts_to_range a (Ghost.reveal (SZ.v lb)) (Ghost.reveal (SZ.v rb)) s **
-        R.pts_to pi i **
-        R.pts_to pj j **
-        R.pts_to pidx idx **
+        pts_to pi i **
+        pts_to pj j **
+        pts_to pidx idx **
         pure (
           SZ.v idx >= SZ.v lb /\
           SZ.v idx < SZ.v rb /\

--- a/lib/pulse/lib/Pulse.Lib.Box.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Box.fsti
@@ -20,6 +20,7 @@ open FStar.Ghost
 open PulseCore.FractionalPermission
 
 open Pulse.Lib.Core
+open Pulse.Class.PtsTo
 
 module U32 = FStar.UInt32
 module T = FStar.Tactics.V2
@@ -33,6 +34,11 @@ val pts_to (#a:Type0)
            ([@@@equate_strict] b:box a)
            (#[T.exact (`1.0R)] p:perm)
            (v:a) : slprop
+
+[@@pulse_unfold]
+instance has_pts_to_box (a:Type u#0) : has_pts_to (box a) a = {
+  pts_to = pts_to;
+}
 
 val pts_to_is_slprop2 (#a:Type) (r:box a) (p:perm) (x:a)
   : Lemma (is_slprop2 (pts_to r #p x))

--- a/lib/pulse/lib/Pulse.Lib.CancellableInvariant.fst
+++ b/lib/pulse/lib/Pulse.Lib.CancellableInvariant.fst
@@ -31,14 +31,14 @@ instance non_informative_cinv = {
 }
 
 let cinv_vp_aux (r:GR.ref bool) (v:slprop) : (w:slprop { is_storable v ==> is_storable w }) =
-  exists* (b:bool). GR.pts_to r #0.5R b **
+  exists* (b:bool). pts_to r #0.5R b **
                     (if b then v else emp)
 
 let cinv_vp c v = cinv_vp_aux c.r v
 
 let is_storable_cinv_vp _ _ = ()
 
-let active c p = GR.pts_to c.r #(p /. 2.0R) true
+let active c p = pts_to c.r #(p /. 2.0R) true
 
 let active_is_slprop2 p c = ()
 
@@ -59,12 +59,12 @@ fn new_cancellable_invariant (v:slprop { is_storable v })
   let i = new_invariant (cinv_vp_aux r v);
   let c = {i;r};
   rewrite (inv i (cinv_vp_aux r v)) as (inv (iname_of c) (cinv_vp c v));
-  with _p _v. rewrite (GR.pts_to r #_p _v) as (active c 1.0R);
+  with _p _v. rewrite (pts_to r #_p _v) as (active c 1.0R);
   c
 }
 
 
-let unpacked c _v = GR.pts_to c.r #0.5R true
+let unpacked c _v = pts_to c.r #0.5R true
 
 
 
@@ -148,7 +148,7 @@ opens []
   GR.share2 c.r;
   fold (cinv_vp_aux c.r v);
   fold (cinv_vp c v);
-  drop_ (GR.pts_to c.r #0.5R _)
+  drop_ (pts_to c.r #0.5R _)
 }
 
 

--- a/lib/pulse/lib/Pulse.Lib.ConditionVarWithCodes.fst
+++ b/lib/pulse/lib/Pulse.Lib.ConditionVarWithCodes.fst
@@ -76,8 +76,8 @@ let map_invariant #c (v:U32.t) (m:carrier c) (n:nat) (p:slprop)
 let cvar_inv #c (b: cvar_t_core c) (p:slprop)
 : slprop3
 = exists* v n m.
-    Box.pts_to b.r #0.5R v **
-    GR.pts_to #nat b.ctr n **
+    pts_to b.r #0.5R v **
+    pts_to b.ctr n **
     big_ghost_pcm_pts_to b.gref m **
     big_ghost_pcm_pts_to b.gref (empty_map_below n) **
     map_invariant v m n p
@@ -91,7 +91,7 @@ let inv_name #c (b:cvar_t c) = b.i
 let send #c (b: cvar_t c) (p:slprop)
 : slprop
 = cvar b p **
-  Box.pts_to b.core.r #0.5R 0ul
+  pts_to b.core.r #0.5R 0ul
 
 let singleton #c (i:nat) (#p:perm) (code:c.t)
 : carrier c
@@ -234,8 +234,8 @@ ghost
 fn fold_cvar_inv #c (b: cvar_t_core c) (p:slprop)
                     (v n m:_)
 requires
-    Box.pts_to b.r #0.5R v **
-    GR.pts_to #nat b.ctr n **
+    pts_to b.r #0.5R v **
+    pts_to b.ctr n **
     big_ghost_pcm_pts_to b.gref m **
     big_ghost_pcm_pts_to b.gref (empty_map_below n) **
     map_invariant v m n p
@@ -320,7 +320,7 @@ ensures emp
     Box.gather b.core.r;
     write_atomic_box b.core.r 1ul;
     Box.share b.core.r;
-    drop_ (Box.pts_to b.core.r #0.5R 1ul);
+    drop_ (pts_to b.core.r #0.5R 1ul);
     flip_map_invariant #c _ _ _ _;
     fold (cvar_inv b.core p);
   };
@@ -605,7 +605,7 @@ ensures
 ghost
 fn alloc #c (#b:cvar_t_core c) (#n:nat) (q:c.t)
 requires big_ghost_pcm_pts_to b.gref (empty_map_below n) **
-         GR.pts_to b.ctr n
+         pts_to b.ctr n
 ensures  GR.pts_to b.ctr (n + 1) **
          big_ghost_pcm_pts_to b.gref (empty_map_below (n + 1)) **
          big_ghost_pcm_pts_to b.gref (singleton n #0.5R q) **
@@ -796,7 +796,7 @@ ensures cvinv cv p ** cvinv cv p
 
 
 let send_core #c (cv:cvar_t c) : slprop3 =
-  Box.pts_to cv.core.r #0.5R 0ul
+  pts_to cv.core.r #0.5R 0ul
 
 
 ghost

--- a/lib/pulse/lib/Pulse.Lib.Deque.fst
+++ b/lib/pulse/lib/Pulse.Lib.Deque.fst
@@ -36,14 +36,14 @@ let rec is_deque_suffix
   = match l with
     | [n] ->
       exists* (v:node t).
-        Box.pts_to p v **
+        pts_to p v **
         pure (v.value == n /\
           v.dnext == last /\
           v.dprev == prev /\
           p == tail)
     | n::ns ->
       exists* (v:node t) (np:node_ptr t).
-        Box.pts_to p v **
+        pts_to p v **
         is_deque_suffix np ns (Some p) tail last **
         pure (v.value == n /\
           v.dprev == prev /\
@@ -61,7 +61,7 @@ fn fold_is_deque_suffix_cons
   (last:option (node_ptr t))
   (v : node t) (np : node_ptr t)
   requires
-    Box.pts_to p v **
+    pts_to p v **
     is_deque_suffix np ns (Some p) tail last **
     pure (v.value == n /\
       v.dprev == prev /\
@@ -281,7 +281,7 @@ let is_deque_suffix_factored
    (last : option (node_ptr t))
 : Tot slprop
   = exists* (v:node t).
-      Box.pts_to x v **
+      pts_to x v **
       pure (
         v.value == List.Tot.hd l /\
         v.dprev == prev
@@ -305,14 +305,14 @@ fn factor_is_deque_suffix
     Nil -> {
       assert (pure (l == [hd]));
       unfold (is_deque_suffix p [hd] prev tail);
-      with v. assert (Box.pts_to p v);
+      with v. assert (pts_to p v);
       fold (is_deque_suffix_factored_next p [hd] tail last v.dnext);
       fold (is_deque_suffix_factored p [hd] prev tail last);
     }
     Cons y ys -> {
       assert (pure (l == hd::y::ys));
       unfold (is_deque_suffix p (hd::y::ys) prev tail);
-      with v. assert (Box.pts_to p v);
+      with v. assert (pts_to p v);
       fold (is_deque_suffix_factored_next p (hd::y::ys) tail last v.dnext);
       fold (is_deque_suffix_factored p (hd::y::ys) prev tail last);
     }
@@ -333,7 +333,7 @@ fn unfactor_is_deque_suffix
      is_deque_suffix p l prev tail last
 {
   unfold (is_deque_suffix_factored p l prev tail last);
-  with v. assert (Box.pts_to p v);
+  with v. assert (pts_to p v);
   unfold (is_deque_suffix_factored_next p l tail last v.dnext);
   let hd : t = List.Tot.hd l;
   let tl : list t = List.Tot.tl l;
@@ -365,7 +365,7 @@ fn set_back_pointer
 {
   factor_is_deque_suffix x l prev tail;
   unfold (is_deque_suffix_factored x l prev tail);
-  with v. assert (Box.pts_to x v);
+  with v. assert (pts_to x v);
   let cv = Box.( !x );
   let cv' = { cv with dprev = prev' };
   Box.( x := cv' );
@@ -589,7 +589,7 @@ fn is_singleton
   factor_is_deque_suffix headp _ _ _;
   unfold is_deque_suffix_factored;
 
-  with v. assert (Box.pts_to headp v);
+  with v. assert (pts_to headp v);
   let vv = Box.( !headp );
   rewrite each v as vv;
 
@@ -663,7 +663,7 @@ fn rec join_last
   (#last : erased (option (node_ptr t)))
   (#v : erased (node t))
   requires is_deque_suffix headp ys prev tailp (Some tailp') **
-           Box.pts_to tailp' v **
+           pts_to tailp' v **
            pure (v.value == y /\ v.dprev == Some (reveal tailp) /\ v.dnext == last)
   ensures  is_deque_suffix headp (snoc ys y) prev tailp' last
   decreases length ys
@@ -772,7 +772,7 @@ fn rec sep_last
   requires is_deque_suffix headp (snoc ys y) prev tailp last
   returns  tailp' : erased (node_ptr t)
   ensures  is_deque_suffix headp ys prev tailp' (Some tailp) **
-           (exists* v. Box.pts_to tailp v
+           (exists* v. pts_to tailp v
                     ** pure (v.value == y /\ v.dprev == Some (reveal tailp') /\ v.dnext == last))
   decreases length ys
 {
@@ -787,7 +787,7 @@ fn rec sep_last
         is_deque_suffix headp [y1; reveal y] prev tailp last;
 
       unfold is_deque_suffix;
-      with v_headp. assert (Box.pts_to headp v_headp);
+      with v_headp. assert (pts_to headp v_headp);
       with np. assert (is_deque_suffix np [reveal y] (Some headp) tailp last);
       unfold is_deque_suffix np [reveal y] (Some headp) tailp last;
 
@@ -807,7 +807,7 @@ fn rec sep_last
 
       unfold (is_deque_suffix headp (y1 :: y2 :: snoc ys' y) prev tailp last);
       
-      with v np. assert (Box.pts_to headp v ** is_deque_suffix np (y2 :: snoc ys' y) (Some headp) tailp last);
+      with v np. assert (pts_to headp v ** is_deque_suffix np (y2 :: snoc ys' y) (Some headp) tailp last);
       rewrite is_deque_suffix np (y2 :: snoc ys' y) (Some headp) tailp last
            as is_deque_suffix np (snoc (y2 :: ys') y) (Some headp) tailp last;
       let tailp' = sep_last np tailp;
@@ -832,7 +832,7 @@ let rec is_deque_suffix_nolast
       pure (p == tail)
     | n::ns ->
       exists* (v:node t) (np:node_ptr t).
-        Box.pts_to p v **
+        pts_to p v **
         is_deque_suffix_nolast np ns (Some p) tail **
         pure (v.value == n /\
           v.dprev == prev /\
@@ -850,8 +850,8 @@ fn rec is_deque_suffix_nolast_helper
   (last' : option (node_ptr t))
   requires is_deque_suffix p l prev tail last
   returns  v : erased (node t)
-  ensures  Box.pts_to tail v **
-           trade (Box.pts_to tail { v with dnext = last' }) (is_deque_suffix p l prev tail last')
+  ensures  pts_to tail v **
+           trade (pts_to tail { v with dnext = last' }) (is_deque_suffix p l prev tail last')
   decreases length l
 {
   let hd = List.Tot.hd l;
@@ -862,11 +862,11 @@ fn rec is_deque_suffix_nolast_helper
     Nil -> {
       unfold is_deque_suffix p [hd] prev tail last;
       rewrite each p as tail;
-      with v. assert (Box.pts_to tail v);
+      with v. assert (pts_to tail v);
       ghost fn pf ()
         requires
           emp **
-          Box.pts_to tail ({ v with dnext = last' })
+          pts_to tail ({ v with dnext = last' })
         ensures
           is_deque_suffix p [hd] prev tail last'
       {
@@ -874,7 +874,7 @@ fn rec is_deque_suffix_nolast_helper
         fold (is_deque_suffix p [hd] prev tail last');
       };
       intro_trade
-        (Box.pts_to tail { v with dnext = last' })
+        (pts_to tail { v with dnext = last' })
         (is_deque_suffix p [hd] prev tail last')
         emp
         pf;
@@ -884,7 +884,7 @@ fn rec is_deque_suffix_nolast_helper
       rewrite each l as (hd :: h2 :: tl2);
       unfold is_deque_suffix p (hd :: h2 :: tl2) prev tail last;
       
-      with vp. assert (Box.pts_to p vp);
+      with vp. assert (pts_to p vp);
       let p' = Some?.v vp.dnext;
       
       let v = is_deque_suffix_nolast_helper p' (h2 :: tl2) (Some p) tail last last';
@@ -892,10 +892,10 @@ fn rec is_deque_suffix_nolast_helper
       ghost fn pf ()
         requires
           (
-            Box.pts_to p vp **
-            trade (Box.pts_to tail { v with dnext = last' }) (is_deque_suffix p' (h2 :: tl2) (Some p) tail last')
+            pts_to p vp **
+            trade (pts_to tail { v with dnext = last' }) (is_deque_suffix p' (h2 :: tl2) (Some p) tail last')
           ) **
-          Box.pts_to tail ({ v with dnext = last' })
+          pts_to tail ({ v with dnext = last' })
         ensures
           is_deque_suffix p (hd :: h2 :: tl2) prev tail last'
       {
@@ -903,11 +903,11 @@ fn rec is_deque_suffix_nolast_helper
         fold (is_deque_suffix p (hd :: h2 :: tl2) prev tail last');
       };
       intro_trade
-        (Box.pts_to tail { v with dnext = last' })
+        (pts_to tail { v with dnext = last' })
         (is_deque_suffix p (hd :: h2 :: tl2) prev tail last')
         (
-          Box.pts_to p vp **
-          trade (Box.pts_to tail { v with dnext = last' }) (is_deque_suffix p' (h2 :: tl2) (Some p) tail last')
+          pts_to p vp **
+          trade (pts_to tail { v with dnext = last' }) (is_deque_suffix p' (h2 :: tl2) (Some p) tail last')
         )
         pf;
 

--- a/lib/pulse/lib/Pulse.Lib.FlippableInv.fst
+++ b/lib/pulse/lib/Pulse.Lib.FlippableInv.fst
@@ -21,7 +21,7 @@ open Pulse.Lib.Pervasives
 module GR = Pulse.Lib.GhostReference
 
 let finv_p (p:slprop { is_storable p }) (r : GR.ref bool) : v:slprop { is_storable v } =
-  exists* (b:bool). GR.pts_to r #0.5R b ** (if b then p else emp)
+  exists* (b:bool). pts_to r #0.5R b ** (if b then p else emp)
 
 noeq
 type finv (p:slprop) = {
@@ -31,9 +31,9 @@ type finv (p:slprop) = {
 }
 
 let off #p (fi : finv p) : slprop =
-  GR.pts_to fi.r #0.5R false ** inv fi.i (finv_p p fi.r)
+  pts_to fi.r #0.5R false ** inv fi.i (finv_p p fi.r)
 let on  #p (fi : finv p) : slprop =
-  GR.pts_to fi.r #0.5R true ** inv fi.i (finv_p p fi.r)
+  pts_to fi.r #0.5R true ** inv fi.i (finv_p p fi.r)
 
 
 fn mk_finv (p:slprop { is_storable p })
@@ -48,8 +48,8 @@ fn mk_finv (p:slprop { is_storable p })
    fold finv_p p r;
    let i = new_invariant (finv_p p r);
    let fi = Mkfinv r i (() <: squash (is_storable p)); // See #121
-   rewrite (GR.pts_to r #0.5R false)
-        as (GR.pts_to fi.r #0.5R false);
+   rewrite (pts_to r #0.5R false)
+        as (pts_to fi.r #0.5R false);
    rewrite (inv i (finv_p p r))
         as (inv fi.i (finv_p p fi.r));
    fold (off #p fi);
@@ -72,7 +72,7 @@ fn flip_on (#p:slprop) (fi:finv p)
   with_invariants fi.i
     returns _:unit
     ensures finv_p p fi.r **
-            GR.pts_to fi.r #0.5R true
+            pts_to fi.r #0.5R true
     opens [fi.i]
   {
     unfold finv_p;
@@ -99,7 +99,7 @@ fn flip_off (#p:slprop) (fi : finv p)
   with_invariants fi.i
     returns _:unit
     ensures finv_p p fi.r **
-            GR.pts_to fi.r #0.5R false ** p
+            pts_to fi.r #0.5R false ** p
     opens [fi.i]
   {
     unfold finv_p;

--- a/lib/pulse/lib/Pulse.Lib.GhostReference.fsti
+++ b/lib/pulse/lib/Pulse.Lib.GhostReference.fsti
@@ -17,6 +17,7 @@
 module Pulse.Lib.GhostReference
 open FStar.Tactics
 open Pulse.Lib.Core
+open Pulse.Class.PtsTo
 open PulseCore.FractionalPermission
 open FStar.Ghost
 
@@ -31,6 +32,11 @@ val pts_to (#a:Type)
            (#[exact (`1.0R)] p:perm)
            (n:a)
 : slprop
+
+[@@pulse_unfold]
+instance has_pts_to_ref (a:Type) : has_pts_to (ref a) a = {
+  pts_to = (fun r #f v -> pts_to r #f v);
+}
 
 val pts_to_is_slprop2 (#a:Type) (r:ref a) (p:perm) (x:a)
   : Lemma (is_slprop2 (pts_to r #p x))

--- a/lib/pulse/lib/Pulse.Lib.HashTable.fst
+++ b/lib/pulse/lib/Pulse.Lib.HashTable.fst
@@ -110,11 +110,11 @@ fn lookup
          let vcont = !cont;
          (voff <=^ ht.sz && vcont = true))
   invariant b. exists* (voff:SZ.t) (vcont :bool) vcontents. (
-    R.pts_to contents vcontents **
+    pts_to contents vcontents **
     V.pts_to vcontents pht.repr.seq **
-    R.pts_to off voff **
-    R.pts_to cont vcont **
-    R.pts_to ret (if vcont then None else (PHT.lookup_index_us pht k)) **
+    pts_to off voff **
+    pts_to cont vcont **
+    pts_to ret (if vcont then None else (PHT.lookup_index_us pht k)) **
     pure (
       SZ.v ht.sz == pht_sz pht /\
       V.is_full_vec vcontents /\
@@ -128,7 +128,7 @@ fn lookup
     if (voff = ht.sz)
     {
       cont := false;
-      assert (R.pts_to ret None);
+      assert (pts_to ret None);
     }
     else
     {
@@ -144,8 +144,8 @@ fn lookup
             cont := false;
             ret := Some idx;
             V.replace_i_ref contents idx (Used k' v');
-            with vcontents. assert (R.pts_to contents vcontents);
-            with s. assert (V.pts_to vcontents s);
+            with vcontents. assert (pts_to contents vcontents);
+            with s. assert (pts_to vcontents s);
             assert (pure (Seq.equal s pht.repr.seq));
             assert (pure (pht.repr @@ SZ.v idx == Used k' v'));
             assert (pure (lookup_repr_index pht.repr k == Some (v', SZ.v idx)));
@@ -153,8 +153,8 @@ fn lookup
           {
             off := voff +^ 1sz;
             V.replace_i_ref contents idx (Used k' v');
-            with vcontents. assert (R.pts_to contents vcontents);
-            with s. assert (V.pts_to vcontents s);
+            with vcontents. assert (pts_to contents vcontents);
+            with s. assert (pts_to vcontents s);
             assert (pure (Seq.equal s pht.repr.seq));
             assert (pure (walk_get_idx pht.repr (SZ.v cidx) k (SZ.v voff)
               == walk_get_idx pht.repr (SZ.v cidx) k (SZ.v (voff+^1sz))));
@@ -164,18 +164,18 @@ fn lookup
         {
           cont := false;
           V.replace_i_ref contents idx c;
-          with vcontents. assert (R.pts_to contents vcontents);
-          with s. assert (V.pts_to vcontents s);
+          with vcontents. assert (pts_to contents vcontents);
+          with s. assert (pts_to vcontents s);
           assert (pure (Seq.equal s pht.repr.seq));
           assert (pure (walk_get_idx pht.repr (SZ.v cidx) k (SZ.v voff) == None));
-          assert (R.pts_to ret (PHT.lookup_index_us pht k));
+          assert (pts_to ret (PHT.lookup_index_us pht k));
         }
         Zombie ->
         {
           off := voff +^ 1sz;
           V.replace_i_ref contents idx c;
-          with vcontents. assert (R.pts_to contents vcontents);
-          with s. assert (V.pts_to vcontents s);
+          with vcontents. assert (pts_to contents vcontents);
+          with s. assert (pts_to vcontents s);
           assert (pure (Seq.equal s pht.repr.seq));
           assert (pure (walk_get_idx pht.repr (SZ.v cidx) k (SZ.v voff)
             == walk_get_idx pht.repr (SZ.v cidx) k (SZ.v (voff+^1sz))));
@@ -187,11 +187,11 @@ fn lookup
 
   let vcontents = !contents;
   let ht = mk_ht ht.sz ht.hashf vcontents;
-  with vcontents_g. assert (R.pts_to contents vcontents_g);
+  with vcontents_g. assert (pts_to contents vcontents_g);
   rewrite (V.pts_to vcontents_g pht.repr.seq) as (V.pts_to ht.contents pht.repr.seq);
   fold (models ht pht);
   let res = ((ht <: ht_t kt vt), o);
-  assert (R.pts_to ret (PHT.lookup_index_us pht k));
+  assert (pts_to ret (PHT.lookup_index_us pht k));
   rewrite (models ht pht) as (models (fst res) pht);
   res
 }
@@ -217,7 +217,7 @@ fn replace
   let hashf = ht.hashf;
   let mut contents = ht.contents;
   unfold models;
-  rewrite (R.pts_to contents ht.contents) as (R.pts_to contents (reveal (hide ht.contents)));
+  rewrite (pts_to contents ht.contents) as (pts_to contents (reveal (hide ht.contents)));
   rewrite (V.pts_to ht.contents pht.repr.seq) as (V.pts_to (reveal (hide ht.contents)) pht.repr.seq);
   let v' = V.replace_i_ref contents idx (mk_used_cell k v);
   let vcontents = !contents;
@@ -275,10 +275,10 @@ fn insert
     (vcont = true)
   )
   invariant b. exists* (voff:SZ.t) (vcont :bool) (vcontents:V.vec _) vidx s. (
-    R.pts_to off voff **
-    R.pts_to cont vcont **
-    R.pts_to idx vidx **
-    R.pts_to contents vcontents **
+    pts_to off voff **
+    pts_to cont vcont **
+    pts_to idx vidx **
+    pts_to contents vcontents **
     V.pts_to vcontents s **
     pure (
       related ht pht /\
@@ -315,8 +315,8 @@ fn insert
         Used k' v' -> {
           if (k' = k) {
             V.write_ref contents vidx (Used k' v');
-            with vcontents. assert (R.pts_to contents vcontents);
-            with s. assert (V.pts_to vcontents s);
+            with vcontents. assert (pts_to contents vcontents);
+            with s. assert (pts_to vcontents s);
             assert (pure (Seq.equal s pht.repr.seq));
             cont := false;
             idx := vidx;
@@ -324,16 +324,16 @@ fn insert
                           Seq.upd pht.repr.seq (SZ.v vidx) (mk_used_cell k v)));
           } else {
             V.write_ref contents vidx (Used k' v');
-            with vcontents. assert (R.pts_to contents vcontents);
-            with s. assert (V.pts_to vcontents s);
+            with vcontents. assert (pts_to contents vcontents);
+            with s. assert (pts_to vcontents s);
             assert (pure (Seq.equal s pht.repr.seq));
             off := SZ.(voff +^ 1sz);
           };
         }
         Clean -> {
           V.write_ref contents vidx Clean;
-          with vcontents. assert (R.pts_to contents vcontents);
-          with s. assert (V.pts_to vcontents s);
+          with vcontents. assert (pts_to contents vcontents);
+          with s. assert (pts_to vcontents s);
           assert (pure (Seq.equal s pht.repr.seq));
           cont := false;
           idx := vidx;
@@ -342,8 +342,8 @@ fn insert
         }
         Zombie ->
         {
-          with vcontents_g. assert (R.pts_to contents vcontents_g);
-          with s. assert (V.pts_to vcontents_g s);
+          with vcontents_g. assert (pts_to contents vcontents_g);
+          with s. assert (pts_to vcontents_g s);
           assert (pure (Seq.equal s pht.repr.seq));
           let vcontents = !contents;
           let ht = { sz = ht.sz; hashf = hashf; contents = vcontents;};
@@ -392,7 +392,7 @@ fn insert
     V.write_ref contents vidx (mk_used_cell k v);
     let vcontents = !contents;
     let ht = mk_ht ht.sz hashf vcontents;
-    with vcontents. assert (R.pts_to contents vcontents);
+    with vcontents. assert (pts_to contents vcontents);
     with s. assert (V.pts_to vcontents s);
     assert (pure (Seq.equal s (PHT.insert pht k v).repr.seq));
     rewrite (V.pts_to vcontents s) as (V.pts_to ht.contents s);
@@ -404,7 +404,7 @@ fn insert
     let vcontents = !contents;
     let ht = mk_ht ht.sz hashf vcontents;
     let res = ((ht <: ht_t kt vt), false);
-    with vcontents. assert (R.pts_to contents vcontents);
+    with vcontents. assert (pts_to contents vcontents);
     with s. assert (V.pts_to vcontents s);
     rewrite (V.pts_to vcontents s) as (V.pts_to ht.contents s);
     fold (models ht pht);
@@ -449,7 +449,7 @@ fn not_full
       let c = V.replace_i_ref contents vi Zombie;
       let b = is_used c;
       V.replace_i_ref contents vi (snd b);
-      with vcontents. assert (R.pts_to contents vcontents);
+      with vcontents. assert (pts_to contents vcontents);
       with s. assert (V.pts_to vcontents s);
       assert (pure (Seq.equal s pht.repr.seq));
       (fst b)
@@ -460,9 +460,9 @@ fn not_full
     }
   )
   invariant b. exists* (vi:SZ.t) vcontents. (
-    R.pts_to contents vcontents **
+    pts_to contents vcontents **
     V.pts_to vcontents pht.repr.seq **
-    R.pts_to i vi **
+    pts_to i vi **
     pure (
       V.is_full_vec vcontents /\
       SZ.v ht.sz == pht_sz pht /\
@@ -481,7 +481,7 @@ fn not_full
 
   let vcontents = !contents;
   let ht = mk_ht ht.sz hashf vcontents;
-  with vcontentsg. assert (R.pts_to contents vcontentsg);
+  with vcontentsg. assert (pts_to contents vcontentsg);
   with s. rewrite (V.pts_to vcontentsg s) as (V.pts_to ht.contents s);
   fold (models ht pht);
   let b = ((ht <: ht_t kt vt), (res <: bool));
@@ -553,10 +553,10 @@ fn delete
     (vcont = true && verr = false)
   )
   invariant b. exists* (voff:SZ.t) (vcont verr:bool) (contents_v:V.vec _). (
-    R.pts_to off voff **
-    R.pts_to cont vcont **
-    R.pts_to err verr **
-    R.pts_to contents contents_v **
+    pts_to off voff **
+    pts_to cont vcont **
+    pts_to err verr **
+    pts_to contents contents_v **
     V.pts_to contents_v (if (vcont || verr) then pht.repr.seq else (PHT.delete pht k).repr.seq) **
     pure (
       V.is_full_vec contents_v /\
@@ -569,7 +569,7 @@ fn delete
       b == (vcont = true && verr = false)
     ))
   {
-    with vcont. assert (R.pts_to cont vcont);
+    with vcont. assert (pts_to cont vcont);
     let voff = !off;
     if (voff = ht.sz)
     {
@@ -612,7 +612,7 @@ fn delete
     }
   };
 
-  with contents_v_g. assert (R.pts_to contents contents_v_g);
+  with contents_v_g. assert (pts_to contents contents_v_g);
   let contents_v = !contents;
   let ht = mk_ht ht.sz hashf contents_v;
   with s. rewrite (V.pts_to contents_v_g s) as (V.pts_to ht.contents s);

--- a/lib/pulse/lib/Pulse.Lib.HigherArray.fsti
+++ b/lib/pulse/lib/Pulse.Lib.HigherArray.fsti
@@ -17,6 +17,7 @@
 module Pulse.Lib.HigherArray
 open FStar.Tactics.V2
 open Pulse.Lib.Core
+open Pulse.Class.PtsTo
 open PulseCore.FractionalPermission
 open FStar.Ghost
 module SZ = FStar.SizeT
@@ -33,6 +34,15 @@ type larray t (n:nat) = a:array t { length a == n }
 val is_full_array (#a:Type) (x:array a) : prop
 
 val pts_to (#a:Type) (x:array a) (#[exact (`1.0R)] p:perm) (s: Seq.seq a) : slprop
+
+[@@pulse_unfold]
+instance has_pts_to_array (a:Type u#1) : has_pts_to (array a) (Seq.seq a) = {
+  pts_to = pts_to;
+}
+[@@pulse_unfold]
+instance has_pts_to_larray (a:Type u#1) (n : nat) : has_pts_to (larray a n) (Seq.seq a) = {
+  pts_to = pts_to;
+}
 
 val pts_to_is_slprop2 (#a:Type) (x:array a) (p:perm) (s:Seq.seq a)
   : Lemma (is_slprop2 (pts_to x #p s))

--- a/lib/pulse/lib/Pulse.Lib.HigherReference.fsti
+++ b/lib/pulse/lib/Pulse.Lib.HigherReference.fsti
@@ -18,11 +18,17 @@ module Pulse.Lib.HigherReference
 open Pulse.Lib.Core
 open PulseCore.FractionalPermission
 open FStar.Ghost
+open Pulse.Class.PtsTo
 module U32 = FStar.UInt32
 module T = FStar.Tactics
 val ref ([@@@unused]a:Type u#1) : Type u#0
 
 val pts_to (#a:Type) (r:ref a) (#[T.exact (`1.0R)] p:perm) (n:a) : slprop
+
+[@@pulse_unfold]
+instance has_pts_to_ref (a:Type) : has_pts_to (ref a) a = {
+  pts_to = (fun r #f v -> pts_to r #f v);
+}
 
 val pts_to_is_slprop2 (#a:Type) (r:ref a) (p:perm) (n:a)
   : Lemma (is_slprop2 (pts_to r #p n))

--- a/lib/pulse/lib/Pulse.Lib.Mutex.fst
+++ b/lib/pulse/lib/Pulse.Lib.Mutex.fst
@@ -37,11 +37,11 @@ let mutex_guard a = R.ref a
 
 let lock_inv (#a:Type0) (r:B.box a) (v:a -> slprop)
   : (w:slprop { (forall x. is_storable (v x)) ==> is_storable w }) =
-  exists* x. B.pts_to r x ** v x
+  exists* x. pts_to r x ** v x
 
 let mutex_live #a m #p v = lock_alive m.l #p (lock_inv m.r v)
 
-let pts_to mg #p x = R.pts_to mg #p x
+let pts_to mg #p x = pts_to mg #p x
 
 let op_Bang #a mg #x #p = R.op_Bang #a mg #x #p
 let op_Colon_Equals #a r y #x = R.op_Colon_Equals #a r y #x

--- a/lib/pulse/lib/Pulse.Lib.Mutex.fst
+++ b/lib/pulse/lib/Pulse.Lib.Mutex.fst
@@ -20,6 +20,7 @@ open Pulse.Lib.Core
 
 open Pulse.Lib.Reference
 open Pulse.Lib.SpinLock
+open Pulse.Class.PtsTo
 
 module R = Pulse.Lib.Reference
 module B = Pulse.Lib.Box

--- a/lib/pulse/lib/Pulse.Lib.MutexToken.fst
+++ b/lib/pulse/lib/Pulse.Lib.MutexToken.fst
@@ -27,13 +27,13 @@ module L = Pulse.Lib.SpinLockToken
 noeq
 type mutex (#a:Type0) (p:a -> slprop) = {
   r : B.box a;
-  l : L.lock (exists* v. B.pts_to r v ** p v)
+  l : L.lock (exists* v. pts_to r v ** p v)
 }
 
 let mutex_guard (a:Type0) : Type0 = R.ref a
 
 let pts_to (#a:Type0) (mg:mutex_guard a) (#[T.exact (`1.0R)] p:perm) (x:a) : slprop =
-  R.pts_to mg #p x
+  pts_to mg #p x
 
 let ( ! ) (#a:Type0) (mg:mutex_guard a) (#x:erased a) (#p:perm)
   : stt a

--- a/lib/pulse/lib/Pulse.Lib.Pervasives.fst
+++ b/lib/pulse/lib/Pulse.Lib.Pervasives.fst
@@ -22,6 +22,7 @@ include Pulse.Lib.Forall
 include Pulse.Lib.Array
 include Pulse.Lib.Reference
 include Pulse.Lib.Primitives // TODO: what if we want to support several architectures?
+include Pulse.Class.PtsTo
 include PulseCore.FractionalPermission
 include PulseCore.Observability
 include FStar.Ghost

--- a/lib/pulse/lib/Pulse.Lib.Primitives.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Primitives.fsti
@@ -51,17 +51,17 @@ val cas (r:ref U32.t) (u v:U32.t) (#i:erased U32.t)
 
 val read_atomic_box (r:B.box U32.t) (#n:erased U32.t) (#p:perm)
   : stt_atomic U32.t emp_inames
-    (B.pts_to r #p n)
-    (fun x -> B.pts_to r #p n ** pure (reveal n == x))
+    (pts_to r #p n)
+    (fun x -> pts_to r #p n ** pure (reveal n == x))
 
 val write_atomic_box (r:B.box U32.t) (x:U32.t) (#n:erased U32.t)
   : stt_atomic unit emp_inames
-        (B.pts_to r n) 
-        (fun _ -> B.pts_to r (hide x))
+        (pts_to r n) 
+        (fun _ -> pts_to r (hide x))
 
 val cas_box (r:B.box U32.t) (u v:U32.t) (#i:erased U32.t)
   : stt_atomic bool #Observable emp_inames 
-    (B.pts_to r i)
+    (pts_to r i)
     (fun b ->
-      cond b (B.pts_to r v ** pure (reveal i == u)) 
-             (B.pts_to r i))
+      cond b (pts_to r v ** pure (reveal i == u)) 
+             (pts_to r i))

--- a/lib/pulse/lib/Pulse.Lib.Primitives.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Primitives.fsti
@@ -22,6 +22,7 @@ open PulseCore.FractionalPermission
 open Pulse.Main
 open Pulse.Lib.Reference
 open FStar.Ghost
+open Pulse.Class.PtsTo
 
 module U32 = FStar.UInt32
 module B = Pulse.Lib.Box

--- a/lib/pulse/lib/Pulse.Lib.Reference.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Reference.fsti
@@ -21,6 +21,7 @@ open FStar.Tactics
 open FStar.Ghost
 open Pulse.Main
 open Pulse.Lib.Core
+open Pulse.Class.PtsTo
 open PulseCore.FractionalPermission
 
 val ref ([@@@unused] a:Type u#0) : Type u#0
@@ -31,6 +32,11 @@ val pts_to
     (#[exact (`1.0R)] p:perm)
     (n:a)
   : slprop
+
+[@@pulse_unfold]
+instance has_pts_to_ref (a:Type) : has_pts_to (ref a) a = {
+  pts_to = (fun r #f v -> pts_to r #f v);
+}
 
 val pts_to_is_slprop2 (#a:Type) (r:ref a) (p:perm) (x:a)
   : Lemma (is_slprop2 (pts_to r #p x))

--- a/lib/pulse/lib/Pulse.Lib.SpinLock.fst
+++ b/lib/pulse/lib/Pulse.Lib.SpinLock.fst
@@ -26,8 +26,8 @@ module GR = Pulse.Lib.GhostReference
 module CInv = Pulse.Lib.CancellableInvariant
 
 let lock_inv_aux (r:B.box U32.t) (gr:GR.ref U32.t) (v:slprop) : (w:slprop { is_storable v ==> is_storable w })  =
-  exists* i p. B.pts_to r #1.0R i **
-               GR.pts_to gr #p i **
+  exists* i p. pts_to r #1.0R i **
+               pts_to gr #p i **
                (if i = 0ul then v else emp) **
                pure ((i == 0ul ==> p == 1.0R) /\
                      (i =!= 0ul ==> p == 0.5R)) 
@@ -48,7 +48,7 @@ type lock = {
 let lock_alive l #p v =
   inv (iname_of l.i) (cinv_vp l.i (lock_inv l.r l.gr v)) ** active l.i p
 
-let lock_acquired l = GR.pts_to l.gr #0.5R 1ul
+let lock_acquired l = pts_to l.gr #0.5R 1ul
 
 
 fn new_lock (v:slprop { is_storable v })
@@ -83,11 +83,11 @@ fn rec acquire (#v:slprop) (#p:perm) (l:lock)
       returns b:bool
       ensures cinv_vp l.i (lock_inv l.r l.gr v) **
               active l.i p **
-              (if b then v ** GR.pts_to l.gr #0.5R 1ul else emp) {
+              (if b then v ** pts_to l.gr #0.5R 1ul else emp) {
       unpack_cinv_vp l.i;
       unfold lock_inv;
       unfold lock_inv_aux;
-      with i. assert (B.pts_to l.r i);
+      with i. assert (pts_to l.r i);
       let b = cas_box l.r 0ul 1ul;
       if b {
         elim_cond_true _ _ _;
@@ -99,11 +99,11 @@ fn rec acquire (#v:slprop) (#p:perm) (l:lock)
         pack_cinv_vp l.i;
         assert (cinv_vp l.i (lock_inv l.r l.gr v) **
                 active l.i p **
-                GR.pts_to l.gr #0.5R 1ul **
+                pts_to l.gr #0.5R 1ul **
                 v);
         let b = true;
-        rewrite (v ** GR.pts_to l.gr #0.5R 1ul)
-             as (if b then v ** GR.pts_to l.gr #0.5R 1ul else emp);
+        rewrite (v ** pts_to l.gr #0.5R 1ul)
+             as (if b then v ** pts_to l.gr #0.5R 1ul else emp);
         b
       } else {
         elim_cond_false _ _ _;
@@ -114,7 +114,7 @@ fn rec acquire (#v:slprop) (#p:perm) (l:lock)
                 active l.i p);
         let b = false;
         rewrite emp as
-                (if b then v ** GR.pts_to l.gr #0.5R 1ul else emp);
+                (if b then v ** pts_to l.gr #0.5R 1ul else emp);
         b
       }
     };

--- a/lib/pulse/lib/Pulse.Lib.Vec.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Vec.fsti
@@ -19,6 +19,7 @@ module Pulse.Lib.Vec
 open FStar.Ghost
 open PulseCore.FractionalPermission
 open Pulse.Lib.Core
+open Pulse.Class.PtsTo
 
 module SZ = FStar.SizeT
 module Seq = FStar.Seq
@@ -42,6 +43,11 @@ val pts_to
   (#[T.exact (`1.0R)] p:perm)
   (s:Seq.seq a)
 : slprop
+
+[@@pulse_unfold]
+instance has_pts_to_vec (a:Type u#0) : has_pts_to (vec a) (Seq.seq a) = { pts_to; }
+[@@pulse_unfold]
+instance has_pts_to_lvec (a:Type u#0) (n : nat) : has_pts_to (lvec a n) (Seq.seq a) = { pts_to; }
 
 val pts_to_is_slprop2 (#a:Type0) (v:vec a) (p:perm) (s:Seq.seq a)
   : Lemma (is_slprop2 (pts_to v #p s))

--- a/lib/pulse/lib/class/Pulse.Class.PtsTo.fsti
+++ b/lib/pulse/lib/class/Pulse.Class.PtsTo.fsti
@@ -1,28 +1,24 @@
 module Pulse.Class.PtsTo
 
-open Pulse.Lib.Pervasives
+open Pulse.Lib.Core
+open PulseCore.FractionalPermission
 open FStar.Tactics.V2
-
-(* NOTE: this class is not very useful unless we either inline these methods
-early in the typechecking process, or we make the pulse checker normalize
-(and unfold) the contexts. *)
+open FStar.Ghost
 
 let full_default () : Tac unit = exact (`1.0R)
 
-class pointer (r v : Type) = {
-  pts_to : r -> (#[full_default()] f : perm) -> v -> slprop;
+[@@FStar.Tactics.Typeclasses.fundeps [1]] // The pointer determines the representation
+class has_pts_to (p r : Type) = {
+  [@@@pulse_unfold]
+  pts_to : p -> (#[full_default()] f : perm) -> r -> slprop;
 }
 
-instance pts_to_r (a:Type) : pointer (ref a) a = {
-  pts_to = (fun r v -> Pulse.Lib.Reference.pts_to r v);
-}
+(* Always full permission *)
+[@@pulse_unfold]
+let ( |-> ) #p #r {| has_pts_to p r |} = pts_to #p #r
 
-instance pts_to_gr (a:Type) : pointer (Pulse.Lib.GhostReference.ref a) a = {
-  pts_to = (fun r v -> Pulse.Lib.GhostReference.pts_to r v);
+(* We can always have an erased value. *)
+[@@pulse_unfold]
+instance pts_to_erased (p r : Type) (_ : has_pts_to p r) : has_pts_to p (erased r) = {
+  pts_to = (fun r #f v -> pts_to r #f (reveal v));
 }
-
-instance pts_to_hr (a:Type) : pointer (Pulse.Lib.HigherReference.ref a) a = {
-  pts_to = (fun r v -> Pulse.Lib.HigherReference.pts_to r v);
-}
-
-let ( |-> ) #r #v {| pointer r v |} = pts_to #r #v

--- a/share/pulse/examples/Assert.fst
+++ b/share/pulse/examples/Assert.fst
@@ -17,6 +17,7 @@
 module Assert
 #lang-pulse
 open Pulse.Lib.Pervasives
+module R = Pulse.Lib.Reference
 
 
 fn test_assert (r0 r1: ref nat)
@@ -30,7 +31,7 @@ fn test_assert (r0 r1: ref nat)
         (exists* v1. pts_to r1 #p1 v1)
 {
     //assert_ (pts_to r1 ?p1 ?v1); would be nice to have a version that also binds witnesses
-    assert_ (pts_to r0 #p0 (v0 + 0));
+    assert (R.pts_to r0 #p0 (v0 + 0));
     ()
 }
 

--- a/share/pulse/examples/AuxPredicate.fst
+++ b/share/pulse/examples/AuxPredicate.fst
@@ -28,15 +28,15 @@ module R = Pulse.Lib.Reference
 // writing Pulse syntax for slprops in predicates 
 let my_inv (b:bool) (r:R.ref int) : slprop
   = exists* v.
-      R.pts_to r v ** 
+      pts_to r v ** 
       pure ( (v==0 \/ v == 1) /\ b == (v = 0) )
     
 
 
 
 fn invar_introduces_ghost (r:R.ref int)
-  requires R.pts_to r 0
-  ensures R.pts_to r 1
+  requires pts_to r 0
+  ensures  pts_to r 1
 {
   r := 0;
 
@@ -70,8 +70,8 @@ fn invar_introduces_ghost (r:R.ref int)
 [@@expect_failure]
 
 fn invar_introduces_orig (r:R.ref int)
-  requires R.pts_to r 0
-  ensures R.pts_to r 1
+  requires pts_to r 0
+  ensures pts_to r 1
 {
   r := 0;
 
@@ -92,15 +92,15 @@ fn invar_introduces_orig (r:R.ref int)
 // it just works without further ado
 
 fn invar_introduces_ghost_alt (r:R.ref int)
-  requires R.pts_to r 0
-  ensures R.pts_to r 1
+  requires pts_to r 0
+  ensures pts_to r 1
 {
   r := 0;
 
   while (let vr = !r; (vr = 0))
   invariant b. 
     exists* v.
-      R.pts_to r v **
+      pts_to r v **
       pure ( (v==0 \/ v == 1) /\ b == (v = 0) )
   {
     r := 1;
@@ -112,8 +112,8 @@ fn invar_introduces_ghost_alt (r:R.ref int)
 
 
 fn exists_introduces_ghost (r:R.ref int)
-  requires R.pts_to r 0
-  ensures exists* v. R.pts_to r v ** pure (v == 0 \/ v == 1)
+  requires pts_to r 0
+  ensures exists* v. pts_to r v ** pure (v == 0 \/ v == 1)
 {
   r := 0;
 
@@ -128,8 +128,8 @@ fn exists_introduces_ghost (r:R.ref int)
 
 
 fn with_assert_OK (r:R.ref int)
-  requires R.pts_to r 0
-  ensures R.pts_to r 0
+  requires pts_to r 0
+  ensures pts_to r 0
 {
   r := 0;
 

--- a/share/pulse/examples/Demo.MultiplyByRepeatedAddition.fst
+++ b/share/pulse/examples/Demo.MultiplyByRepeatedAddition.fst
@@ -64,7 +64,7 @@ fn mult32 (x y:U32.t)
     let mut acc = 0ul;
     while ((ctr < x))
     invariant b.
-    exists* c a.
+    exists* c (a : UInt32.t). // FIXME: this type should have been instantiate by fundeps?
         pts_to ctr c **
         pts_to acc a **
         pure (c <= x /\

--- a/share/pulse/examples/ExistsWitness.fst
+++ b/share/pulse/examples/ExistsWitness.fst
@@ -24,9 +24,9 @@ module R = Pulse.Lib.Reference
 
 
 fn get_witness (x:R.ref int) (#p:perm) (#y:Ghost.erased int)
-requires R.pts_to x #p y
+requires pts_to x #p y
 returns z:Ghost.erased int
-ensures R.pts_to x #p y ** pure (y==z)
+ensures pts_to x #p y ** pure (y==z)
 {   
     y
 }
@@ -36,8 +36,8 @@ let assume_squash (p:prop) : squash p = assume p
 
 
 fn sample (x:R.ref int)
-requires exists* p y. R.pts_to x #p y
-ensures exists* p y. R.pts_to x #p y ** pure (y == 17)
+requires exists* p y. pts_to x #p y
+ensures exists* p y. pts_to x #p y ** pure (y == 17)
 {
     let y' = get_witness x;
     assume_squash (y'==17);
@@ -47,8 +47,8 @@ ensures exists* p y. R.pts_to x #p y ** pure (y == 17)
 
 
 fn sample_ (x:R.ref int) (#p:perm)
-requires exists* y. R.pts_to x #p y
-ensures exists* y. R.pts_to x #p y ** pure (y == 17)
+requires exists* y. pts_to x #p y
+ensures exists* y. pts_to x #p y ** pure (y == 17)
 {
     let y = get_witness x;
     assume_squash (y==17);
@@ -58,11 +58,11 @@ ensures exists* y. R.pts_to x #p y ** pure (y == 17)
 
 
 fn sample2 (x:R.ref int) (#p:perm)
-requires exists* y. R.pts_to x #p y
-ensures exists* y. R.pts_to x #p y ** pure (y == 17)
+requires exists* y. pts_to x #p y
+ensures exists* y. pts_to x #p y ** pure (y == 17)
 {
     with (y:erased _).
-    assert (R.pts_to x #p y);
+    assert (pts_to x #p y);
     assume_squash (y==17);
     ()
 }
@@ -72,55 +72,55 @@ assume val drop (p:slprop) : stt unit p (fun _ -> emp)
 
 
 fn sample3 (x0:R.ref int) (x1:R.ref bool) (#p0 #p1:perm)
-requires exists* v0 v1. R.pts_to x0 #p0 v0 ** R.pts_to x1 #p1 v1
+requires exists* v0 v1. pts_to x0 #p0 v0 ** pts_to x1 #p1 v1
 ensures emp
 {
     
     with (v0 v1:erased _).
-    assert (R.pts_to x0 #p0 v0 ** R.pts_to x1 #p1 v1);
-    drop (R.pts_to x0 #p0 v0);
-    drop (R.pts_to x1 #p1 v1)
+    assert (pts_to x0 #p0 v0 ** pts_to x1 #p1 v1);
+    drop (pts_to x0 #p0 v0);
+    drop (pts_to x1 #p1 v1)
 }
 
 
 
 fn sample4 (x0:R.ref int) (x1:R.ref bool) (#p0 #p1:perm)
-requires exists* v0 v1. R.pts_to x0 #p0 v0 ** R.pts_to x1 #p1 v1
+requires exists* v0 v1. pts_to x0 #p0 v0 ** pts_to x1 #p1 v1
 ensures emp
 {
     
     with v0 v1.
-    assert R.pts_to x0 #p0 v0 ** R.pts_to x1 #p1 v1;
-    drop (R.pts_to x0 #p0 v0);
-    drop (R.pts_to x1 #p1 v1)
+    assert pts_to x0 #p0 v0 ** pts_to x1 #p1 v1;
+    drop (pts_to x0 #p0 v0);
+    drop (pts_to x1 #p1 v1)
 }
 
 
 
 fn sample5 (x0:R.ref int) (x1:R.ref bool) (#p0 #p1:perm)
-requires exists* v0 v1. R.pts_to x0 #p0 v0 ** R.pts_to x1 #p1 v1
+requires exists* v0 v1. pts_to x0 #p0 v0 ** pts_to x1 #p1 v1
 ensures emp
 {
     
     with v0.
-    assert R.pts_to x0 #p0 v0;
+    assert pts_to x0 #p0 v0;
     with v1.
-    assert R.pts_to x1 #p1 v1;
-    drop (R.pts_to x0 #p0 v0);
-    drop (R.pts_to x1 #p1 v1)
+    assert pts_to x1 #p1 v1;
+    drop (pts_to x0 #p0 v0);
+    drop (pts_to x1 #p1 v1)
 }
 
 
 
 fn sample6 (x0:R.ref int) (x1:R.ref bool)
-requires exists* p0 p1 v0 v1. R.pts_to x0 #p0 v0 ** R.pts_to x1 #p1 v1
+requires exists* p0 p1 v0 v1. pts_to x0 #p0 v0 ** pts_to x1 #p1 v1
 ensures emp
 {
     
     with p0 p1 v0 v1.
-    assert R.pts_to x0 #p0 v0 ** R.pts_to x1 #p1 v1;
-    drop (R.pts_to x0 #p0 v0);
-    drop (R.pts_to x1 #p1 v1)
+    assert pts_to x0 #p0 v0 ** pts_to x1 #p1 v1;
+    drop (pts_to x0 #p0 v0);
+    drop (pts_to x1 #p1 v1)
 }
 
 
@@ -128,12 +128,12 @@ ensures emp
 //existential in the environment, you can just bind its witnesses as below
 
 fn sample7 (x0:R.ref int) (x1:R.ref bool)
-requires exists* p0 p1 v0 v1. R.pts_to x0 #p0 v0 ** R.pts_to x1 #p1 v1
+requires exists* p0 p1 v0 v1. pts_to x0 #p0 v0 ** pts_to x1 #p1 v1
 ensures emp
 {
     
     with p0 p1 v0 v1. _;
-    drop (R.pts_to x0 #p0 v0);
-    drop (R.pts_to x1 #p1 v1)
+    drop (pts_to x0 #p0 v0);
+    drop (pts_to x1 #p1 v1)
 }
 

--- a/share/pulse/examples/ExtractionTest.fst
+++ b/share/pulse/examples/ExtractionTest.fst
@@ -89,8 +89,8 @@ module A = Pulse.Lib.Array
 
 
 fn fill_array (x:array U32.t) (n:SZ.t) (v:U32.t)
-  requires A.pts_to x 's ** pure (A.length x == SZ.v n)
-  ensures exists* s. A.pts_to x s ** pure (Seq.equal s (Seq.create (SZ.v n) v))
+  requires pts_to x 's ** pure (A.length x == SZ.v n)
+  ensures exists* s. pts_to x s ** pure (Seq.equal s (Seq.create (SZ.v n) v))
 {
   A.pts_to_len x;
   let mut i : SZ.t = 0sz;
@@ -98,7 +98,7 @@ fn fill_array (x:array U32.t) (n:SZ.t) (v:U32.t)
   invariant b.
     exists* (vi:SZ.t) (s:Seq.seq U32.t).
       pts_to i vi **
-      A.pts_to x s **
+      pts_to x s **
       pure (SZ.(vi <=^ n) /\
             Seq.length s == Seq.length 's /\
             (forall (j:nat). j < SZ.v vi ==> Seq.index s j == v) /\

--- a/share/pulse/examples/Fibo32.fst
+++ b/share/pulse/examples/Fibo32.fst
@@ -20,6 +20,8 @@ open Pulse.Lib.Pervasives
 module U32 = FStar.UInt32
 #push-options "--fuel 2 --ifuel 2"
 
+module R = Pulse.Lib.Reference
+
 
 let rec fib (n:nat) : nat =
   if n <= 1 then 1
@@ -44,7 +46,7 @@ fn fibo32 (k:U32.t) (_:squash(0ul < k /\ fits #U32.t (fib (v k))))
   let mut j = 1ul;
   let mut ctr = 1ul;
   while (let vctr = !ctr; (vctr < k))
-  invariant b . exists* vi vj vctr. (
+  invariant b . exists* (vi vj vctr : U32.t). (
      pts_to i vi **
      pts_to j vj **
      pts_to ctr vctr **     
@@ -67,5 +69,3 @@ fn fibo32 (k:U32.t) (_:squash(0ul < k /\ fits #U32.t (fib (v k))))
   let r = !j;
   r
 }
-
-

--- a/share/pulse/examples/Fibonacci.fst
+++ b/share/pulse/examples/Fibonacci.fst
@@ -44,7 +44,7 @@ fn fibonacci (k:pos)
   let mut ctr = 1;
   while ((ctr < k))
   invariant b . 
-    exists* vi vj vctr. 
+    exists* (vi vj vctr : int).
     pts_to i vi **
     pts_to j vj **
     pts_to ctr vctr **
@@ -73,7 +73,7 @@ fn fibonacci32 (k:U32.t)
   let mut ctr = 1ul;
   while ((ctr < k))
   invariant b . 
-    exists* vi vj vctr. 
+    exists* (vi vj vctr : U32.t).
      pts_to i vi **
      pts_to j vj **
      pts_to ctr vctr **
@@ -103,7 +103,8 @@ fn fibo (n:pos)
   let mut j = 1;
   let mut ctr = 1;
   while ((ctr < n))
-  invariant b . exists* vi vj vctr. (
+  invariant b.
+    exists* (vi vj vctr : int). (
      pts_to i vi **
      pts_to j vj **
      pts_to ctr vctr **
@@ -132,7 +133,7 @@ fn fibo2 (n:pos)
   let mut j : nat = 1;
   let mut ctr : nat = 1;
   while ((ctr < n))
-  invariant b . exists* vi vj vctr. (
+  invariant b . exists* (vi vj vctr : nat). (
      pts_to i vi **
      pts_to j vj **
      pts_to ctr vctr **     
@@ -160,7 +161,7 @@ fn fibo3 (n:pos)
   let mut j : nat = 1;
   let mut ctr : nat = 1;
   while ((ctr < n))
-  invariant b . exists* vi vj vctr. (
+  invariant b. exists* (vi vj vctr : nat). (
      pts_to i vi **
      pts_to j vj **
      pts_to ctr vctr **     

--- a/share/pulse/examples/GhostFunction.fst
+++ b/share/pulse/examples/GhostFunction.fst
@@ -29,8 +29,8 @@ assume val f (x:int) : GTot int
 
 ghost
 fn test_gtot (x:GR.ref int)
-  requires GR.pts_to x 0
-  ensures GR.pts_to x (f 0)
+  requires pts_to x 0
+  ensures pts_to x (f 0)
 {
   open GR;
   let y = f 0;
@@ -40,8 +40,8 @@ fn test_gtot (x:GR.ref int)
 
 
 fn increment (x:GR.ref int) (#n:erased int)
-    requires GR.pts_to x n
-    ensures GR.pts_to x (n + 1)
+    requires pts_to x n
+    ensures pts_to x (n + 1)
 {  
    open GR;
    let v = !x;
@@ -52,8 +52,8 @@ fn increment (x:GR.ref int) (#n:erased int)
 
 ghost
 fn incrementg (x:GR.ref int) (#n:erased int)
-    requires GR.pts_to x n
-    ensures GR.pts_to x (n + 1)
+    requires pts_to x n
+    ensures pts_to x (n + 1)
 {
    open GR;
    let v = !x;
@@ -64,8 +64,8 @@ fn incrementg (x:GR.ref int) (#n:erased int)
 
 ghost
 fn test_gtot_app_f (x:GR.ref int) (y:int)
-  requires GR.pts_to x 0
-  ensures GR.pts_to x y
+  requires pts_to x 0
+  ensures pts_to x y
 {
   open GR;
   x := y
@@ -78,8 +78,8 @@ fn test_gtot_app_f (x:GR.ref int) (y:int)
 
 ghost
 fn test_gtot_app (x:GR.ref int)
-  requires GR.pts_to x 0
-  ensures GR.pts_to x (f 0)
+  requires pts_to x 0
+  ensures pts_to x (f 0)
 {
   test_gtot_app_f x (f 0)
 }

--- a/share/pulse/examples/MSort.Base.fst
+++ b/share/pulse/examples/MSort.Base.fst
@@ -121,8 +121,8 @@ merge_impl
       pts_to i vi **
       pts_to j vj **
       pts_to k vk **
-      A.pts_to sw1 (reveal s1) **
-      A.pts_to sw2 (reveal s2) **
+      pts_to sw1 (reveal s1) **
+      pts_to sw2 (reveal s2) **
       pts_to_range a (SZ.v lo) (SZ.v hi) ss **
       pure (SZ.v vi <= SZ.v l1 /\ SZ.v vj <= SZ.v l2 /\ vk == vi `SZ.add` vj /\
             (ss == S.append (merge (stake (SZ.v vi) (reveal s1)) (stake (SZ.v vj) (reveal s2)))

--- a/share/pulse/examples/PulseCorePaper.S2.Lock.fst
+++ b/share/pulse/examples/PulseCorePaper.S2.Lock.fst
@@ -26,10 +26,10 @@ module B = Pulse.Lib.Box
 assume
 val cas_box_alt (r:B.box U32.t) (u v:U32.t) (#i:erased U32.t)
   : stt_atomic bool #Observable emp_inames 
-    (B.pts_to r i)
+    (pts_to r i)
     (fun b ->
-      if b then (B.pts_to r v ** pure (reveal i == u)) 
-           else (B.pts_to r i))
+      if b then (pts_to r v ** pure (reveal i == u)) 
+           else (pts_to r i))
 
 noeq
 type lock = { r:Pulse.Lib.Box.box U32.t; i:iname }

--- a/share/pulse/examples/PulseExample.BinarySearch.fst
+++ b/share/pulse/examples/PulseExample.BinarySearch.fst
@@ -35,7 +35,7 @@ fn binary_search
       (#s:erased (Seq.seq t) { Seq.length s == SZ.v len })
       (#p:perm)
 requires
-  A.pts_to a #p s **
+  pts_to a #p s **
   pure ((forall (i j: SZ.t).
           i <= j /\
           j < len ==>
@@ -45,7 +45,7 @@ requires
           Seq.index s (SZ.v k) == key))
 returns k:SZ.t
 ensures
-  A.pts_to a #p s **
+  pts_to a #p s **
   pure (k < len /\ Seq.index s (SZ.v k) == key)
 {
   let mut i1 : SZ.t = 0sz;
@@ -59,7 +59,7 @@ ensures
     exists* v1 v2.
       pts_to i1 v1 **
       pts_to i2 v2 **
-      A.pts_to a #p s **
+      pts_to a #p s **
       pure (
         (b == (v1 <> v2)) /\
         v2 < len /\
@@ -98,7 +98,7 @@ fn binary_search_int
       (#s:erased (Seq.seq int) { Seq.length s == SZ.v len })
       (#p:perm)
 requires
-  A.pts_to a #p s **
+  pts_to a #p s **
   pure ((forall (i j: SZ.t).
           i <= j /\
           j < len ==>
@@ -108,7 +108,7 @@ requires
           Seq.index s (SZ.v k) == key))
 returns k:SZ.t
 ensures
-  A.pts_to a #p s **
+  pts_to a #p s **
   pure (k < len /\ Seq.index s (SZ.v k) == key)
 { 
   binary_search a key len

--- a/share/pulse/examples/PulseExample.ContiguousSubSequence.fst
+++ b/share/pulse/examples/PulseExample.ContiguousSubSequence.fst
@@ -21,12 +21,12 @@ fn check_starts_with_at
       (#s1:erased (Seq.seq t) { Seq.length s1 == SZ.v len1})
       (#p:perm)
 requires
-  A.pts_to a0 #p s0 **
-  A.pts_to a1 #p s1
+  pts_to a0 #p s0 **
+  pts_to a1 #p s1
 returns b:bool
 ensures
-  A.pts_to a0 #p s0 **
-  A.pts_to a1 #p s1 **
+  pts_to a0 #p s0 **
+  pts_to a1 #p s1 **
   pure (b <==> starts_with_at (SZ.v j) s0 s1)
 {
   if (len1 - j < len0)
@@ -51,8 +51,8 @@ ensures
         pts_to i0 v0 **
         pts_to i1 v1 **
         pts_to break vb **
-        A.pts_to a0 #p s0 **
-        A.pts_to a1 #p s1 **
+        pts_to a0 #p s0 **
+        pts_to a1 #p s1 **
         pure (
           v0 <= len0 /\
           v1 <= len1 /\
@@ -94,12 +94,12 @@ fn contiguous_sub_sequence
       (#s1:erased (Seq.seq t) { Seq.length s1 == SZ.v len1})
       (#p:perm)
 requires
-  A.pts_to a0 #p s0 **
-  A.pts_to a1 #p s1
+  pts_to a0 #p s0 **
+  pts_to a1 #p s1
 returns b:bool
 ensures
-  A.pts_to a0 #p s0 **
-  A.pts_to a1 #p s1 **
+  pts_to a0 #p s0 **
+  pts_to a1 #p s1 **
   pure (b <==> (exists (j:nat { j < SZ.v len1 }).  starts_with_at j s0 s1))
 { 
   let mut j : SZ.t = 0sz;
@@ -114,8 +114,8 @@ ensures
     exists* vj vb.
       pts_to j vj **
       pts_to found vb **
-      A.pts_to a0 #p s0 **
-      A.pts_to a1 #p s1 **
+      pts_to a0 #p s0 **
+      pts_to a1 #p s1 **
       pure (
         vj <= len1 /\
         b == (not vb && vj < len1) /\

--- a/share/pulse/examples/PulseExample.UseBigRef.fst
+++ b/share/pulse/examples/PulseExample.UseBigRef.fst
@@ -30,7 +30,7 @@ let closure_list = B.ref (list closure)
 fn mk_closure_list ()
 requires emp
 returns r:closure_list
-ensures B.pts_to r []
+ensures pts_to r []
 {
   B.alloc #(list closure) []
 }
@@ -47,8 +47,8 @@ let mk_closure
 fn push (l:closure_list)
         (#p #q:slprop2)
         (f: unit -> stt unit p (fun _ -> q))
-requires B.pts_to l 'xs
-ensures B.pts_to l (mk_closure f :: 'xs)
+requires pts_to l 'xs
+ensures pts_to l (mk_closure f :: 'xs)
 {
   open B;
   let xs = !l;
@@ -114,7 +114,7 @@ ensures pre_of c ** inv tl
 
 let lock_inv (r:closure_list) : v:slprop { is_slprop3 v } =
   exists* (l:list closure). 
-    B.pts_to r l **
+    pts_to r l **
     inv l
 
 noeq

--- a/share/pulse/examples/ZetaHashAccumulator.fst
+++ b/share/pulse/examples/ZetaHashAccumulator.fst
@@ -140,10 +140,10 @@ val blake2b:
   -> #p:perm
   -> #sd:Ghost.erased (Seq.seq U8.t) { Seq.length sd == SZ.v ll}
   -> stt unit
-    (A.pts_to output sout ** A.pts_to d #p sd ** pure (Seq.length sout == 32))
-    (λ _ → A.pts_to output (blake_spec (Seq.slice sd 0 (SZ.v ll)))
+    (pts_to output sout ** pts_to d #p sd ** pure (Seq.length sout == 32))
+    (λ _ → pts_to output (blake_spec (Seq.slice sd 0 (SZ.v ll)))
            **
-           A.pts_to d #p sd)
+           pts_to d #p sd)
 
 (***************************************************************)
 (* Pulse *)

--- a/share/pulse/examples/bug-reports/BugWhileInv.fst
+++ b/share/pulse/examples/bug-reports/BugWhileInv.fst
@@ -17,14 +17,15 @@
 module BugWhileInv
 #lang-pulse
 open Pulse.Lib.Pervasives
+module R = Pulse.Lib.Reference
 
 let workaround (b:bool) (v:nat) : slprop =
     pure (not b ==> v == 0)
 
 
 fn count_down_ugly (x:ref nat)
-requires exists* v. pts_to x v
-ensures pts_to x 0
+requires exists* v. R.pts_to x v
+ensures  R.pts_to x 0
 {
   with v. assert (pts_to x v);
   fold (workaround true v);
@@ -54,8 +55,8 @@ ensures pts_to x 0
 
 
 fn count_down (x:ref nat)
-requires exists* v. pts_to x v
-ensures pts_to x 0
+requires exists* v. R.pts_to x v
+ensures  R.pts_to x 0
 {
   while (
     let v = !x;
@@ -71,7 +72,7 @@ ensures pts_to x 0
   )
   invariant b.
     exists* v. 
-        pts_to x v **
+        R.pts_to x v **
         pure ((b == false) ==> (v == 0))
   { () };
  }

--- a/share/pulse/examples/by-example/ParallelIncrement.fst
+++ b/share/pulse/examples/by-example/ParallelIncrement.fst
@@ -27,18 +27,18 @@ module R = Pulse.Lib.Reference
 fn increment (#p:perm)
              (x:ref nat)
              (l:L.lock)
-requires (L.lock_alive l #p (exists* v. pts_to x #0.5R v)) ** pts_to x #0.5R 'i
-ensures (L.lock_alive l #p (exists* v. pts_to x #0.5R v)) ** pts_to x #0.5R ('i + 1)
+requires (L.lock_alive l #p (exists* v. pts_to x #0.5R v)) ** R.pts_to x #0.5R 'i
+ensures  (L.lock_alive l #p (exists* v. pts_to x #0.5R v)) ** R.pts_to x #0.5R ('i + 1)
  {
     let v = !x;
     L.acquire l;
     R.gather x;
-    with p _v. rewrite (pts_to x #p _v) as (pts_to x _v);
+    with p _v. rewrite (R.pts_to x #p _v) as (R.pts_to x _v);
     x := (v + 1);
     R.share x;
-    with p _v. rewrite (pts_to x #p _v) as (pts_to x #0.5R _v);
+    with p _v. rewrite (R.pts_to x #p _v) as (R.pts_to x #0.5R _v);
     L.release l;
-    with p _v. rewrite (pts_to x #p _v) as (pts_to x #0.5R _v);
+    with p _v. rewrite (R.pts_to x #p _v) as (R.pts_to x #0.5R _v);
 }
 
 
@@ -50,23 +50,23 @@ fn increment_f (x: ref nat)
                (l:L.lock)
                (f: (v:nat -> stt_ghost unit
                         emp_inames
-                        (pred v ** qpred v ** pts_to x #0.5R (v + 1))
-                        (fun _ -> pred (v + 1) ** qpred (v + 1) ** pts_to x #0.5R (v + 1))))
-requires L.lock_alive l #p (exists* v. pts_to x #0.5R v ** pred v) ** pts_to x #0.5R 'i ** qpred 'i
-ensures L.lock_alive l #p (exists* v. pts_to x #0.5R v ** pred v) ** pts_to x #0.5R ('i + 1) ** qpred ('i + 1)
+                        (pred v ** qpred v ** R.pts_to x #0.5R (v + 1))
+                        (fun _ -> pred (v + 1) ** qpred (v + 1) ** R.pts_to x #0.5R (v + 1))))
+requires L.lock_alive l #p (exists* v. pts_to x #0.5R v ** pred v) ** R.pts_to x #0.5R 'i ** qpred 'i
+ensures  L.lock_alive l #p (exists* v. pts_to x #0.5R v ** pred v) ** R.pts_to x #0.5R ('i + 1) ** qpred ('i + 1)
  {
     let vx = !x;
     rewrite (qpred 'i) as (qpred vx);
     L.acquire l;
     R.gather x;
-    with p v. rewrite (pts_to x #p v) as (pts_to x v);
+    with p v. rewrite (R.pts_to x #p v) as (R.pts_to x v);
     x := (vx + 1);
     R.share x;
-    with p _v. rewrite (pts_to x #p _v) as (pts_to x #0.5R _v);
+    with p _v. rewrite (R.pts_to x #p _v) as (R.pts_to x #0.5R _v);
     with _v. rewrite (pred _v) as (pred vx);
     f vx;
     L.release l;
-    with p _v. rewrite (pts_to x #p _v) as (pts_to x #0.5R _v);
+    with p _v. rewrite (R.pts_to x #p _v) as (R.pts_to x #0.5R _v);
     rewrite (qpred (vx + 1)) as (qpred ('i + 1));
 }
 
@@ -107,8 +107,8 @@ ensures pts_to x ('i + 2)
       exists* (v:int).
         pts_to x v **
         (exists* (vl vr:int).
-          GR.pts_to left #0.5R vl **
-          GR.pts_to right #0.5R vr **
+          pts_to left #0.5R vl **
+          pts_to right #0.5R vr **
           pure (v == 'i + vl + vr))
     );
     ghost
@@ -118,49 +118,49 @@ ensures pts_to x ('i + 2)
         (v vq:int)
       requires 
         (exists* (vl vr:int).
-            GR.pts_to left #0.5R vl **
-            GR.pts_to right #0.5R vr **
+            pts_to left #0.5R vl **
+            pts_to right #0.5R vr **
             pure (v == 'i + vl + vr)) **
-        GR.pts_to lr #0.5R vq **
+        pts_to lr #0.5R vq **
         pts_to x (v + 1)
       ensures
         (exists* (vl vr:int).
-            GR.pts_to left #0.5R vl **
-            GR.pts_to right #0.5R vr **
+            pts_to left #0.5R vl **
+            pts_to right #0.5R vr **
             pure (v + 1 == 'i + vl + vr)) **
-        GR.pts_to lr #0.5R (vq + 1) **
+        pts_to lr #0.5R (vq + 1) **
         pts_to x (v + 1)
     { 
       if b
       {
-        with _p _v. rewrite (GR.pts_to lr #_p _v) as (GR.pts_to left #_p _v);
+        with _p _v. rewrite (pts_to lr #_p _v) as (pts_to left #_p _v);
         GR.gather left;
-        with _p _v. rewrite (GR.pts_to left #_p _v) as (GR.pts_to left _v);
+        with _p _v. rewrite (pts_to left #_p _v) as (pts_to left _v);
         GR.( left := vq + 1 );
         GR.share left;      
-        with _p _v. rewrite (GR.pts_to left #_p _v) as (GR.pts_to lr #_p _v);
+        with _p _v. rewrite (pts_to left #_p _v) as (pts_to lr #_p _v);
       }
       else
       {
-        with _p _v. rewrite (GR.pts_to lr #_p _v) as (GR.pts_to right #_p _v);
+        with _p _v. rewrite (pts_to lr #_p _v) as (pts_to right #_p _v);
         GR.gather right;
-        with _p _v. rewrite (GR.pts_to right #_p _v) as (GR.pts_to right _v);
+        with _p _v. rewrite (pts_to right #_p _v) as (pts_to right _v);
         GR.( right := vq + 1 );
         GR.share right;      
-        with _p _v. rewrite (GR.pts_to right #_p _v) as (GR.pts_to lr #_p _v);
+        with _p _v. rewrite (pts_to right #_p _v) as (pts_to lr #_p _v);
       }
     };
 
     with pred. assert (L.lock_alive lock #1.0R (exists* v. pts_to x v ** pred v));
     L.share2 lock;
     parallel
-    requires GR.pts_to left #0.5R 0 **
+    requires pts_to left #0.5R 0 **
              L.lock_alive lock #0.5R (exists* v. pts_to x v ** pred v)
-         and GR.pts_to right #0.5R 0 **
+         and pts_to right #0.5R 0 **
              L.lock_alive lock #0.5R (exists* v. pts_to x v ** pred v)
-    ensures  GR.pts_to left #0.5R 1 **
+    ensures  pts_to left #0.5R 1 **
              L.lock_alive lock #0.5R (exists* v. pts_to x v ** pred v)
-         and GR.pts_to right #0.5R 1 **
+         and pts_to right #0.5R 1 **
              L.lock_alive lock #0.5R (exists* v. pts_to x v ** pred v)
     { increment_f2 x lock (step left true) }
     { increment_f2 x lock (step right false) };
@@ -169,8 +169,8 @@ ensures pts_to x ('i + 2)
     L.acquire lock;
     GR.gather left;
     GR.gather right;
-    with _p _v. rewrite (GR.pts_to left #_p _v) as (GR.pts_to left _v);
-    with _p _v. rewrite (GR.pts_to right #_p _v) as (GR.pts_to right _v);
+    with _p _v. rewrite (pts_to left #_p _v) as (pts_to left _v);
+    with _p _v. rewrite (pts_to right #_p _v) as (pts_to right _v);
     GR.free left;
     GR.free right;
     L.free lock
@@ -403,8 +403,8 @@ ensures pts_to x ('i + 2)
       exists* (v:int).
           pts_to x v **
           (exists* (vl vr:int).
-            GR.pts_to left #0.5R vl **
-            GR.pts_to right #0.5R vr **
+            pts_to left #0.5R vl **
+            pts_to right #0.5R vr **
             pure (v == 'i + vl + vr))
 
     );
@@ -415,36 +415,36 @@ ensures pts_to x ('i + 2)
         (v vq:int)
       requires 
         (exists* (vl vr:int).
-            GR.pts_to left #0.5R vl **
-            GR.pts_to right #0.5R vr **
+            pts_to left #0.5R vl **
+            pts_to right #0.5R vr **
             pure (v == 'i + vl + vr)) **
-        GR.pts_to lr #0.5R vq **
+        pts_to lr #0.5R vq **
         pts_to x (v + 1)
       ensures
         (exists* (vl vr:int).
-            GR.pts_to left #0.5R vl **
-            GR.pts_to right #0.5R vr **
+            pts_to left #0.5R vl **
+            pts_to right #0.5R vr **
             pure (v + 1 == 'i + vl + vr)) **
-        GR.pts_to lr #0.5R (vq + 1) **
+        pts_to lr #0.5R (vq + 1) **
         pts_to x (v + 1)
     { 
       if b
       {
-        with _p _v. rewrite (GR.pts_to lr #_p _v) as (GR.pts_to left #_p _v);
+        with _p _v. rewrite (pts_to lr #_p _v) as (pts_to left #_p _v);
         GR.gather left;
-        with _p _v. rewrite (GR.pts_to left #_p _v) as (GR.pts_to left _v);
+        with _p _v. rewrite (pts_to left #_p _v) as (pts_to left _v);
         GR.( left := vq + 1 );
         GR.share left;      
-        with _p _v. rewrite (GR.pts_to left #_p _v) as (GR.pts_to lr #_p _v);
+        with _p _v. rewrite (pts_to left #_p _v) as (pts_to lr #_p _v);
       }
       else
       {
-        with _p _v. rewrite (GR.pts_to lr #_p _v) as (GR.pts_to right #_p _v);
+        with _p _v. rewrite (pts_to lr #_p _v) as (pts_to right #_p _v);
         GR.gather right;
-        with _p _v. rewrite (GR.pts_to right #_p _v) as (GR.pts_to right _v);
+        with _p _v. rewrite (pts_to right #_p _v) as (pts_to right _v);
         GR.( right := vq + 1 );
         GR.share right;      
-        with _p _v. rewrite (GR.pts_to right #_p _v) as (GR.pts_to lr #_p _v);
+        with _p _v. rewrite (pts_to right #_p _v) as (pts_to lr #_p _v);
       }
     };
 
@@ -453,16 +453,16 @@ ensures pts_to x ('i + 2)
     dup_inv (C.iname_of c) (C.cinv_vp c (exists* v. pts_to x v ** pred v));
 
     parallel
-    requires GR.pts_to left #0.5R 0 **
+    requires pts_to left #0.5R 0 **
              C.active c 0.5R **
              inv (C.iname_of c) (C.cinv_vp c (exists* v. pts_to x v ** pred v))
-         and GR.pts_to right #0.5R 0 **
+         and pts_to right #0.5R 0 **
              C.active c 0.5R **
              inv (C.iname_of c) (C.cinv_vp c (exists* v. pts_to x v ** pred v))
-    ensures  GR.pts_to left #0.5R 1 **
+    ensures  pts_to left #0.5R 1 **
              C.active c 0.5R **
              inv (C.iname_of c) (C.cinv_vp c (exists* v. pts_to x v ** pred v))
-         and GR.pts_to right #0.5R 1 **
+         and pts_to right #0.5R 1 **
              C.active c 0.5R **
              inv (C.iname_of c) (C.cinv_vp c (exists* v. pts_to x v ** pred v))
     { atomic_increment_f6 x c (step left true) }
@@ -473,8 +473,8 @@ ensures pts_to x ('i + 2)
     C.cancel c;
     GR.gather left;
     GR.gather right;
-    with _p _v. rewrite (GR.pts_to left #_p _v) as (GR.pts_to left _v);
-    with _p _v. rewrite (GR.pts_to right #_p _v) as (GR.pts_to right _v);
+    with _p _v. rewrite (pts_to left #_p _v) as (pts_to left _v);
+    with _p _v. rewrite (pts_to right #_p _v) as (pts_to right _v);
     GR.free left;
     GR.free right;
 }

--- a/share/pulse/examples/by-example/PulseTutorial.Loops.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.Loops.fst
@@ -17,18 +17,19 @@
 module PulseTutorial.Loops
 #lang-pulse
 open Pulse.Lib.Pervasives
+module R = Pulse.Lib.Reference
 
  //count_down$
 fn count_down (x:ref nat)
-requires pts_to x 'v
-ensures pts_to x 0
+requires R.pts_to x 'v
+ensures  R.pts_to x 0
 {
     let mut keep_going = true;
     while (
         !keep_going
     )
     invariant b. 
-      exists* v.
+      exists* (v:nat).
         pts_to keep_going b **
         pts_to x v **
         pure (b == false ==> v == 0)
@@ -48,8 +49,8 @@ ensures pts_to x 0
 
  //count_down3$
 fn count_down3 (x:ref nat)
-requires pts_to x 'v
-ensures pts_to x 0
+requires R.pts_to x 'v
+ensures  R.pts_to x 0
 {
     while (
         let n = !x;
@@ -64,7 +65,7 @@ ensures pts_to x 0
         }
     )
     invariant b. 
-      exists* v.
+      exists* (v:nat).
         pts_to x v **
         pure (b == false ==> v == 0)
     { () }
@@ -73,8 +74,8 @@ ensures pts_to x 0
 
  //count_down_loopy$
 fn count_down_loopy (x:ref nat)
-requires pts_to x 'v
-ensures pts_to x 0
+requires R.pts_to x 'v
+ensures  R.pts_to x 0
 {
     while (
         let n = !x;
@@ -90,7 +91,7 @@ ensures pts_to x 0
     )
     invariant b. 
       exists* v.
-        pts_to x v **
+        R.pts_to x v **
         pure (b == false ==> v == 0)
     { () }
 }
@@ -111,8 +112,8 @@ fn multiply_by_repeated_addition (x y:nat)
     )
     invariant b.
     exists* c a.
-        pts_to ctr c **
-        pts_to acc a **
+        R.pts_to ctr c **
+        R.pts_to acc a **
         pure (c <= x /\
               a == (c * y) /\
               b == (c < x))
@@ -159,8 +160,8 @@ ensures pure ((n * (n + 1) / 2) == z)
     )
     invariant b.
     exists* c a.
-        pts_to ctr c **
-        pts_to acc a **
+        R.pts_to ctr c **
+        R.pts_to acc a **
         pure (c <= n /\
               a == sum c /\
               b == (c < n))
@@ -228,9 +229,9 @@ fn fib_loop (k:pos)
   )
   invariant b . 
     exists* vi vj vctr. 
-        pts_to i vi **
-        pts_to j vj **
-        pts_to ctr vctr **
+        R.pts_to i vi **
+        R.pts_to j vj **
+        R.pts_to ctr vctr **
         pure (
             1 <= vctr /\
             vctr <= k /\
@@ -279,9 +280,9 @@ fn fibonacci32 (k:U32.t)
   )
   invariant b . 
     exists* vi vj vctr. 
-     pts_to i vi **
-     pts_to j vj **
-     pts_to ctr vctr **
+     R.pts_to i vi **
+     R.pts_to j vj **
+     R.pts_to ctr vctr **
      pure (1ul <= vctr /\
            vctr <= k /\
            fib (v (vctr - 1ul)) == v vi/\

--- a/share/pulse/examples/by-example/PulseTutorial.PCMParallelIncrement.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.PCMParallelIncrement.fst
@@ -6,6 +6,7 @@ module MS = Pulse.Lib.PCM.MonoidShares
 module U = FStar.Universe
 module GPR = Pulse.Lib.GhostPCMReference
 module CI = Pulse.Lib.CancellableInvariant
+module R = Pulse.Lib.Reference
 
 // For this example: we assume we have an atomic operation
 // to increment a ref nat
@@ -15,8 +16,8 @@ module CI = Pulse.Lib.CancellableInvariant
 
 atomic
 fn atomic_incr (r:ref nat)
-requires pts_to r 'i
-ensures pts_to r ('i + 1)
+requires R.pts_to r 'i
+ensures  R.pts_to r ('i + 1)
 {
   admit()
 }
@@ -305,7 +306,7 @@ requires
   contributions capacity initial gs r **
   has_given gs capacity
 ensures
-  pts_to r (initial + capacity)
+  R.pts_to r (initial + capacity)
 {
   unfold contributions;
   unfold has_given;
@@ -374,8 +375,8 @@ opens [CI.iname_of i] //we used the invariant
 // the classic Owicki-Gries example
 
 fn incr2 (r:ref nat)
-requires pts_to r 'i
-ensures pts_to r ('i + 2)
+requires R.pts_to r 'i
+ensures  R.pts_to r ('i + 2)
 {
   let gs = init_ghost_state 'i 2 r; // initialize the ghost state with a capacity of 2
   let ci = CI.new_cancellable_invariant (contributions 2 'i gs r); // allocate an invariant
@@ -489,8 +490,8 @@ decreases remaining
 /// Finally, the main `incr_n r n`
 
 fn incr_n (r:ref nat) (n:nat)
-requires pts_to r 'i
-ensures pts_to r ('i + n)
+requires R.pts_to r 'i
+ensures  R.pts_to r ('i + n)
 {
   let gs = init_ghost_state 'i n r;
   let ci = CI.new_cancellable_invariant (contributions n 'i gs r);

--- a/share/pulse/examples/dice/cbor/CBOR.Pulse.Extern.fsti
+++ b/share/pulse/examples/dice/cbor/CBOR.Pulse.Extern.fsti
@@ -124,9 +124,9 @@ let cbor_read_success_post
 : Tot slprop
 = exists* v rem.
     raw_data_item_match 1.0R c.cbor_read_payload v **
-    A.pts_to c.cbor_read_remainder #p rem **
-    ((raw_data_item_match 1.0R c.cbor_read_payload v ** A.pts_to c.cbor_read_remainder #p rem) @==>
-      A.pts_to a #p va) **
+    pts_to c.cbor_read_remainder #p rem **
+    ((raw_data_item_match 1.0R c.cbor_read_payload v ** pts_to c.cbor_read_remainder #p rem) @==>
+      pts_to a #p va) **
     pure (cbor_read_success_postcond va c v rem)
 
 
@@ -141,7 +141,7 @@ let cbor_read_error_post
   (p: perm)
   (va: Ghost.erased (Seq.seq U8.t))
 : Tot slprop
-= A.pts_to a #p va ** pure (cbor_read_error_postcond va)
+= pts_to a #p va ** pure (cbor_read_error_postcond va)
 
 let cbor_read_post
   (a: A.array U8.t)
@@ -159,7 +159,7 @@ val cbor_read
   (#va: Ghost.erased (Seq.seq U8.t))
   (#p: perm)
 : stt cbor_read_t
-    (A.pts_to a #p va ** pure (
+    (pts_to a #p va ** pure (
       (SZ.v sz == Seq.length va \/ SZ.v sz == A.length a)
     ))
     (fun res -> cbor_read_post a p va res)
@@ -182,9 +182,9 @@ let cbor_read_deterministically_encoded_success_post
 : Tot slprop
 = ((exists* v rem.
     raw_data_item_match 1.0R c.cbor_read_payload v **
-    A.pts_to c.cbor_read_remainder #p rem **
-    ((raw_data_item_match 1.0R c.cbor_read_payload v ** A.pts_to c.cbor_read_remainder #p rem) @==>
-      A.pts_to a #p va) **
+    pts_to c.cbor_read_remainder #p rem **
+    ((raw_data_item_match 1.0R c.cbor_read_payload v ** pts_to c.cbor_read_remainder #p rem) @==>
+      pts_to a #p va) **
     pure (cbor_read_deterministically_encoded_success_postcond va c v rem)
   ))
 
@@ -199,7 +199,7 @@ let cbor_read_deterministically_encoded_error_post
   (p: perm)
   (va: Ghost.erased (Seq.seq U8.t))
 : Tot slprop
-= A.pts_to a #p va ** pure (cbor_read_deterministically_encoded_error_postcond va)
+= pts_to a #p va ** pure (cbor_read_deterministically_encoded_error_postcond va)
 
 let cbor_read_deterministically_encoded_post
   (a: A.array U8.t)
@@ -217,7 +217,7 @@ val cbor_read_deterministically_encoded
   (#va: Ghost.erased (Seq.seq U8.t))
   (#p: perm)
 : stt cbor_read_t
-    (A.pts_to a #p va ** pure (SZ.v sz == Seq.length va \/ SZ.v sz == A.length a))
+    (pts_to a #p va ** pure (SZ.v sz == Seq.length va \/ SZ.v sz == A.length a))
     (fun res -> cbor_read_deterministically_encoded_post a p va res)
 
 (* Destructors and constructors *)
@@ -281,8 +281,8 @@ val cbor_destr_string
       Cbor.String? va
     ))
     (fun c' -> exists* vc' p'.
-      A.pts_to c'.cbor_string_payload #p' vc' **
-      (A.pts_to c'.cbor_string_payload #p' vc' @==> raw_data_item_match p c (Ghost.reveal va)) **
+      pts_to c'.cbor_string_payload #p' vc' **
+      (pts_to c'.cbor_string_payload #p' vc' @==> raw_data_item_match p c (Ghost.reveal va)) **
       pure (cbor_destr_string_post va c'  vc'
     ))
 
@@ -293,13 +293,13 @@ val cbor_constr_string
   (#va: Ghost.erased (Seq.seq U8.t))
   (#p: perm)
 : stt cbor
-    (A.pts_to a #p va ** pure (
+    (pts_to a #p va ** pure (
       U64.v len == Seq.length va
     ))
     (fun c' -> exists* vc'.
       raw_data_item_match 1.0R c' vc' **
       (raw_data_item_match 1.0R c' vc' @==>
-        A.pts_to a #p va
+        pts_to a #p va
       ) ** pure (
       U64.v len == Seq.length va /\
       vc' == Cbor.String typ va
@@ -311,7 +311,7 @@ val cbor_constr_array
   (#c': Ghost.erased (Seq.seq cbor))
   (#v': Ghost.erased (list Cbor.raw_data_item))
 : stt cbor
-    (A.pts_to a c' **
+    (pts_to a c' **
       raw_data_item_array_match 1.0R c' v' **
       pure (
         U64.v len == List.Tot.length v'
@@ -319,7 +319,7 @@ val cbor_constr_array
     (fun res -> exists* vres.
       raw_data_item_match 1.0R res vres **
       (raw_data_item_match 1.0R res vres @==>
-        (A.pts_to a c' **
+        (pts_to a c' **
           raw_data_item_array_match 1.0R c' v')
       ) ** pure (
       U64.v len == List.Tot.length v' /\
@@ -405,11 +405,11 @@ val cbor_array_iterator_next
   (#l: Ghost.erased (list Cbor.raw_data_item))
   (#i: Ghost.erased cbor_array_iterator_t)
 : stt cbor
-    (R.pts_to pi i ** cbor_array_iterator_match p i l **
+    (pts_to pi i ** cbor_array_iterator_match p i l **
       pure (Cons? l)
     )
     (fun c -> exists* i' vc vi'.
-      R.pts_to pi i' **
+      pts_to pi i' **
       raw_data_item_match p c vc **
       cbor_array_iterator_match p i' vi' **
       ((raw_data_item_match p c vc **
@@ -428,7 +428,7 @@ val cbor_read_array
   (#vdest: Ghost.erased (Seq.seq cbor))
 : stt (A.array cbor)
     (raw_data_item_match p a v **
-      A.pts_to dest vdest **
+      pts_to dest vdest **
       pure (
         (Cbor.Array? v /\
           (U64.v len == A.length dest \/ U64.v len == Seq.length vdest) /\
@@ -436,12 +436,12 @@ val cbor_read_array
         )
     ))
     (fun res -> exists* vres.
-      A.pts_to res vres **
+      pts_to res vres **
       raw_data_item_array_match p vres (maybe_cbor_array v) **
-      ((A.pts_to res vres **
+      ((pts_to res vres **
         raw_data_item_array_match p vres (maybe_cbor_array v)) @==> (
         raw_data_item_match p a v **
-        (exists* _x. (A.pts_to dest #1.0R _x))
+        (exists* _x. (pts_to dest #1.0R _x))
       )) ** pure (
       Cbor.Array? v /\
       U64.v len == A.length dest /\
@@ -495,12 +495,12 @@ val cbor_constr_tagged
   (#c': Ghost.erased (cbor))
   (#v': Ghost.erased (Cbor.raw_data_item))
 : stt cbor
-    (R.pts_to a c' **
+    (pts_to a c' **
       raw_data_item_match 1.0R c' v')
     (fun res ->
       raw_data_item_match 1.0R res (Cbor.Tagged tag v') **
       (raw_data_item_match 1.0R res (Cbor.Tagged tag v') @==>
-        (R.pts_to a c' **
+        (pts_to a c' **
           raw_data_item_match 1.0R c' v')
       )
     )
@@ -511,7 +511,7 @@ val cbor_constr_map
   (#c': Ghost.erased (Seq.seq cbor_map_entry))
   (#v': Ghost.erased (list (Cbor.raw_data_item & Cbor.raw_data_item)))
 : stt cbor
-    (A.pts_to a c' **
+    (pts_to a c' **
       raw_data_item_map_match 1.0R c' v' **
       pure (
         U64.v len == List.Tot.length v'
@@ -519,7 +519,7 @@ val cbor_constr_map
     (fun res -> exists* vres.
       raw_data_item_match 1.0R res vres **
       (raw_data_item_match 1.0R res vres @==>
-        (A.pts_to a c' **
+        (pts_to a c' **
           raw_data_item_map_match 1.0R c' v')
       ) ** pure (
       U64.v len == List.Tot.length v' /\
@@ -649,7 +649,7 @@ let cbor_write_post
   (vout': Seq.seq U8.t)
 : Tot slprop
 = 
-  A.pts_to out vout' **
+  pts_to out vout' **
   pure (cbor_write_postcond va out vout' res)
 
 val cbor_write
@@ -661,7 +661,7 @@ val cbor_write
   (#vout: Ghost.erased (Seq.seq U8.t))
 : stt SZ.t
     (raw_data_item_match p c (Ghost.reveal va) **
-      A.pts_to out vout **
+      pts_to out vout **
       pure (
         (SZ.v sz == A.length out)
     ))

--- a/share/pulse/examples/dice/cbor/CBOR.Pulse.fst
+++ b/share/pulse/examples/dice/cbor/CBOR.Pulse.fst
@@ -134,10 +134,10 @@ fn byte_array_compare
   (#va1: Ghost.erased (Seq.seq U8.t))
   (#va2: Ghost.erased (Seq.seq U8.t))
 requires
-    (A.pts_to a1 #p1 va1 ** A.pts_to a2 #p2 va2)
+    (pts_to a1 #p1 va1 ** pts_to a2 #p2 va2)
 returns res: I16.t
 ensures
-        A.pts_to a1 #p1 va1 ** A.pts_to a2 #p2 va2 **
+        pts_to a1 #p1 va1 ** pts_to a2 #p2 va2 **
         pure (I16.v res == Cbor.bytes_lex_compare va1 va2)
 {
     A.pts_to_len a1;
@@ -148,7 +148,7 @@ ensures
     let prf2 : squash (Ghost.reveal va2 `Seq.equal` Seq.slice va2 0 (SZ.v sz)) = ();
     while (let i = !pi; let res = !pres; ((i `SZ.lt` sz) && (res = 0s)))
     invariant cont . exists* i res .
-        A.pts_to a1 #p1 va1 ** A.pts_to a2 #p2 va2 **
+        pts_to a1 #p1 va1 ** pts_to a2 #p2 va2 **
         pts_to pi i ** pts_to pres res **
         pure (
             SZ.v i <= SZ.v sz /\
@@ -927,12 +927,12 @@ fn cbor_map_sort
     (#c: Ghost.erased (Seq.seq cbor_map_entry))
     (#l: Ghost.erased (list (Cbor.raw_data_item & Cbor.raw_data_item)))
 requires
-    A.pts_to a c **
+    pts_to a c **
     SM.seq_list_match c l (raw_data_item_map_entry_match 1.0R) **
     pure (SZ.v len == A.length a \/ SZ.v len == Seq.length c \/ SZ.v len == List.Tot.length l)
 returns res: bool
 ensures exists* c' l' .
-    A.pts_to a c' **
+    pts_to a c' **
     SM.seq_list_match c' l' (raw_data_item_map_entry_match 1.0R) **
     pure (
         Cbor.cbor_map_sort l == (res, l')

--- a/share/pulse/examples/dice/cbor/CDDL.Pulse.fst
+++ b/share/pulse/examples/dice/cbor/CDDL.Pulse.fst
@@ -200,12 +200,12 @@ let impl_array_group3
     (#i: Ghost.erased cbor_array_iterator_t) ->
     (#l: Ghost.erased (list raw_data_item)) ->
     stt bool
-        (R.pts_to pi i **
+        (pts_to pi i **
             cbor_array_iterator_match p i l **
             pure (opt_precedes (Ghost.reveal l) b)
         )
         (fun res -> exists* i' l'.
-            R.pts_to pi i' **
+            pts_to pi i' **
             cbor_array_iterator_match p i' l' **
             (cbor_array_iterator_match p i' l' @==> cbor_array_iterator_match p i l) **
             pure (
@@ -229,7 +229,7 @@ fn intro_impl_array_group3_post
     (l': list raw_data_item)
 requires
     (
-            R.pts_to pi i' **
+            pts_to pi i' **
             cbor_array_iterator_match p i' l' **
             (cbor_array_iterator_match p i' l' @==> cbor_array_iterator_match p i l) **
             pure (
@@ -240,7 +240,7 @@ requires
     )
 ensures
         (exists* i' l'.
-            R.pts_to pi i' **
+            pts_to pi i' **
             cbor_array_iterator_match p i' l' **
             (cbor_array_iterator_match p i' l' @==> cbor_array_iterator_match p i l) **
             pure (
@@ -322,7 +322,7 @@ fn impl_array_group3_item
                 #(raw_data_item_match p c gc ** cbor_array_iterator_match p i' l')
                 #(cbor_array_iterator_match p gi l); // FIXME: WHY WHY WHY those explicit arguments?
             pi := i;
-            rewrite (R.pts_to pi i) as (R.pts_to pi gi);
+            rewrite (pts_to pi i) as (pts_to pi gi);
             stick_refl0 (cbor_array_iterator_match p gi l);
             false
         }
@@ -389,9 +389,9 @@ let cbor_read_with_typ_success_post
 : Tot slprop
 = exists* v rem.
     raw_data_item_match 1.0R c.cbor_read_payload v **
-    A.pts_to c.cbor_read_remainder #p rem **
-    ((raw_data_item_match 1.0R c.cbor_read_payload v ** A.pts_to c.cbor_read_remainder #p rem) @==>
-      A.pts_to a #p va) **
+    pts_to c.cbor_read_remainder #p rem **
+    ((raw_data_item_match 1.0R c.cbor_read_payload v ** pts_to c.cbor_read_remainder #p rem) @==>
+      pts_to a #p va) **
     pure (cbor_read_with_typ_success_postcond t va c v rem)
 
 noextract [@@noextract_to "krml"]
@@ -425,7 +425,7 @@ let cbor_read_with_typ_error_post
   (p: perm)
   (va: Ghost.erased (Seq.seq U8.t))
 : Tot slprop
-= A.pts_to a #p va ** pure (cbor_read_with_typ_error_postcond t va)
+= pts_to a #p va ** pure (cbor_read_with_typ_error_postcond t va)
 
 let cbor_read_with_typ_post
   (t: typ)
@@ -456,7 +456,7 @@ fn cbor_read_with_typ
   (#va: Ghost.erased (Seq.seq U8.t))
   (#p: perm)
 requires
-    (A.pts_to a #p va ** pure (
+    (pts_to a #p va ** pure (
       (SZ.v sz == Seq.length va \/ SZ.v sz == A.length a)
     ))
 returns res: cbor_read_t
@@ -473,10 +473,10 @@ ensures cbor_read_with_typ_post t a p va res
             res
         } else {
             with v . assert (raw_data_item_match 1.0R res.cbor_read_payload v);
-            with vrem . assert (A.pts_to res.cbor_read_remainder #p vrem);
+            with vrem . assert (pts_to res.cbor_read_remainder #p vrem);
             cbor_read_with_typ_error_postcond_intro_typ_fail t va res v vrem;
             elim_stick0 ()
-                #(raw_data_item_match 1.0R res.cbor_read_payload v ** A.pts_to res.cbor_read_remainder #p vrem);
+                #(raw_data_item_match 1.0R res.cbor_read_payload v ** pts_to res.cbor_read_remainder #p vrem);
             fold (cbor_read_with_typ_error_post t a p va);
             let res = mk_cbor_read_error res;
             rewrite (cbor_read_with_typ_error_post t a p va) as (cbor_read_with_typ_post t a p va res);
@@ -539,9 +539,9 @@ let cbor_read_deterministically_encoded_with_typ_success_post
 : Tot slprop
 =   exists* v rem.
         raw_data_item_match 1.0R res.cbor_read_payload v **
-        A.pts_to res.cbor_read_remainder #p rem **
-        ((raw_data_item_match 1.0R res.cbor_read_payload v ** A.pts_to res.cbor_read_remainder #p rem) @==>
-        A.pts_to a #p va) **
+        pts_to res.cbor_read_remainder #p rem **
+        ((raw_data_item_match 1.0R res.cbor_read_payload v ** pts_to res.cbor_read_remainder #p rem) @==>
+        pts_to a #p va) **
         pure (cbor_read_deterministically_encoded_with_typ_success_postcond t va res v rem)
 
 let cbor_read_deterministically_encoded_with_typ_error_post
@@ -550,7 +550,7 @@ let cbor_read_deterministically_encoded_with_typ_error_post
   (p: perm)
   (va: Ghost.erased (Seq.seq U8.t))
 : Tot slprop
-= A.pts_to a #p va ** pure (cbor_read_deterministically_encoded_with_typ_error_postcond t va)
+= pts_to a #p va ** pure (cbor_read_deterministically_encoded_with_typ_error_postcond t va)
 
 let cbor_read_deterministically_encoded_with_typ_post
   (t: typ)
@@ -575,7 +575,7 @@ fn cbor_read_deterministically_encoded_with_typ
   (#va: Ghost.erased (Seq.seq U8.t))
   (#p: perm)
 requires
-    (A.pts_to a #p va ** pure (
+    (pts_to a #p va ** pure (
       (SZ.v sz == Seq.length va \/ SZ.v sz == A.length a)
     ))
 returns res: cbor_read_t
@@ -592,10 +592,10 @@ ensures cbor_read_deterministically_encoded_with_typ_post t a p va res
             res
         } else {
             with v . assert (raw_data_item_match 1.0R res.cbor_read_payload v);
-            with vrem . assert (A.pts_to res.cbor_read_remainder #p vrem);
+            with vrem . assert (pts_to res.cbor_read_remainder #p vrem);
             cbor_read_deterministically_encoded_with_typ_error_postcond_intro_typ_fail t va res v vrem;
             elim_stick0 ()
-                #(raw_data_item_match 1.0R res.cbor_read_payload v ** A.pts_to res.cbor_read_remainder #p vrem);
+                #(raw_data_item_match 1.0R res.cbor_read_payload v ** pts_to res.cbor_read_remainder #p vrem);
             let res = mk_cbor_read_error res;
             fold (cbor_read_deterministically_encoded_with_typ_error_post t a p va);
             fold (cbor_read_deterministically_encoded_with_typ_post t a p va res);

--- a/share/pulse/examples/dice/dpe/DPE.TestClient.fst
+++ b/share/pulse/examples/dice/dpe/DPE.TestClient.fst
@@ -29,7 +29,7 @@ module A = Pulse.Lib.Array
 assume val get_uds ()  // used only for testing a client
   : stt (larray U8.t (US.v uds_len))
         (requires emp)
-        (ensures fun uds -> exists* uds_repr. A.pts_to uds uds_repr)
+        (ensures fun uds -> exists* uds_repr. pts_to uds uds_repr)
 
 assume val get_engine_record ()  // used only for testing a client
   : stt record_t
@@ -54,7 +54,7 @@ fn dpe_client ()
   match sid_opt {
     Some sid -> {
       let uds = get_uds ();
-      with uds_repr. assert (A.pts_to uds uds_repr);
+      with uds_repr. assert (pts_to uds uds_repr);
       unfold (open_session_client_perm (Some sid));
       initialize_context sid _ uds;
       unfold (initialize_context_client_perm sid uds_repr);
@@ -66,10 +66,10 @@ fn dpe_client ()
         unfold (derive_child_client_perm sid t repr true);
         let r = get_l0_record ();
         let hopt = derive_child sid _ r;
-        drop_ (A.pts_to uds uds_repr);
+        drop_ (pts_to uds uds_repr);
         drop_ (derive_child_client_perm _ _ _ _);
       } else {
-        drop_ (A.pts_to uds uds_repr);
+        drop_ (pts_to uds uds_repr);
         drop_ (derive_child_client_perm _ _ _ _)
       }
     }
@@ -90,7 +90,7 @@ fn dpe_client_err ()
   match sid_opt {
     Some sid -> {
       let uds = get_uds ();
-      with uds_repr. assert (A.pts_to uds uds_repr);
+      with uds_repr. assert (pts_to uds uds_repr);
       unfold (open_session_client_perm (Some sid));
       initialize_context sid _ uds;
       unfold (initialize_context_client_perm sid uds_repr);

--- a/share/pulse/examples/dice/dpe/DPE.fsti
+++ b/share/pulse/examples/dice/dpe/DPE.fsti
@@ -384,10 +384,10 @@ val initialize_context (sid:sid_t)
   (uds:A.larray U8.t (SZ.v uds_len)) 
   : stt unit
         (requires
-           A.pts_to uds #p uds_bytes **
+           pts_to uds #p uds_bytes **
            sid_pts_to trace_ref sid t)
         (ensures fun b ->
-           A.pts_to uds #p uds_bytes **
+           pts_to uds #p uds_bytes **
            initialize_context_client_perm sid uds_bytes)
 
 noextract
@@ -465,13 +465,13 @@ val certify_key (sid:sid_t)
         (requires
            sid_pts_to trace_ref sid t **
            (exists* pub_key_repr crt_repr.
-              A.pts_to pub_key pub_key_repr **
-              A.pts_to crt crt_repr))
+              pts_to pub_key pub_key_repr **
+              pts_to crt crt_repr))
         (ensures fun _ ->
            certify_key_client_perm sid t **
            (exists* pub_key_repr crt_repr.
-              A.pts_to pub_key pub_key_repr **
-              A.pts_to crt crt_repr))
+              pts_to pub_key pub_key_repr **
+              pts_to crt crt_repr))
 
 noextract
 let trace_valid_for_sign (t:trace) : prop =
@@ -492,10 +492,10 @@ val sign (sid:sid_t)
         (requires
            sid_pts_to trace_ref sid t **
            (exists* signature_repr msg_repr.
-              A.pts_to signature signature_repr **
-              A.pts_to msg msg_repr))
+              pts_to signature signature_repr **
+              pts_to msg msg_repr))
         (ensures fun _ ->
            certify_key_client_perm sid t **
            (exists* signature_repr msg_repr.
-              A.pts_to signature signature_repr **
-              A.pts_to msg msg_repr))
+              pts_to signature signature_repr **
+              pts_to msg msg_repr))

--- a/share/pulse/examples/dice/dpe/DPETypes.fsti
+++ b/share/pulse/examples/dice/dpe/DPETypes.fsti
@@ -135,7 +135,7 @@ type engine_context_t = {
 }
 
 let engine_context_perm (c:engine_context_t) (uds_bytes:Seq.seq U8.t) : slprop
-  = V.pts_to c.uds uds_bytes ** 
+  = pts_to c.uds uds_bytes ** 
     pure (V.is_full_vec c.uds)
 
 let mk_engine_context_t uds : engine_context_t = {uds}
@@ -167,7 +167,7 @@ let mk_l0_context_repr_t
 = {uds; cdi; repr}
 
 let l0_context_perm (c:l0_context_t) (r:l0_context_repr_t): slprop
-  = V.pts_to c.cdi r.cdi **
+  = pts_to c.cdi r.cdi **
     pure (V.is_full_vec c.cdi)
 
 (* L1 Context *)
@@ -257,11 +257,11 @@ let mk_l1_context_repr_t
 
 let l1_context_perm (c:l1_context_t) (r:l1_context_repr_t)
   : slprop
-  = V.pts_to c.deviceID_pub r.deviceID_pub **
-    V.pts_to c.aliasKey_pub r.aliasKey_pub **
-    V.pts_to c.aliasKey_priv r.aliasKey_priv **
-    V.pts_to c.deviceIDCSR r.deviceIDCSR **
-    V.pts_to c.aliasKeyCRT r.aliasKeyCRT **
+  = pts_to c.deviceID_pub r.deviceID_pub **
+    pts_to c.aliasKey_pub r.aliasKey_pub **
+    pts_to c.aliasKey_priv r.aliasKey_priv **
+    pts_to c.deviceIDCSR r.deviceIDCSR **
+    pts_to c.aliasKeyCRT r.aliasKeyCRT **
     pure (V.is_full_vec c.deviceID_pub /\
           V.is_full_vec c.aliasKey_pub /\
           V.is_full_vec c.aliasKey_priv /\

--- a/share/pulse/examples/dice/dpe/DPE_CBOR.fst
+++ b/share/pulse/examples/dice/dpe/DPE_CBOR.fst
@@ -18,6 +18,7 @@ module DPE_CBOR
 #lang-pulse
 open Pulse.Lib.Pervasives
 open Pulse.Lib.Mutex
+open Pulse.Class.PtsTo
 
 open DPE
 open DPE.Messages.Parse
@@ -55,23 +56,23 @@ fn elim_implies () (#p #q:slprop)
 
 
 fn finish (c:cbor_read_t)
-          (input:_)
+          (input:array U8.t)
           (#p:perm)
           (#v:erased (raw_data_item))
           (#s:erased (Seq.seq U8.t))
           (#rem:erased (Seq.seq U8.t))
   requires ((raw_data_item_match 1.0R c.cbor_read_payload v **
-               A.pts_to c.cbor_read_remainder #p rem) @==>
-              A.pts_to input #p s) **
+               pts_to c.cbor_read_remainder #p rem) @==>
+              pts_to input #p s) **
             raw_data_item_match 1.0R c.cbor_read_payload v **
-            A.pts_to c.cbor_read_remainder #p rem **
+            pts_to c.cbor_read_remainder #p rem **
             'uds_is_enabled
   returns _:bool
-  ensures A.pts_to input #p s
+  ensures pts_to input #p s
 {
    elim_implies ()  #(raw_data_item_match 1.0R c.cbor_read_payload v **
-                            A.pts_to c.cbor_read_remainder #p rem)
-                            #(A.pts_to input #p s);
+                            pts_to c.cbor_read_remainder #p rem)
+                            #(pts_to input #p s);
     drop 'uds_is_enabled;
     false
 }
@@ -86,10 +87,10 @@ fn initialize_context (len:SZ.t)
                       (#s:erased (Seq.seq U8.t))
                       (#p:perm)
     requires
-        A.pts_to input #p s
+        pts_to input #p s
     returns r:bool
     ensures
-        A.pts_to input #p s
+        pts_to input #p s
 {
     let read = parse_dpe_cmd len input;
     match read
@@ -130,8 +131,8 @@ fn initialize_context (len:SZ.t)
                                   pure (DPE.trace_valid_for_initialize_context t));
               with t. assert (DPE.sid_pts_to DPE.trace_ref sid t);
               DPE.initialize_context sid t uds.cbor_string_payload;
-              with p' _vv. assert (A.pts_to uds.cbor_string_payload #p' _vv);
-              elim_stick0 () #(A.pts_to uds.cbor_string_payload #p' _);
+              with p' _vv. assert (pts_to uds.cbor_string_payload #p' _vv);
+              elim_stick0 () #(pts_to uds.cbor_string_payload #p' _);
               elim_stick0 () #(raw_data_item_match 1.0R _ _);
               elim_stick0 ();
               drop_ (initialize_context_client_perm sid _);

--- a/share/pulse/examples/dice/engine/EngineCore.fst
+++ b/share/pulse/examples/dice/engine/EngineCore.fst
@@ -98,14 +98,14 @@ fn compute_cdi
   ([@@@ Rust_mut_binder] record:engine_record_t)
   (#uds_perm #p:perm)
   (#uds_bytes:Ghost.erased (Seq.seq U8.t))
-  requires A.pts_to uds #uds_perm uds_bytes
-        ** A.pts_to cdi 'c0
+  requires pts_to uds #uds_perm uds_bytes
+        ** pts_to cdi 'c0
         ** engine_record_perm record p 'repr
   returns record:engine_record_t
   ensures engine_record_perm record p 'repr
-       ** A.pts_to uds #uds_perm uds_bytes
+       ** pts_to uds #uds_perm uds_bytes
        ** (exists* (c1:Seq.seq U8.t). 
-            A.pts_to cdi c1 **
+            pts_to cdi c1 **
             pure (cdi_functional_correctness c1 uds_bytes 'repr))
 {
   A.pts_to_len uds;
@@ -137,13 +137,13 @@ fn engine_main
   (#repr:Ghost.erased engine_record_repr)
   (#uds_perm #p:perm) (#uds_bytes:Ghost.erased (Seq.seq U8.t))
   requires engine_record_perm record p repr **
-           A.pts_to uds #uds_perm uds_bytes **
-           A.pts_to cdi c0
+           pts_to uds #uds_perm uds_bytes **
+           pts_to cdi c0
   returns  r:(engine_record_t & dice_return_code)
   ensures  engine_record_perm (fst r) p repr **
-           A.pts_to uds #uds_perm uds_bytes **
+           pts_to uds #uds_perm uds_bytes **
           (exists* (c1:Seq.seq U8.t).
-             A.pts_to cdi c1 **
+             pts_to cdi c1 **
              pure (snd r = DICE_SUCCESS ==> l0_is_authentic repr /\ cdi_functional_correctness c1 uds_bytes repr))
 {
   let b = authenticate_l0_image record;

--- a/share/pulse/examples/dice/engine/EngineCore.fsti
+++ b/share/pulse/examples/dice/engine/EngineCore.fsti
@@ -35,12 +35,12 @@ val engine_main (cdi:A.larray U8.t (SZ.v (digest_len dice_hash_alg))) (uds:A.lar
                 (#uds_bytes:Ghost.erased (Seq.seq U8.t))
   : stt (engine_record_t & dice_return_code)
         (engine_record_perm record p repr **
-         A.pts_to uds #uds_perm uds_bytes **
-         A.pts_to cdi c0)
+         pts_to uds #uds_perm uds_bytes **
+         pts_to cdi c0)
         (fun r ->
          engine_record_perm (fst r) p repr **
-         A.pts_to uds #uds_perm uds_bytes **
+         pts_to uds #uds_perm uds_bytes **
          (exists* (c1:Seq.seq U8.t).
-          A.pts_to cdi c1 **
+          pts_to cdi c1 **
           pure (snd r = DICE_SUCCESS ==>
                 l0_is_authentic repr /\ cdi_functional_correctness c1 uds_bytes repr)))

--- a/share/pulse/examples/dice/engine/EngineTypes.fsti
+++ b/share/pulse/examples/dice/engine/EngineTypes.fsti
@@ -55,8 +55,8 @@ let mk_engine_repr  l0_image_header_size l0_image_header l0_image_header_sig
 
 let engine_record_perm (record:engine_record_t) (p:perm) (repr:engine_record_repr)
   : slprop = 
-  V.pts_to record.l0_image_header #p repr.l0_image_header **
-  V.pts_to record.l0_image_header_sig #p repr.l0_image_header_sig **
-  V.pts_to record.l0_binary #p repr.l0_binary **
-  V.pts_to record.l0_binary_hash #p repr.l0_binary_hash **
-  V.pts_to record.l0_image_auth_pubkey #p repr.l0_image_auth_pubkey
+  pts_to record.l0_image_header #p repr.l0_image_header **
+  pts_to record.l0_image_header_sig #p repr.l0_image_header_sig **
+  pts_to record.l0_binary #p repr.l0_binary **
+  pts_to record.l0_binary_hash #p repr.l0_binary_hash **
+  pts_to record.l0_image_auth_pubkey #p repr.l0_image_auth_pubkey

--- a/share/pulse/examples/dice/external/hacl/EverCrypt.Ed25519.fsti
+++ b/share/pulse/examples/dice/external/hacl/EverCrypt.Ed25519.fsti
@@ -35,14 +35,14 @@ val sign:
   -> msg:A.larray U8.t (U32.v msg_len) ->
   stt (squash (Seq.length v_private_key == 32 /\ Seq.length v_msg == U32.v msg_len))
     (requires
-      (exists* v_signature . A.pts_to signature v_signature) **
-      A.pts_to private_key #p_private_key v_private_key **
-      A.pts_to msg #p_msg v_msg
+      (exists* v_signature . pts_to signature v_signature) **
+      pts_to private_key #p_private_key v_private_key **
+      pts_to msg #p_msg v_msg
     )
     (ensures fun _ ->
       A.pts_to signature (spec_ed25519_sign v_private_key v_msg) **
-      A.pts_to private_key #p_private_key v_private_key **
-      A.pts_to msg #p_msg v_msg
+      pts_to private_key #p_private_key v_private_key **
+      pts_to msg #p_msg v_msg
     )
 
 /// From Spec.Ed25519
@@ -68,9 +68,9 @@ val verify:
   -> signature:A.larray U8.t 64 ->
   stt bool
     (requires
-      A.pts_to public_key #p_public_key v_public_key **
-      A.pts_to msg #p_msg v_msg **
-      A.pts_to signature #p_signature v_signature
+      pts_to public_key #p_public_key v_public_key **
+      pts_to msg #p_msg v_msg **
+      pts_to signature #p_signature v_signature
     )
     (ensures fun b ->
       pure (
@@ -79,7 +79,7 @@ val verify:
         Seq.length v_signature == 64 /\
         b == spec_ed25519_verify v_public_key v_msg v_signature
       ) **
-      A.pts_to public_key #p_public_key v_public_key **
-      A.pts_to msg #p_msg v_msg **
-      A.pts_to signature #p_signature v_signature
+      pts_to public_key #p_public_key v_public_key **
+      pts_to msg #p_msg v_msg **
+      pts_to signature #p_signature v_signature
     )

--- a/share/pulse/examples/dice/external/hacl/EverCrypt.HMAC.fsti
+++ b/share/pulse/examples/dice/external/hacl/EverCrypt.HMAC.fsti
@@ -59,14 +59,14 @@ let compute_st (a: H.hash_alg) =
   datalen: U32.t{ U32.v datalen = A.length data } ->
   stt (squash (Seq.length v_key == A.length key /\ Seq.length v_data == A.length data))
   (requires
-    (exists* v_tag . A.pts_to tag v_tag) **
-    A.pts_to key #p_key v_key **
-    A.pts_to data #p_data v_data
+    (exists* v_tag . pts_to tag v_tag) **
+    pts_to key #p_key v_key **
+    pts_to data #p_data v_data
   )
   (ensures fun _ ->
     A.pts_to tag (spec_hmac a v_key v_data) **
-    A.pts_to key #p_key v_key **
-    A.pts_to data #p_data v_data
+    pts_to key #p_key v_key **
+    pts_to data #p_data v_data
   )
 
 /// From EverCrypt.HMAC.compute

--- a/share/pulse/examples/dice/external/hacl/EverCrypt.Hash.Incremental.fsti
+++ b/share/pulse/examples/dice/external/hacl/EverCrypt.Hash.Incremental.fsti
@@ -46,10 +46,10 @@ val hash :
   stt unit
   (requires
     EverCrypt.AutoConfig2.initialized ** // see https://github.com/hacl-star/hacl-star/blob/59723f7dde13bd7b7eb90491f1385b4e3ee2904f/providers/evercrypt/fst/EverCrypt.Hash.Incremental.fst#L292-L294
-    A.pts_to input #p_input v_input **
-      (exists* v_output . A.pts_to output v_output)
+    pts_to input #p_input v_input **
+      (exists* v_output . pts_to output v_output)
   )
   (ensures fun _ ->
     EverCrypt.AutoConfig2.initialized **
-    A.pts_to input #p_input v_input **
-      A.pts_to output (spec_hash a v_input))
+    pts_to input #p_input v_input **
+      pts_to output (spec_hash a v_input))

--- a/share/pulse/examples/dice/external/hacl/HACL.fst
+++ b/share/pulse/examples/dice/external/hacl/HACL.fst
@@ -30,11 +30,11 @@ fn hacl_hash0
               (#psrc:perm)
               (#src_seq #dst_seq:erased (Seq.seq U8.t))
 requires
-    (A.pts_to dst dst_seq **
-     A.pts_to src #psrc src_seq)
+    (pts_to dst dst_seq **
+     pts_to src #psrc src_seq)
 ensures
-       A.pts_to src #psrc src_seq **
-       A.pts_to dst (spec_hash alg src_seq)
+       pts_to src #psrc src_seq **
+       pts_to dst (spec_hash alg src_seq)
 {
   A.pts_to_len src;
   EverCrypt.AutoConfig2.init ();
@@ -67,17 +67,17 @@ fn hacl_hmac0 (alg:alg_t { alg == Spec.Hash.Definitions.sha2_256 })
               (#key_seq:erased (Seq.seq U8.t))
               (#msg_seq:erased (Seq.seq U8.t))
 requires
-    (A.pts_to dst dst_seq **
-     A.pts_to key #pkey key_seq **
-     A.pts_to msg #pmsg msg_seq)
+    (pts_to dst dst_seq **
+     pts_to key #pkey key_seq **
+     pts_to msg #pmsg msg_seq)
 ensures    (
-       A.pts_to key #pkey key_seq **
-       A.pts_to msg #pmsg msg_seq **
-       A.pts_to dst (spec_hmac alg key_seq msg_seq))
+       pts_to key #pkey key_seq **
+       pts_to msg #pmsg msg_seq **
+       pts_to dst (spec_hmac alg key_seq msg_seq))
 {
   let prf = EverCrypt.HMAC.compute alg dst key pkey key_seq (US.sizet_to_uint32 key_len) msg pmsg msg_seq (US.sizet_to_uint32 msg_len);
   rewrite (A.pts_to dst (EverCrypt.HMAC.spec_hmac alg key_seq msg_seq))
-    as (A.pts_to dst (spec_hmac alg key_seq msg_seq))
+    as (pts_to dst (spec_hmac alg key_seq msg_seq))
 }
 
 
@@ -103,15 +103,15 @@ fn ed25519_verify0
   (#ppubk #phdr #psig:perm)
   (#pubk_seq #hdr_seq #sig_seq:erased (Seq.seq U8.t))
 requires
-    (A.pts_to pubk #ppubk pubk_seq **
-     A.pts_to hdr #phdr hdr_seq **
-     A.pts_to sig #psig sig_seq)
+    (pts_to pubk #ppubk pubk_seq **
+     pts_to hdr #phdr hdr_seq **
+     pts_to sig #psig sig_seq)
 returns res: bool
 ensures
     (
-      A.pts_to pubk #ppubk pubk_seq **
-      A.pts_to hdr #phdr hdr_seq **
-      A.pts_to sig #psig sig_seq **
+      pts_to pubk #ppubk pubk_seq **
+      pts_to hdr #phdr hdr_seq **
+      pts_to sig #psig sig_seq **
       pure (res == true <==> spec_ed25519_verify pubk_seq hdr_seq sig_seq)
     )
 {
@@ -140,14 +140,14 @@ fn ed25519_sign0
   (#pprivk #pmsg:perm)
   (#buf0 #privk_seq #msg_seq:erased (Seq.seq U8.t))
 requires
-    (A.pts_to buf buf0 **
-     A.pts_to privk #pprivk privk_seq **
-     A.pts_to msg #pmsg msg_seq)
+    (pts_to buf buf0 **
+     pts_to privk #pprivk privk_seq **
+     pts_to msg #pmsg msg_seq)
 ensures
     (exists* (buf1:Seq.seq U8.t).
-      A.pts_to buf buf1 ** 
-      A.pts_to privk #pprivk privk_seq **
-      A.pts_to msg #pmsg msg_seq **
+      pts_to buf buf1 ** 
+      pts_to privk #pprivk privk_seq **
+      pts_to msg #pmsg msg_seq **
       pure (buf1 `Seq.equal` spec_ed25519_sign privk_seq msg_seq))
 {
   A.pts_to_len privk;

--- a/share/pulse/examples/dice/external/hacl/HACL.fsti
+++ b/share/pulse/examples/dice/external/hacl/HACL.fsti
@@ -68,11 +68,11 @@ val hacl_hash (alg:alg_t)
               (#psrc:perm)
               (#src_seq #dst_seq:erased (Seq.seq U8.t))
   : stt unit
-    (A.pts_to dst dst_seq **
-     A.pts_to src #psrc src_seq)
+    (pts_to dst dst_seq **
+     pts_to src #psrc src_seq)
     (fun _ ->
-       A.pts_to src #psrc src_seq **
-       A.pts_to dst (spec_hash alg src_seq))
+       pts_to src #psrc src_seq **
+       pts_to dst (spec_hash alg src_seq))
 
 noextract [@@noextract_to "krml"]
 val spec_hmac 
@@ -92,13 +92,13 @@ val hacl_hmac (alg:alg_t { alg == Spec.Hash.Definitions.sha2_256 })
               (#key_seq:erased (Seq.seq U8.t))
               (#msg_seq:erased (Seq.seq U8.t))
   : stt unit
-    (A.pts_to dst dst_seq **
-     A.pts_to key #pkey key_seq **
-     A.pts_to msg #pmsg msg_seq)
+    (pts_to dst dst_seq **
+     pts_to key #pkey key_seq **
+     pts_to msg #pmsg msg_seq)
     (fun _ ->
-       A.pts_to key #pkey key_seq **
-       A.pts_to msg #pmsg msg_seq **
-       A.pts_to dst (spec_hmac alg key_seq msg_seq))
+       pts_to key #pkey key_seq **
+       pts_to msg #pmsg msg_seq **
+       pts_to dst (spec_hmac alg key_seq msg_seq))
 
 val spec_ed25519_verify (pubk hdr sig:Seq.seq U8.t) : prop 
 
@@ -110,13 +110,13 @@ val ed25519_verify
   (#ppubk #phdr #psig:perm)
   (#pubk_seq #hdr_seq #sig_seq:erased (Seq.seq U8.t))
   : stt bool
-    (A.pts_to pubk #ppubk pubk_seq **
-     A.pts_to hdr #phdr hdr_seq **
-     A.pts_to sig #psig sig_seq)
+    (pts_to pubk #ppubk pubk_seq **
+     pts_to hdr #phdr hdr_seq **
+     pts_to sig #psig sig_seq)
     (fun res ->
-      A.pts_to pubk #ppubk pubk_seq **
-      A.pts_to hdr #phdr hdr_seq **
-      A.pts_to sig #psig sig_seq **
+      pts_to pubk #ppubk pubk_seq **
+      pts_to hdr #phdr hdr_seq **
+      pts_to sig #psig sig_seq **
       pure (res == true <==> spec_ed25519_verify pubk_seq hdr_seq sig_seq))
 
 noextract [@@noextract_to "krml"]
@@ -130,13 +130,13 @@ val ed25519_sign
   (#pprivk #pmsg:perm)
   (#buf0 #privk_seq #msg_seq:erased (Seq.seq U8.t))
   : stt unit
-    (A.pts_to buf buf0 **
-     A.pts_to privk #pprivk privk_seq **
-     A.pts_to msg #pmsg msg_seq)
+    (pts_to buf buf0 **
+     pts_to privk #pprivk privk_seq **
+     pts_to msg #pmsg msg_seq)
     (fun _ -> exists* (buf1:Seq.seq U8.t).
-      A.pts_to buf buf1 ** 
-      A.pts_to privk #pprivk privk_seq **
-      A.pts_to msg #pmsg msg_seq **
+      pts_to buf buf1 ** 
+      pts_to privk #pprivk privk_seq **
+      pts_to msg #pmsg msg_seq **
       pure (buf1 `Seq.equal` spec_ed25519_sign privk_seq msg_seq))
 
 (* DICE hash constants *)

--- a/share/pulse/examples/dice/external/l0/L0Core.fsti
+++ b/share/pulse/examples/dice/external/l0/L0Core.fsti
@@ -137,26 +137,26 @@ val l0
 
   : stt unit
       (requires
-         A.pts_to cdi cdi_repr **
-         A.pts_to fwid fwid_repr **
-         A.pts_to deviceID_label deviceID_label_repr **
-         A.pts_to aliasKey_label aliasKey_label_repr **
-         A.pts_to deviceID_pub deviceID_pub_repr **
-         A.pts_to aliasKey_pub aliasKey_pub_repr **
-         A.pts_to aliasKey_priv aliasKey_priv_repr **
-         A.pts_to deviceIDCSR_buf deviceIDCSR_buf_repr **
-         A.pts_to aliasKeyCRT_buf aliasKeyCRT_buf_repr)
+         pts_to cdi cdi_repr **
+         pts_to fwid fwid_repr **
+         pts_to deviceID_label deviceID_label_repr **
+         pts_to aliasKey_label aliasKey_label_repr **
+         pts_to deviceID_pub deviceID_pub_repr **
+         pts_to aliasKey_pub aliasKey_pub_repr **
+         pts_to aliasKey_priv aliasKey_priv_repr **
+         pts_to deviceIDCSR_buf deviceIDCSR_buf_repr **
+         pts_to aliasKeyCRT_buf aliasKeyCRT_buf_repr)
       (ensures fun _ ->
-         A.pts_to cdi cdi_repr **
-         A.pts_to fwid fwid_repr **
-         A.pts_to deviceID_label deviceID_label_repr **
-         A.pts_to aliasKey_label aliasKey_label_repr **
+         pts_to cdi cdi_repr **
+         pts_to fwid fwid_repr **
+         pts_to deviceID_label deviceID_label_repr **
+         pts_to aliasKey_label aliasKey_label_repr **
          (exists* deviceID_pub_repr aliasKey_pub_repr aliasKey_priv_repr deviceIDCSR_buf_repr aliasKeyCRT_buf_repr.
-            A.pts_to deviceID_pub deviceID_pub_repr **
-            A.pts_to aliasKey_pub aliasKey_pub_repr **
-            A.pts_to aliasKey_priv aliasKey_priv_repr **
-            A.pts_to deviceIDCSR_buf deviceIDCSR_buf_repr **
-            A.pts_to aliasKeyCRT_buf aliasKeyCRT_buf_repr **
+            pts_to deviceID_pub deviceID_pub_repr **
+            pts_to aliasKey_pub aliasKey_pub_repr **
+            pts_to aliasKey_priv aliasKey_priv_repr **
+            pts_to deviceIDCSR_buf deviceIDCSR_buf_repr **
+            pts_to aliasKeyCRT_buf aliasKeyCRT_buf_repr **
             pure (l0_post
               cdi_repr
               fwid_repr

--- a/share/pulse/examples/dice/l0/L0Types.fsti
+++ b/share/pulse/examples/dice/l0/L0Types.fsti
@@ -70,6 +70,6 @@ let mk_l0_repr fwid deviceID_label aliasKey_label
   = {fwid; deviceID_label; aliasKey_label}
 
 let l0_record_perm (record:l0_record_t) (p:perm) (repr:l0_record_repr_t) : slprop =
-  V.pts_to record.fwid #p repr.fwid **
-  V.pts_to record.deviceID_label #p repr.deviceID_label **
-  V.pts_to record.aliasKey_label #p repr.aliasKey_label
+  pts_to record.fwid #p repr.fwid **
+  pts_to record.deviceID_label #p repr.deviceID_label **
+  pts_to record.aliasKey_label #p repr.aliasKey_label

--- a/share/pulse/examples/parix/ParallelFor.fst
+++ b/share/pulse/examples/parix/ParallelFor.fst
@@ -25,6 +25,7 @@ open Pulse.Lib.Pledge
 open Pulse.Lib.OnRange
 
 module P = Pulse.Lib.Pledge
+module R = Pulse.Lib.Reference
 
 
 ghost
@@ -349,7 +350,7 @@ let wsr_loop_inv_f
   : Tot slprop
   =
   exists* (ii:nat).
-       pts_to i ii
+       R.pts_to i ii
     ** full_post ii
     ** on_range post ii n
     ** pure (b == (Prims.op_LessThan ii n))


### PR DESCRIPTION
By adding a `pulse_unfold` attribute to the `pts_to` method (and the instances), it gets automatically unfolded by the Pulse checker whenever needed, and we can just work with the polymorphic `pts_to`. This PR fixes the class, defines some instances for the pointer-like types in the library, and uses it wherever possible.

There is tension whenever refinements are involved, as usual. See for instance FStarLang/FStar#3534. I think that if that is fixed, this will become quite robust.

The operator `|->` is aliased to `pts_to` (with full permission). However the precedence is wrong: it binds weaker than `**`, so we would require parenthesis everywhere, and hence I didn't use it. I think we should just add configurable mixfix operators to F* to fix this.

Resugaring and context printing do not know about the typeclasses being unfolded, so context dumps are still in the underlying terms (`R.pts_to`, `A.pts_to`, etc). This is sometimes good, sometimes bad. A toggle would be nice, but this is an F* problem.

Note: using typeclasses for Pulse *functions*, instead of just slprops, also somewhat works.