### PR TITLE
Use gensym from F*

### DIFF
--- a/share/pulse/examples/bug-reports/Bug234.fst
+++ b/share/pulse/examples/bug-reports/Bug234.fst
@@ -1,0 +1,18 @@
+module Bug234
+#lang-pulse
+open Pulse
+
+type a =
+type b =
+type c =
+type d =
+type f =
+
+let ok (x:a) (y:b) (z:c) (w:d) (u:f) : slprop =
+  emp
+
+let ty (x:a) (y:b) (z:c) (w:d) = u:f -> stt unit emp (fun r -> ok x y z w u)
+
+fn foo x y z w : ty x y z w  = u {
+  fold ok x y z w u;
+}

--- a/src/checker/Pulse.Checker.Base.fst
+++ b/src/checker/Pulse.Checker.Base.fst
@@ -285,7 +285,7 @@ let st_equiv_post (#g:env) (#t:st_term) (#c:comp_st) (d:st_typing g t c)
                          slprop_equiv (push_binding g x ppname_default (comp_res c)) 
                                      (open_term (comp_post c) x)
                                      (open_term post x)))
-  : st_typing g t (comp_st_with_post c post)
+  : Dv (st_typing g t (comp_st_with_post c post))
   = if eq_tm post (comp_post c) then d
     else
       let c' = comp_st_with_post c post in
@@ -298,7 +298,7 @@ let st_equiv_post (#g:env) (#t:st_term) (#c:comp_st) (d:st_typing g t c)
 
 let simplify_post (#g:env) (#t:st_term) (#c:comp_st) (d:st_typing g t c)
                   (post:term { comp_post c == tm_star post tm_emp})
-  : st_typing g t (comp_st_with_post c post)
+  : Dv (st_typing g t (comp_st_with_post c post))
   = st_equiv_post d post (fun x -> ve_unit_r (push_binding g x ppname_default (comp_res c)) (open_term post x))
 
 let simplify_lemma (c:comp_st) (c':comp_st) (post_hint:option post_hint_t)
@@ -329,7 +329,7 @@ let comp_with_pre (c:comp_st) (pre:term) =
 let st_equiv_pre (#g:env) (#t:st_term) (#c:comp_st) (d:st_typing g t c)
                  (pre:term)
                  (veq: slprop_equiv g (comp_pre c) pre)
-  : st_typing g t (comp_with_pre c pre)
+  : Dv (st_typing g t (comp_with_pre c pre))
   = if eq_tm pre (comp_pre c) then d
     else
       let c' = comp_with_pre c pre in
@@ -476,7 +476,7 @@ let st_comp_typing_with_post_hint
       (ctxt_typing:tot_typing g ctxt tm_slprop)
       (post_hint:post_hint_opt g { Some? post_hint })
       (c:comp_st { comp_pre c == ctxt /\ comp_post_matches_hint c post_hint })
-: st_comp_typing g (st_comp_of_comp c)
+: Dv (st_comp_typing g (st_comp_of_comp c))
 = let st = st_comp_of_comp c in
   let Some ph = post_hint in
   let post_typing_src
@@ -582,7 +582,7 @@ let emp_inames_included (g:env) (i:term) (_:tot_typing g i tm_inames)
 let return_in_ctxt (g:env) (y:var) (y_ppname:ppname) (u:universe) (ty:term) (ctxt:slprop)
   (ty_typing:universe_of g ty u)
   (post_hint0:post_hint_opt g { Some? post_hint0 /\ checker_res_matches_post_hint g post_hint0 y ty ctxt})
-: Pure (st_typing_in_ctxt g ctxt post_hint0)
+: Div  (st_typing_in_ctxt g ctxt post_hint0)
        (requires lookup g y == Some ty)
        (ensures fun _ -> True)
 = let Some post_hint = post_hint0 in

--- a/src/checker/Pulse.Checker.Exists.fst
+++ b/src/checker/Pulse.Checker.Exists.fst
@@ -123,7 +123,8 @@ let check_intro_exists
   let Tm_ExistsSL u b p = tv in
 
   Pulse.Typing.FV.tot_typing_freevars t_typing;
-  let ty_typing, _ = Metatheory.tm_exists_inversion #g #u #b.binder_ty #p t_typing (fresh g) in
+  let x = fresh g in
+  let ty_typing, _ = Metatheory.tm_exists_inversion #g #u #b.binder_ty #p t_typing x in
   let (| witness, witness_typing |) = 
     check_term g witness T.E_Ghost b.binder_ty in
   let d = T_IntroExists g u b p witness ty_typing t_typing witness_typing in

--- a/src/checker/Pulse.Checker.STApp.fst
+++ b/src/checker/Pulse.Checker.STApp.fst
@@ -44,7 +44,7 @@ let canon_comp_eq_res (g:env) (c:comp_st)
 #pop-options
 
 let canonicalize_st_typing (#g:env) (#t:st_term) (#c:comp_st) (d:st_typing g t c)
-  : st_typing g t (canon_comp c)
+  : Dv (st_typing g t (canon_comp c))
   = let c' = canon_comp c in
     let x = fresh g in
     assume ( ~(x `Set.mem` freevars (comp_post c)) /\

--- a/src/checker/Pulse.Checker.While.fst
+++ b/src/checker/Pulse.Checker.While.fst
@@ -29,12 +29,12 @@ module RU = Pulse.RuntimeUtils
 
 let while_cond_comp_typing (#g:env) (u:universe) (x:ppname) (ty:term) (inv_body:term)
                            (inv_typing:tot_typing g (tm_exists_sl u (as_binder ty) inv_body) tm_slprop)
-  : comp_typing_u g (comp_while_cond x inv_body)
+  : Dv (comp_typing_u g (comp_while_cond x inv_body))
   = Metatheory.admit_comp_typing g (comp_while_cond x inv_body)
 
 let while_body_comp_typing (#g:env) (u:universe) (x:ppname) (ty:term) (inv_body:term)
                            (inv_typing:tot_typing g (tm_exists_sl u (as_binder ty) inv_body) tm_slprop)
-  : comp_typing_u g (comp_while_body x inv_body)
+  : Dv (comp_typing_u g (comp_while_body x inv_body))
   = Metatheory.admit_comp_typing g (comp_while_body x inv_body)
 
 #push-options "--fuel 0 --ifuel 1 --z3rlimit_factor 4"

--- a/src/checker/Pulse.RuntimeUtils.fsti
+++ b/src/checker/Pulse.RuntimeUtils.fsti
@@ -27,6 +27,7 @@ val print_context (c:context) : T.Tac string
 val debug_at_level_no_module (s:string) : bool
 val debug_at_level (g:env) (s:string) : bool
 val print_exn (e:exn) : string
+val next_id () : Dv nat
 val bv_set_range (x:bv) (r:range) : b:bv{b==x}
 val bv_range (x:bv) : range
 val binder_set_range (x:binder) (r:range) : b:binder{b==x}

--- a/src/checker/Pulse.Typing.Combinators.fst
+++ b/src/checker/Pulse.Typing.Combinators.fst
@@ -458,7 +458,7 @@ let apply_frame (#g:env)
                 (#c:comp { stateful_comp c })
                 (t_typing: st_typing g t c)
                 (frame_t:frame_for_req_in_ctxt g ctxt (comp_pre c))
-  : Tot (c':comp_st { comp_pre c' == ctxt /\
+  : Dv  (c':comp_st { comp_pre c' == ctxt /\
                       comp_res c' == comp_res c /\
                       comp_u c' == comp_u c /\
                       comp_post c' == tm_star (comp_post c) (frame_of frame_t) } &

--- a/src/checker/Pulse.Typing.Combinators.fsti
+++ b/src/checker/Pulse.Typing.Combinators.fsti
@@ -93,7 +93,7 @@ val apply_frame (#g:env)
                 (#c:comp { stateful_comp c })
                 (t_typing: st_typing g t c)
                 (frame_t:frame_for_req_in_ctxt g ctxt (comp_pre c))
-  : Tot (c':comp_st { comp_pre c' == ctxt /\
+  : Dv  (c':comp_st { comp_pre c' == ctxt /\
                       comp_res c' == comp_res c /\
                       comp_u c' == comp_u c /\
                       comp_post c' == tm_star (comp_post c) (frame_of frame_t) } &

--- a/src/checker/Pulse.Typing.Env.fst
+++ b/src/checker/Pulse.Typing.Env.fst
@@ -96,20 +96,10 @@ let push_binding_bs _ _ _ _ = ()
 
 let push_binding_as_map _ _ _ _ = ()
 
-let rec max (bs:list (var & typ)) (current:var)
-  : v:var { current <= v /\ (forall (b:var & typ). List.Tot.memP b bs ==> fst b <= v) } =
-  match bs with
-  | [] -> current
-  | (x, t)::rest ->
-    let current = if x < current then current else x in
-    max rest current
-
 let fresh g =
-  match g.bs with
-  | [] -> 1
-  | (x, _)::bs_rest ->
-    let max = max bs_rest x in
-    max + 1
+  let v = RU.next_id () in
+  assume ~(v `Set.mem` dom g);
+  v
 
 //
 // TODO: Move to ulib

--- a/src/checker/Pulse.Typing.Env.fsti
+++ b/src/checker/Pulse.Typing.Env.fsti
@@ -93,7 +93,7 @@ let lookup (g:env) (x:var) : option typ =
   let m = as_map g in
   if Map.contains m x then Some (Map.sel m x) else None
 
-val fresh (g:env) : v:var { ~ (Set.mem v (dom g)) }
+val fresh (g:env) : Dv (v:var { ~ (Set.mem v (dom g)) })
 
 let contains (g:env) (x:var) = Map.contains (as_map g) x
 

--- a/src/checker/Pulse.Typing.Metatheory.Base.fst
+++ b/src/checker/Pulse.Typing.Metatheory.Base.fst
@@ -23,12 +23,13 @@ module T = FStar.Tactics.V2
 module RT = FStar.Reflection.Typing
 
 let admit_st_comp_typing (g:env) (st:st_comp) 
-  : st_comp_typing g st
+  : Dv (st_comp_typing g st)
   = admit(); 
-    STC g st (fresh g) (admit()) (admit()) (admit())
+    let x = fresh g in
+    STC g st x (admit()) (admit()) (admit())
 
 let admit_comp_typing (g:env) (c:comp_st)
-  : comp_typing_u g c
+  : Dv (comp_typing_u g c)
   = match c with
     | C_ST st ->
       CT_ST g st (admit_st_comp_typing g st)
@@ -46,12 +47,12 @@ let st_typing_correctness_ctot (#g:env) (#t:st_term) (#c:comp{C_Tot? c})
 
 let st_typing_correctness (#g:env) (#t:st_term) (#c:comp_st) 
                           (_:st_typing g t c)
-  : comp_typing_u g c
+  : Dv (comp_typing_u g c)
   = admit_comp_typing g c
     
 let add_frame_well_typed (#g:env) (#c:comp_st) (ct:comp_typing_u g c)
                          (#f:term) (ft:tot_typing g f tm_slprop)
-  : comp_typing_u g (add_frame c f)
+  : Dv (comp_typing_u g (add_frame c f))
   = admit_comp_typing _ _
 
 let emp_inames_typing (g:env) : tot_typing g tm_emp_inames tm_inames = RU.magic()
@@ -100,7 +101,7 @@ let non_informative_c_weakening (g g':env) (g1:env{ pairwise_disjoint g g1 g' })
 let bind_comp_weakening (g:env) (g':env { disjoint g g' })
   (#x:var) (#c1 #c2 #c3:comp) (d:bind_comp (push_env g g') x c1 c2 c3)
   (g1:env { pairwise_disjoint g g1 g' })
-  : Tot (bind_comp (push_env (push_env g g1) g') x c1 c2 c3)
+  : Dv (bind_comp (push_env (push_env g g1) g') x c1 c2 c3)
         (decreases d) =
   
   match d with
@@ -187,7 +188,7 @@ let comp_typing_weakening (g:env) (g':env { disjoint g g' })
 
 #push-options "--split_queries no --z3rlimit_factor 8 --fuel 1 --ifuel 1"
 let rec st_typing_weakening g g' t c d g1
-  : Tot (st_typing (push_env (push_env g g1) g') t c)
+  : Dv (st_typing (push_env (push_env g g1) g') t c)
         (decreases d) =
   
   match d with

--- a/src/checker/Pulse.Typing.Metatheory.Base.fsti
+++ b/src/checker/Pulse.Typing.Metatheory.Base.fsti
@@ -32,7 +32,7 @@ open FStar.Ghost
 
 
 val admit_comp_typing (g:env) (c:comp_st)
-  : comp_typing_u g c
+  : Dv (comp_typing_u g c)
 
 let rt_equiv_typing (#g:_) (#t0 #t1:_) (d:RT.equiv g t0 t1)
                     (#k:_)
@@ -54,7 +54,7 @@ let iname_typing (g:env) (c:comp_st) = tot_typing g (inames_of_comp_st c) tm_ina
 
 val st_typing_correctness (#g:env) (#t:st_term) (#c:comp_st) 
                           (d:st_typing g t c)
-  : comp_typing_u g c
+  : Dv (comp_typing_u g c)
   
 val comp_typing_inversion (#g:env) (#c:comp_st) (ct:comp_typing_u g c)
   : st_comp_typing g (st_comp_of_comp c) & iname_typing g c
@@ -109,7 +109,7 @@ val st_typing_weakening
   (g:env) (g':env { disjoint g g' })
   (t:st_term) (c:comp) (_:st_typing (push_env g g') t c)
   (g1:env { pairwise_disjoint g g1 g' })
-  : st_typing (push_env (push_env g g1) g') t c
+  : Dv (st_typing (push_env (push_env g g1) g') t c)
 
 let veq_weakening
   (g:env) (g':env { disjoint g g' })

--- a/src/checker/Pulse.Typing.Metatheory.fst
+++ b/src/checker/Pulse.Typing.Metatheory.fst
@@ -41,7 +41,7 @@ let st_typing_weakening
   (g:env) (g':env { disjoint g g' })
   (t:st_term) (c:comp) (d:st_typing (push_env g g') t c)
   (g1:env { g1 `env_extends` g /\ disjoint g1 g' })
-  : st_typing (push_env g1 g') t c =
+  : Dv (st_typing (push_env g1 g') t c) =
 
   let g2 = diff g1 g in
   let d = st_typing_weakening g g' t c d g2 in
@@ -51,7 +51,7 @@ let st_typing_weakening
 let st_typing_weakening_standard
   (#g:env) (#t:st_term) (#c:comp) (d:st_typing g t c)
   (g1:env { g1 `env_extends` g })
-  : st_typing g1 t c =
+  : Dv (st_typing g1 t c) =
 
   let g' = mk_env (fstar_env g) in
   assert (equal (push_env g g') g);
@@ -63,7 +63,7 @@ let st_typing_weakening_end
   (g:env) (g':env { disjoint g g' })
   (t:st_term) (c:comp) (d:st_typing (push_env g g') t c)
   (g'':env { g'' `env_extends` g' /\ disjoint g'' g })
-  : st_typing (push_env g g'') t c =
+  : Dv (st_typing (push_env g g'') t c) =
 
   let g2 = diff g'' g' in
   let emp_env = mk_env (fstar_env g) in

--- a/src/checker/Pulse.Typing.Metatheory.fsti
+++ b/src/checker/Pulse.Typing.Metatheory.fsti
@@ -37,18 +37,18 @@ val st_typing_weakening
   (g:env) (g':env { disjoint g g' })
   (t:st_term) (c:comp) (d:st_typing (push_env g g') t c)
   (g1:env { g1 `env_extends` g /\ disjoint g1 g' })
-  : st_typing (push_env g1 g') t c
+  : Dv (st_typing (push_env g1 g') t c)
 
 val st_typing_weakening_standard
   (#g:env) (#t:st_term) (#c:comp) (d:st_typing g t c)
   (g1:env { g1 `env_extends` g })
-  : st_typing g1 t c
+  : Dv (st_typing g1 t c)
 
 val st_typing_weakening_end
   (g:env) (g':env { disjoint g g' })
   (t:st_term) (c:comp) (d:st_typing (push_env g g') t c)
   (g'':env { g'' `env_extends` g' /\ disjoint g'' g })
-  : st_typing (push_env g g'') t c
+  : Dv (st_typing (push_env g g'') t c)
 
 val veq_weakening
   (g:env) (g':env { disjoint g g' })

--- a/src/ocaml/plugin/Pulse_RuntimeUtils.ml
+++ b/src/ocaml/plugin/Pulse_RuntimeUtils.ml
@@ -47,6 +47,7 @@ let debug_at_level (g:FStar_Reflection_Types.env) (s:string) =
   let r = FStar_Compiler_Debug.get_toggle s in
   !r
 
+let next_id () = FStar_GenSym.next_id ()
 let bv_set_range (bv:FStar_Syntax_Syntax.bv) (r:FStar_Range.range) = FStar_Syntax_Syntax.set_range_of_bv bv r
 let bv_range (bv:FStar_Syntax_Syntax.bv) = FStar_Syntax_Syntax.range_of_bv bv
 let binder_set_range (b:FStar_Syntax_Syntax.binder) (r:FStar_Range.range) =

--- a/src/ocaml/plugin/generated/Pulse_Checker.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker.ml
@@ -53,19 +53,18 @@ let rec (gen_names_for_unknowns :
                                        match Pulse_Syntax_Pure.inspect_term w
                                        with
                                        | Pulse_Syntax_Pure.Tm_Unknown ->
-                                           ((FStar_Pervasives_Native.Some
-                                               (Pulse_Typing_Env.fresh g)),
+                                           let x = Pulse_Typing_Env.fresh g in
+                                           ((FStar_Pervasives_Native.Some x),
                                              (Pulse_Syntax_Pure.tm_var
                                                 {
                                                   Pulse_Syntax_Base.nm_index
-                                                    =
-                                                    (Pulse_Typing_Env.fresh g);
+                                                    = x;
                                                   Pulse_Syntax_Base.nm_ppname
                                                     =
                                                     (b.Pulse_Syntax_Base.binder_ppname)
                                                 }),
                                              (Pulse_Typing_Env.push_binding g
-                                                (Pulse_Typing_Env.fresh g)
+                                                x
                                                 b.Pulse_Syntax_Base.binder_ppname
                                                 b.Pulse_Syntax_Base.binder_ty))
                                        | uu___3 ->

--- a/src/ocaml/plugin/generated/Pulse_Checker_Base.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Base.ml
@@ -1034,10 +1034,12 @@ let (extend_post_hint :
                            Obj.magic
                              (FStar_Tactics_Effect.lift_div_tac
                                 (fun uu___ ->
+                                   let g' =
+                                     Pulse_Typing_Env.push_binding g x
+                                       Pulse_Syntax_Base.ppname_default tx in
+                                   let y = Pulse_Typing_Env.fresh g' in
                                    {
-                                     Pulse_Typing.g =
-                                       (Pulse_Typing_Env.push_binding g x
-                                          Pulse_Syntax_Base.ppname_default tx);
+                                     Pulse_Typing.g = g';
                                      Pulse_Typing.effect_annot =
                                        (p.Pulse_Typing.effect_annot);
                                      Pulse_Typing.effect_annot_typing =
@@ -1049,11 +1051,7 @@ let (extend_post_hint :
                                      Pulse_Typing.post =
                                        (Pulse_Syntax_Pure.tm_star
                                           p.Pulse_Typing.post conjunct);
-                                     Pulse_Typing.x =
-                                       (Pulse_Typing_Env.fresh
-                                          (Pulse_Typing_Env.push_binding g x
-                                             Pulse_Syntax_Base.ppname_default
-                                             tx));
+                                     Pulse_Typing.x = y;
                                      Pulse_Typing.post_typing_src = ();
                                      Pulse_Typing.post_typing = ()
                                    }))) uu___5 uu___4 uu___3 uu___2 uu___1
@@ -1241,13 +1239,16 @@ let (st_equiv_post :
               else
                 (let c' = comp_st_with_post c post in
                  let uu___1 =
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 =
+                         Pulse_Typing_Metatheory_Base.st_typing_correctness g
+                           t c d in
+                       Pulse_Typing_Metatheory_Base.comp_typing_inversion g c
+                         uu___4 in
+                     FStar_Pervasives_Native.fst uu___3 in
                    Pulse_Typing_Metatheory_Base.st_comp_typing_inversion g
-                     (Pulse_Syntax_Base.st_comp_of_comp c)
-                     (FStar_Pervasives_Native.fst
-                        (Pulse_Typing_Metatheory_Base.comp_typing_inversion g
-                           c
-                           (Pulse_Typing_Metatheory_Base.st_typing_correctness
-                              g t c d))) in
+                     (Pulse_Syntax_Base.st_comp_of_comp c) uu___2 in
                  match uu___1 with
                  | FStar_Pervasives.Mkdtuple4
                      (u_of, pre_typing, x, post_typing) ->
@@ -1321,13 +1322,16 @@ let (st_equiv_pre :
               else
                 (let c' = comp_with_pre c pre in
                  let uu___1 =
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 =
+                         Pulse_Typing_Metatheory_Base.st_typing_correctness g
+                           t c d in
+                       Pulse_Typing_Metatheory_Base.comp_typing_inversion g c
+                         uu___4 in
+                     FStar_Pervasives_Native.fst uu___3 in
                    Pulse_Typing_Metatheory_Base.st_comp_typing_inversion g
-                     (Pulse_Syntax_Base.st_comp_of_comp c)
-                     (FStar_Pervasives_Native.fst
-                        (Pulse_Typing_Metatheory_Base.comp_typing_inversion g
-                           c
-                           (Pulse_Typing_Metatheory_Base.st_typing_correctness
-                              g t c d))) in
+                     (Pulse_Syntax_Base.st_comp_of_comp c) uu___2 in
                  match uu___1 with
                  | FStar_Pervasives.Mkdtuple4
                      (u_of, pre_typing, x, post_typing) ->
@@ -1500,13 +1504,16 @@ let (k_elab_equiv_prefix :
                                  (fun res1 ->
                                     FStar_Tactics_Effect.lift_div_tac
                                       (fun uu___2 ->
-                                         match res1 with
+                                         let uu___3 = res1 in
+                                         match uu___3 with
                                          | FStar_Pervasives.Mkdtuple3
                                              (st, c, st_d) ->
+                                             let uu___4 =
+                                               st_equiv_pre g1 st c st_d
+                                                 ctxt2 () in
                                              FStar_Pervasives.Mkdtuple3
                                                (st, (comp_with_pre c ctxt2),
-                                                 (st_equiv_pre g1 st c st_d
-                                                    ctxt2 ())))))) uu___1)
+                                                 uu___4))))) uu___1)
 let (k_elab_equiv :
   Pulse_Typing_Env.env ->
     Pulse_Typing_Env.env ->
@@ -1560,39 +1567,50 @@ let (continuation_elaborator_with_bind :
                                Obj.magic
                                  (FStar_Tactics_Effect.lift_div_tac
                                     (fun uu___ ->
-                                       match Pulse_Typing_Combinators.apply_frame
-                                               g e1
-                                               (Pulse_Syntax_Pure.tm_star
-                                                  ctxt
-                                                  (Pulse_Syntax_Base.comp_pre
-                                                     c1)) () c1 e1_typing
-                                               (FStar_Pervasives.Mkdtuple3
-                                                  (ctxt, (), ()))
-                                       with
+                                       let pre1 =
+                                         Pulse_Syntax_Base.comp_pre c1 in
+                                       let res1 =
+                                         Pulse_Syntax_Base.comp_res c1 in
+                                       let post1 =
+                                         Pulse_Syntax_Base.comp_post c1 in
+                                       let framing_token =
+                                         FStar_Pervasives.Mkdtuple3
+                                           (ctxt, (), ()) in
+                                       let uu___1 =
+                                         Pulse_Typing_Combinators.apply_frame
+                                           g e1
+                                           (Pulse_Syntax_Pure.tm_star ctxt
+                                              (Pulse_Syntax_Base.comp_pre c1))
+                                           () c1 e1_typing framing_token in
+                                       match uu___1 with
                                        | Prims.Mkdtuple2 (c11, e1_typing1) ->
-                                           (match Pulse_Typing_Metatheory_Base.st_comp_typing_inversion
-                                                    g
-                                                    (Pulse_Syntax_Base.st_comp_of_comp
-                                                       c11)
-                                                    (FStar_Pervasives_Native.fst
-                                                       (Pulse_Typing_Metatheory_Base.comp_typing_inversion
-                                                          g c11
-                                                          (Pulse_Typing_Metatheory_Base.st_typing_correctness
-                                                             g e1 c11
-                                                             e1_typing1)))
-                                            with
+                                           let uu___2 =
+                                             let uu___3 =
+                                               let uu___4 =
+                                                 let uu___5 =
+                                                   Pulse_Typing_Metatheory_Base.st_typing_correctness
+                                                     g e1 c11 e1_typing1 in
+                                                 Pulse_Typing_Metatheory_Base.comp_typing_inversion
+                                                   g c11 uu___5 in
+                                               FStar_Pervasives_Native.fst
+                                                 uu___4 in
+                                             Pulse_Typing_Metatheory_Base.st_comp_typing_inversion
+                                               g
+                                               (Pulse_Syntax_Base.st_comp_of_comp
+                                                  c11) uu___3 in
+                                           (match uu___2 with
                                             | FStar_Pervasives.Mkdtuple4
-                                                (u_of_1, pre_typing, uu___1,
-                                                 uu___2)
+                                                (u_of_1, pre_typing, uu___3,
+                                                 uu___4)
                                                 ->
                                                 (match x with
                                                  | (ppname, x1) ->
                                                      (fun post_hint ->
                                                         fun res ->
-                                                          let uu___3 =
+                                                          let uu___5 =
                                                             Obj.magic
                                                               (FStar_Tactics_Effect.lift_div_tac
-                                                                 (fun uu___4
+                                                                 (fun uu___6
                                                                     -> res)) in
                                                           FStar_Tactics_Effect.tac_bind
                                                             (FStar_Sealed.seal
@@ -1611,21 +1629,21 @@ let (continuation_elaborator_with_bind :
                                                                     (Prims.of_int (24))
                                                                     (Prims.of_int (464))
                                                                     (Prims.of_int (5)))))
-                                                            (Obj.magic uu___3)
-                                                            (fun uu___4 ->
-                                                               (fun uu___4 ->
-                                                                  match uu___4
+                                                            (Obj.magic uu___5)
+                                                            (fun uu___6 ->
+                                                               (fun uu___6 ->
+                                                                  match uu___6
                                                                   with
                                                                   | FStar_Pervasives.Mkdtuple3
                                                                     (e2, c2,
                                                                     e2_typing)
                                                                     ->
-                                                                    let uu___5
+                                                                    let uu___7
                                                                     =
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___8 ->
                                                                     e2_typing)) in
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1646,18 +1664,18 @@ let (continuation_elaborator_with_bind :
                                                                     (Prims.of_int (464))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
-                                                                    uu___5)
+                                                                    uu___7)
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___8 ->
                                                                     (fun
                                                                     e2_typing1
                                                                     ->
-                                                                    let uu___6
+                                                                    let uu___8
                                                                     =
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___7 ->
+                                                                    uu___9 ->
                                                                     Pulse_Syntax_Naming.close_st_term
                                                                     e2 x1)) in
                                                                     Obj.magic
@@ -1679,9 +1697,9 @@ let (continuation_elaborator_with_bind :
                                                                     (Prims.of_int (464))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
-                                                                    uu___6)
+                                                                    uu___8)
                                                                     (fun
-                                                                    uu___7 ->
+                                                                    uu___9 ->
                                                                     (fun
                                                                     e2_closed
                                                                     ->
@@ -1697,12 +1715,11 @@ let (continuation_elaborator_with_bind :
                                                                     (Pulse_Typing_Env.push_binding
                                                                     g x1
                                                                     ppname
-                                                                    (Pulse_Syntax_Base.comp_res
-                                                                    c1))
+                                                                    res1)
                                                                     FStar_Pervasives_Native.None
                                                                     "Impossible: freevar clash when constructing continuation elaborator for bind, please file a bug-report")
                                                                     else
-                                                                    (let uu___8
+                                                                    (let uu___10
                                                                     =
                                                                     Pulse_Typing_Combinators.bind_res_and_post_typing
                                                                     g c2 x1
@@ -1726,23 +1743,25 @@ let (continuation_elaborator_with_bind :
                                                                     (Prims.of_int (464))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
-                                                                    uu___8)
+                                                                    uu___10)
                                                                     (fun
-                                                                    uu___9 ->
+                                                                    uu___11
+                                                                    ->
                                                                     (fun
-                                                                    uu___9 ->
-                                                                    match uu___9
+                                                                    uu___11
+                                                                    ->
+                                                                    match uu___11
                                                                     with
                                                                     | 
                                                                     (t_typing,
                                                                     post_typing)
                                                                     ->
-                                                                    let uu___10
+                                                                    let uu___12
                                                                     =
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___13
                                                                     ->
                                                                     Pulse_Typing_Env.push_context
                                                                     g
@@ -1767,20 +1786,19 @@ let (continuation_elaborator_with_bind :
                                                                     (Prims.of_int (463))
                                                                     (Prims.of_int (26)))))
                                                                     (Obj.magic
-                                                                    uu___10)
+                                                                    uu___12)
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___13
                                                                     ->
                                                                     (fun g1
                                                                     ->
-                                                                    let uu___11
+                                                                    let uu___13
                                                                     =
                                                                     Pulse_Typing_Combinators.mk_bind
                                                                     g1
                                                                     (Pulse_Syntax_Pure.tm_star
-                                                                    ctxt
-                                                                    (Pulse_Syntax_Base.comp_pre
-                                                                    c1)) e1
+                                                                    ctxt pre1)
+                                                                    e1
                                                                     e2_closed
                                                                     c11 c2
                                                                     (ppname,
@@ -1809,15 +1827,15 @@ let (continuation_elaborator_with_bind :
                                                                     (Prims.of_int (463))
                                                                     (Prims.of_int (26)))))
                                                                     (Obj.magic
-                                                                    uu___11)
+                                                                    uu___13)
                                                                     (fun
-                                                                    uu___12
+                                                                    uu___14
                                                                     ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___13
+                                                                    uu___15
                                                                     ->
-                                                                    match uu___12
+                                                                    match uu___14
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives.Mkdtuple3
@@ -1827,11 +1845,11 @@ let (continuation_elaborator_with_bind :
                                                                     FStar_Pervasives.Mkdtuple3
                                                                     (e, c,
                                                                     e_typing)))))
-                                                                    uu___11)))
-                                                                    uu___9))))
-                                                                    uu___7)))
-                                                                    uu___6)))
-                                                                 uu___4)))))))
+                                                                    uu___13)))
+                                                                    uu___11))))
+                                                                    uu___9)))
+                                                                    uu___8)))
+                                                                 uu___6)))))))
                   uu___6 uu___5 uu___4 uu___3 uu___2 uu___1 uu___
 let coerce_eq : 'a 'b . 'a -> unit -> 'b =
   fun uu___1 -> fun uu___ -> (fun x -> fun uu___ -> Obj.magic x) uu___1 uu___
@@ -2083,14 +2101,15 @@ let (continuation_elaborator_with_bind_fn :
                                                                     (fun
                                                                     uu___11
                                                                     ->
+                                                                    let stc =
+                                                                    st_comp_typing_with_post_hint
+                                                                    g ctxt ()
+                                                                    post_hint
+                                                                    c2 in
                                                                     Pulse_Typing.CT_ST
                                                                     (g,
                                                                     (Pulse_Syntax_Base.st_comp_of_comp
-                                                                    c2),
-                                                                    (st_comp_typing_with_post_hint
-                                                                    g ctxt ()
-                                                                    post_hint
-                                                                    c2)))))
+                                                                    c2), stc))))
                                                                     | 
                                                                     Pulse_Syntax_Base.C_STAtomic
                                                                     (i, obs,
@@ -2197,8 +2216,8 @@ let (continuation_elaborator_with_bind_fn :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Base.fst"
-                                                                    (Prims.of_int (556))
-                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (554))
+                                                                    (Prims.of_int (68))
                                                                     (Prims.of_int (556))
                                                                     (Prims.of_int (37)))))
                                                                     (Obj.magic
@@ -2210,14 +2229,16 @@ let (continuation_elaborator_with_bind_fn :
                                                                     (fun
                                                                     uu___12
                                                                     ->
+                                                                    let stc =
+                                                                    st_comp_typing_with_post_hint
+                                                                    g ctxt ()
+                                                                    post_hint
+                                                                    c2 in
                                                                     Pulse_Typing.CT_STGhost
                                                                     (g, i,
                                                                     (Pulse_Syntax_Base.st_comp_of_comp
                                                                     c2), (),
-                                                                    (st_comp_typing_with_post_hint
-                                                                    g ctxt ()
-                                                                    post_hint
-                                                                    c2)))))) in
+                                                                    stc))))) in
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
@@ -2696,16 +2717,53 @@ let (match_comp_res_with_post_hint :
                                                                     (fun
                                                                     uu___13
                                                                     ->
-                                                                    match 
+                                                                    let d_equiv
+                                                                    =
+                                                                    FStar_Reflection_Typing.Rel_eq_token
+                                                                    ((Pulse_Typing.elab_env
+                                                                    g), cres,
+                                                                    ret_ty,
+                                                                    ()) in
+                                                                    let c' =
+                                                                    Pulse_Syntax_Base.with_st_comp
+                                                                    c
+                                                                    {
+                                                                    Pulse_Syntax_Base.u
+                                                                    =
+                                                                    ((Pulse_Syntax_Base.st_comp_of_comp
+                                                                    c).Pulse_Syntax_Base.u);
+                                                                    Pulse_Syntax_Base.res
+                                                                    = ret_ty;
+                                                                    Pulse_Syntax_Base.pre
+                                                                    =
+                                                                    ((Pulse_Syntax_Base.st_comp_of_comp
+                                                                    c).Pulse_Syntax_Base.pre);
+                                                                    Pulse_Syntax_Base.post
+                                                                    =
+                                                                    ((Pulse_Syntax_Base.st_comp_of_comp
+                                                                    c).Pulse_Syntax_Base.post)
+                                                                    } in
+                                                                    let uu___14
+                                                                    =
+                                                                    let uu___15
+                                                                    =
+                                                                    let uu___16
+                                                                    =
+                                                                    let uu___17
+                                                                    =
+                                                                    Pulse_Typing_Metatheory_Base.st_typing_correctness
+                                                                    g t c d in
+                                                                    Pulse_Typing_Metatheory_Base.comp_typing_inversion
+                                                                    g c
+                                                                    uu___17 in
+                                                                    FStar_Pervasives_Native.fst
+                                                                    uu___16 in
                                                                     Pulse_Typing_Metatheory_Base.st_comp_typing_inversion
                                                                     g
                                                                     (Pulse_Syntax_Base.st_comp_of_comp
                                                                     c)
-                                                                    (FStar_Pervasives_Native.fst
-                                                                    (Pulse_Typing_Metatheory_Base.comp_typing_inversion
-                                                                    g c
-                                                                    (Pulse_Typing_Metatheory_Base.st_typing_correctness
-                                                                    g t c d)))
+                                                                    uu___15 in
+                                                                    match uu___14
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives.Mkdtuple4
@@ -2715,73 +2773,17 @@ let (match_comp_res_with_post_hint :
                                                                     cpost_typing)
                                                                     ->
                                                                     FStar_Pervasives.Mkdtuple3
-                                                                    (t,
-                                                                    (Pulse_Syntax_Base.with_st_comp
-                                                                    c
-                                                                    {
-                                                                    Pulse_Syntax_Base.u
-                                                                    =
-                                                                    ((Pulse_Syntax_Base.st_comp_of_comp
-                                                                    c).Pulse_Syntax_Base.u);
-                                                                    Pulse_Syntax_Base.res
-                                                                    = ret_ty;
-                                                                    Pulse_Syntax_Base.pre
-                                                                    =
-                                                                    ((Pulse_Syntax_Base.st_comp_of_comp
-                                                                    c).Pulse_Syntax_Base.pre);
-                                                                    Pulse_Syntax_Base.post
-                                                                    =
-                                                                    ((Pulse_Syntax_Base.st_comp_of_comp
-                                                                    c).Pulse_Syntax_Base.post)
-                                                                    }),
+                                                                    (t, c',
                                                                     (Pulse_Typing.T_Equiv
                                                                     (g, t, c,
-                                                                    (Pulse_Syntax_Base.with_st_comp
-                                                                    c
-                                                                    {
-                                                                    Pulse_Syntax_Base.u
-                                                                    =
-                                                                    ((Pulse_Syntax_Base.st_comp_of_comp
-                                                                    c).Pulse_Syntax_Base.u);
-                                                                    Pulse_Syntax_Base.res
-                                                                    = ret_ty;
-                                                                    Pulse_Syntax_Base.pre
-                                                                    =
-                                                                    ((Pulse_Syntax_Base.st_comp_of_comp
-                                                                    c).Pulse_Syntax_Base.pre);
-                                                                    Pulse_Syntax_Base.post
-                                                                    =
-                                                                    ((Pulse_Syntax_Base.st_comp_of_comp
-                                                                    c).Pulse_Syntax_Base.post)
-                                                                    }), d,
+                                                                    c', d,
                                                                     (Pulse_Typing.ST_SLPropEquiv
                                                                     (g, c,
-                                                                    (Pulse_Syntax_Base.with_st_comp
-                                                                    c
-                                                                    {
-                                                                    Pulse_Syntax_Base.u
-                                                                    =
-                                                                    ((Pulse_Syntax_Base.st_comp_of_comp
-                                                                    c).Pulse_Syntax_Base.u);
-                                                                    Pulse_Syntax_Base.res
-                                                                    = ret_ty;
-                                                                    Pulse_Syntax_Base.pre
-                                                                    =
-                                                                    ((Pulse_Syntax_Base.st_comp_of_comp
-                                                                    c).Pulse_Syntax_Base.pre);
-                                                                    Pulse_Syntax_Base.post
-                                                                    =
-                                                                    ((Pulse_Syntax_Base.st_comp_of_comp
-                                                                    c).Pulse_Syntax_Base.post)
-                                                                    }), x,
+                                                                    c', x,
                                                                     (), (),
                                                                     (),
-                                                                    (FStar_Reflection_Typing.Rel_eq_token
-                                                                    ((Pulse_Typing.elab_env
-                                                                    g), cres,
-                                                                    ret_ty,
-                                                                    ())), (),
-                                                                    ())))))))))
+                                                                    d_equiv,
+                                                                    (), ())))))))))
                                                         uu___12)))) uu___10))))
               uu___4 uu___3 uu___2 uu___1 uu___
 let (apply_checker_result_k :
@@ -3015,8 +3017,8 @@ let (checker_result_for_st_typing :
                                                                     (
                                                                     FStar_Range.mk_range
                                                                     "Pulse.Checker.Base.fst"
-                                                                    (Prims.of_int (700))
-                                                                    (Prims.of_int (30))
+                                                                    (Prims.of_int (690))
+                                                                    (Prims.of_int (75))
                                                                     (Prims.of_int (710))
                                                                     (Prims.of_int (66)))))
                                                               (Obj.magic
@@ -3025,32 +3027,8 @@ let (checker_result_for_st_typing :
                                                                  FStar_Tactics_Effect.lift_div_tac
                                                                    (fun
                                                                     uu___6 ->
-                                                                    match 
-                                                                    Pulse_Typing_Metatheory_Base.st_comp_typing_inversion_cofinite
-                                                                    g
-                                                                    (Pulse_Syntax_Base.st_comp_of_comp
-                                                                    c)
-                                                                    (FStar_Pervasives_Native.fst
-                                                                    (Pulse_Typing_Metatheory_Base.comp_typing_inversion
-                                                                    g c
-                                                                    (Pulse_Typing_Metatheory_Base.st_typing_correctness
-                                                                    g t c d1)))
-                                                                    with
-                                                                    | 
-                                                                    (comp_res_typing,
-                                                                    uu___7,
-                                                                    f) ->
-                                                                    FStar_Pervasives.Mkdtuple5
-                                                                    (x, g',
-                                                                    (FStar_Pervasives.Mkdtuple3
-                                                                    ((Pulse_Syntax_Base.comp_u
-                                                                    c),
-                                                                    (Pulse_Syntax_Base.comp_res
-                                                                    c), ())),
-                                                                    (Prims.Mkdtuple2
-                                                                    (ctxt',
-                                                                    ())),
-                                                                    (k_elab_equiv
+                                                                    let k1 =
+                                                                    k_elab_equiv
                                                                     g g'
                                                                     (Pulse_Syntax_Pure.tm_star
                                                                     Pulse_Syntax_Pure.tm_emp
@@ -3062,7 +3040,42 @@ let (checker_result_for_st_typing :
                                                                     ctxt'
                                                                     Pulse_Syntax_Pure.tm_emp)
                                                                     ctxt' k
-                                                                    () ()))))))
+                                                                    () () in
+                                                                    let uu___7
+                                                                    =
+                                                                    let uu___8
+                                                                    =
+                                                                    let uu___9
+                                                                    =
+                                                                    let uu___10
+                                                                    =
+                                                                    Pulse_Typing_Metatheory_Base.st_typing_correctness
+                                                                    g t c d1 in
+                                                                    Pulse_Typing_Metatheory_Base.comp_typing_inversion
+                                                                    g c
+                                                                    uu___10 in
+                                                                    FStar_Pervasives_Native.fst
+                                                                    uu___9 in
+                                                                    Pulse_Typing_Metatheory_Base.st_comp_typing_inversion_cofinite
+                                                                    g
+                                                                    (Pulse_Syntax_Base.st_comp_of_comp
+                                                                    c) uu___8 in
+                                                                    match uu___7
+                                                                    with
+                                                                    | 
+                                                                    (comp_res_typing,
+                                                                    uu___8,
+                                                                    f) ->
+                                                                    FStar_Pervasives.Mkdtuple5
+                                                                    (x, g',
+                                                                    (FStar_Pervasives.Mkdtuple3
+                                                                    ((Pulse_Syntax_Base.comp_u
+                                                                    c),
+                                                                    (Pulse_Syntax_Base.comp_res
+                                                                    c), ())),
+                                                                    (Prims.Mkdtuple2
+                                                                    (ctxt',
+                                                                    ())), k1)))))
                                                         uu___5))) uu___4)))
                                   uu___3))) uu___1)
 let (readback_comp_res_as_comp :

--- a/src/ocaml/plugin/generated/Pulse_Checker_Exists.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Exists.ml
@@ -825,7 +825,7 @@ let (check_intro_exists :
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Checker.Exists.fst"
                            (Prims.of_int (108)) (Prims.of_int (85))
-                           (Prims.of_int (133)) (Prims.of_int (54)))))
+                           (Prims.of_int (134)) (Prims.of_int (54)))))
                   (Obj.magic uu___)
                   (fun uu___1 ->
                      (fun g1 ->
@@ -849,7 +849,7 @@ let (check_intro_exists :
                                       "Pulse.Checker.Exists.fst"
                                       (Prims.of_int (108))
                                       (Prims.of_int (85))
-                                      (Prims.of_int (133))
+                                      (Prims.of_int (134))
                                       (Prims.of_int (54)))))
                              (Obj.magic uu___1)
                              (fun uu___2 ->
@@ -891,7 +891,7 @@ let (check_intro_exists :
                                                      "Pulse.Checker.Exists.fst"
                                                      (Prims.of_int (110))
                                                      (Prims.of_int (62))
-                                                     (Prims.of_int (133))
+                                                     (Prims.of_int (134))
                                                      (Prims.of_int (54)))))
                                             (Obj.magic uu___3)
                                             (fun uu___4 ->
@@ -921,7 +921,7 @@ let (check_intro_exists :
                                                                     "Pulse.Checker.Exists.fst"
                                                                     (Prims.of_int (118))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (54)))))
                                                            (Obj.magic uu___5)
                                                            (fun uu___6 ->
@@ -1023,7 +1023,7 @@ let (check_intro_exists :
                                                                     "Pulse.Checker.Exists.fst"
                                                                     (Prims.of_int (121))
                                                                     (Prims.of_int (34))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (54)))))
                                                                     (Obj.magic
                                                                     uu___6)
@@ -1054,7 +1054,7 @@ let (check_intro_exists :
                                                                     "Pulse.Checker.Exists.fst"
                                                                     (Prims.of_int (121))
                                                                     (Prims.of_int (34))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (54)))))
                                                                     (Obj.magic
                                                                     uu___8)
@@ -1075,12 +1075,8 @@ let (check_intro_exists :
                                                                     (fun
                                                                     uu___11
                                                                     ->
-                                                                    Pulse_Typing_Metatheory_Base.tm_exists_inversion
-                                                                    g1 u
-                                                                    b.Pulse_Syntax_Base.binder_ty
-                                                                    p ()
-                                                                    (Pulse_Typing_Env.fresh
-                                                                    g1))) in
+                                                                    Pulse_Typing_Env.fresh
+                                                                    g1)) in
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
@@ -1088,32 +1084,67 @@ let (check_intro_exists :
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Exists.fst"
                                                                     (Prims.of_int (126))
-                                                                    (Prims.of_int (21))
+                                                                    (Prims.of_int (10))
                                                                     (Prims.of_int (126))
-                                                                    (Prims.of_int (92)))))
+                                                                    (Prims.of_int (17)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Exists.fst"
-                                                                    (Prims.of_int (125))
-                                                                    (Prims.of_int (47))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (126))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (54)))))
                                                                     (Obj.magic
                                                                     uu___10)
                                                                     (fun
                                                                     uu___11
                                                                     ->
+                                                                    (fun x ->
+                                                                    let uu___11
+                                                                    =
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___11
+                                                                    uu___12
                                                                     ->
-                                                                    match uu___11
+                                                                    Pulse_Typing_Metatheory_Base.tm_exists_inversion
+                                                                    g1 u
+                                                                    b.Pulse_Syntax_Base.binder_ty
+                                                                    p () x)) in
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Exists.fst"
+                                                                    (Prims.of_int (127))
+                                                                    (Prims.of_int (21))
+                                                                    (Prims.of_int (127))
+                                                                    (Prims.of_int (84)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Exists.fst"
+                                                                    (Prims.of_int (126))
+                                                                    (Prims.of_int (20))
+                                                                    (Prims.of_int (134))
+                                                                    (Prims.of_int (54)))))
+                                                                    (Obj.magic
+                                                                    uu___11)
+                                                                    (fun
+                                                                    uu___12
+                                                                    ->
+                                                                    (fun
+                                                                    uu___12
+                                                                    ->
+                                                                    match uu___12
                                                                     with
                                                                     | 
                                                                     (ty_typing,
-                                                                    uu___12)
+                                                                    uu___13)
                                                                     ->
-                                                                    let uu___13
+                                                                    let uu___14
                                                                     =
                                                                     Pulse_Checker_Pure.check_term
                                                                     g1
@@ -1126,39 +1157,39 @@ let (check_intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Exists.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (129))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (129))
                                                                     (Prims.of_int (46)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Exists.fst"
-                                                                    (Prims.of_int (126))
-                                                                    (Prims.of_int (95))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (127))
+                                                                    (Prims.of_int (87))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (54)))))
                                                                     (Obj.magic
-                                                                    uu___13)
+                                                                    uu___14)
                                                                     (fun
-                                                                    uu___14
+                                                                    uu___15
                                                                     ->
                                                                     (fun
-                                                                    uu___14
+                                                                    uu___15
                                                                     ->
-                                                                    match uu___14
+                                                                    match uu___15
                                                                     with
                                                                     | 
                                                                     Prims.Mkdtuple2
                                                                     (witness1,
                                                                     witness_typing)
                                                                     ->
-                                                                    let uu___15
+                                                                    let uu___16
                                                                     =
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___16
+                                                                    uu___17
                                                                     ->
                                                                     Pulse_Typing.T_IntroExists
                                                                     (g1, u,
@@ -1172,30 +1203,30 @@ let (check_intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Exists.fst"
-                                                                    (Prims.of_int (129))
+                                                                    (Prims.of_int (130))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (129))
+                                                                    (Prims.of_int (130))
                                                                     (Prims.of_int (73)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Exists.fst"
-                                                                    (Prims.of_int (129))
+                                                                    (Prims.of_int (130))
                                                                     (Prims.of_int (76))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (54)))))
                                                                     (Obj.magic
-                                                                    uu___15)
+                                                                    uu___16)
                                                                     (fun
-                                                                    uu___16
+                                                                    uu___17
                                                                     ->
                                                                     (fun d ->
-                                                                    let uu___16
+                                                                    let uu___17
                                                                     =
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___17
+                                                                    uu___18
                                                                     ->
                                                                     Prims.Mkdtuple2
                                                                     ((Pulse_Typing.comp_intro_exists
@@ -1208,69 +1239,69 @@ let (check_intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Exists.fst"
-                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (45))
-                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (131))
                                                                     (Prims.of_int (55)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Exists.fst"
-                                                                    (Prims.of_int (129))
+                                                                    (Prims.of_int (130))
                                                                     (Prims.of_int (76))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (54)))))
                                                                     (Obj.magic
-                                                                    uu___16)
+                                                                    uu___17)
                                                                     (fun
-                                                                    uu___17
+                                                                    uu___18
                                                                     ->
                                                                     (fun
-                                                                    uu___17
+                                                                    uu___18
                                                                     ->
-                                                                    match uu___17
+                                                                    match uu___18
                                                                     with
                                                                     | 
                                                                     Prims.Mkdtuple2
                                                                     (c, d1)
                                                                     ->
-                                                                    let uu___18
+                                                                    let uu___19
                                                                     =
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___19
+                                                                    uu___20
                                                                     ->
-                                                                    uu___17)) in
+                                                                    uu___18)) in
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Exists.fst"
-                                                                    (Prims.of_int (131))
+                                                                    (Prims.of_int (132))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (54)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Exists.fst"
-                                                                    (Prims.of_int (131))
+                                                                    (Prims.of_int (132))
                                                                     (Prims.of_int (2))
-                                                                    (Prims.of_int (133))
+                                                                    (Prims.of_int (134))
                                                                     (Prims.of_int (54)))))
                                                                     (Obj.magic
-                                                                    uu___18)
+                                                                    uu___19)
                                                                     (fun
-                                                                    uu___19
+                                                                    uu___20
                                                                     ->
                                                                     (fun
-                                                                    uu___19
+                                                                    uu___20
                                                                     ->
-                                                                    let uu___20
-                                                                    =
                                                                     let uu___21
+                                                                    =
+                                                                    let uu___22
                                                                     =
                                                                     Pulse_Checker_Base.match_comp_res_with_post_hint
                                                                     g1
@@ -1293,18 +1324,51 @@ let (check_intro_exists :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Exists.fst"
-                                                                    (Prims.of_int (131))
+                                                                    (Prims.of_int (132))
                                                                     (Prims.of_int (50))
-                                                                    (Prims.of_int (131))
+                                                                    (Prims.of_int (132))
                                                                     (Prims.of_int (93)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Exists.fst"
-                                                                    (Prims.of_int (131))
+                                                                    (Prims.of_int (132))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (131))
+                                                                    (Prims.of_int (132))
                                                                     (Prims.of_int (105)))))
+                                                                    (Obj.magic
+                                                                    uu___22)
+                                                                    (fun
+                                                                    uu___23
+                                                                    ->
+                                                                    (fun
+                                                                    uu___23
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (Pulse_Checker_Prover.try_frame_pre
+                                                                    false g
+                                                                    pre ()
+                                                                    uu___23
+                                                                    res_ppname))
+                                                                    uu___23) in
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Exists.fst"
+                                                                    (Prims.of_int (132))
+                                                                    (Prims.of_int (18))
+                                                                    (Prims.of_int (132))
+                                                                    (Prims.of_int (105)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "Pulse.Checker.Exists.fst"
+                                                                    (Prims.of_int (132))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (134))
+                                                                    (Prims.of_int (54)))))
                                                                     (Obj.magic
                                                                     uu___21)
                                                                     (fun
@@ -1314,50 +1378,18 @@ let (check_intro_exists :
                                                                     uu___22
                                                                     ->
                                                                     Obj.magic
-                                                                    (Pulse_Checker_Prover.try_frame_pre
-                                                                    false g
-                                                                    pre ()
-                                                                    uu___22
-                                                                    res_ppname))
-                                                                    uu___22) in
-                                                                    Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Exists.fst"
-                                                                    (Prims.of_int (131))
-                                                                    (Prims.of_int (18))
-                                                                    (Prims.of_int (131))
-                                                                    (Prims.of_int (105)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "Pulse.Checker.Exists.fst"
-                                                                    (Prims.of_int (131))
-                                                                    (Prims.of_int (2))
-                                                                    (Prims.of_int (133))
-                                                                    (Prims.of_int (54)))))
-                                                                    (Obj.magic
-                                                                    uu___20)
-                                                                    (fun
-                                                                    uu___21
-                                                                    ->
-                                                                    (fun
-                                                                    uu___21
-                                                                    ->
-                                                                    Obj.magic
                                                                     (Pulse_Checker_Prover.prove_post_hint
                                                                     g pre
-                                                                    uu___21
+                                                                    uu___22
                                                                     post_hint
                                                                     (Pulse_RuntimeUtils.range_of_term
                                                                     t1)))
-                                                                    uu___21)))
-                                                                    uu___19)))
+                                                                    uu___22)))
+                                                                    uu___20)))
+                                                                    uu___18)))
                                                                     uu___17)))
-                                                                    uu___16)))
-                                                                    uu___14)))
+                                                                    uu___15)))
+                                                                    uu___12)))
                                                                     uu___11)))
                                                                     uu___9)))
                                                                     uu___7)))

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover.ml
@@ -4376,8 +4376,8 @@ let (try_frame_pre_uvs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.Prover.fst"
-                                                                    (Prims.of_int (569))
-                                                                    (Prims.of_int (35))
+                                                                    (Prims.of_int (562))
+                                                                    (Prims.of_int (107))
                                                                     (Prims.of_int (589))
                                                                     (Prims.of_int (88)))))
                                                                     (Obj.magic
@@ -4387,41 +4387,8 @@ let (try_frame_pre_uvs :
                                                                     (fun
                                                                     uu___18
                                                                     ->
-                                                                    match 
-                                                                    Pulse_Typing_Metatheory_Base.st_comp_typing_inversion_cofinite
-                                                                    g11
-                                                                    (Pulse_Syntax_Base.st_comp_of_comp
-                                                                    c2)
-                                                                    (FStar_Pervasives_Native.fst
-                                                                    (Pulse_Typing_Metatheory_Base.comp_typing_inversion
-                                                                    g11 c2
-                                                                    (Pulse_Typing_Metatheory_Base.st_typing_correctness
-                                                                    g11 t1 c2
-                                                                    d5)))
-                                                                    with
-                                                                    | 
-                                                                    (comp_res_typing_in_g1,
-                                                                    uu___19,
-                                                                    f) ->
-                                                                    FStar_Pervasives.Mkdtuple5
-                                                                    (x, g2,
-                                                                    (FStar_Pervasives.Mkdtuple3
-                                                                    ((Pulse_Syntax_Base.comp_u
-                                                                    c2), ty,
-                                                                    ())),
-                                                                    (Prims.Mkdtuple2
-                                                                    (ctxt',
-                                                                    ())),
-                                                                    (Pulse_Checker_Base.k_elab_trans
-                                                                    g1 g11 g2
-                                                                    ctxt
-                                                                    (Pulse_Checker_Prover_Base.op_Star
-                                                                    (Pulse_Syntax_Base.comp_pre
-                                                                    c2)
-                                                                    remaining_ctxt)
-                                                                    ctxt'
-                                                                    k_frame1
-                                                                    (Pulse_Checker_Base.k_elab_equiv
+                                                                    let k1 =
+                                                                    Pulse_Checker_Base.k_elab_equiv
                                                                     g11 g2
                                                                     (Pulse_Checker_Prover_Base.op_Star
                                                                     remaining_ctxt
@@ -4433,7 +4400,54 @@ let (try_frame_pre_uvs :
                                                                     remaining_ctxt)
                                                                     ctxt'
                                                                     ctxt' k
-                                                                    () ())))))))
+                                                                    () () in
+                                                                    let k2 =
+                                                                    Pulse_Checker_Base.k_elab_trans
+                                                                    g1 g11 g2
+                                                                    ctxt
+                                                                    (Pulse_Checker_Prover_Base.op_Star
+                                                                    (Pulse_Syntax_Base.comp_pre
+                                                                    c2)
+                                                                    remaining_ctxt)
+                                                                    ctxt'
+                                                                    k_frame1
+                                                                    k1 in
+                                                                    let uu___19
+                                                                    =
+                                                                    let uu___20
+                                                                    =
+                                                                    let uu___21
+                                                                    =
+                                                                    let uu___22
+                                                                    =
+                                                                    Pulse_Typing_Metatheory_Base.st_typing_correctness
+                                                                    g11 t1 c2
+                                                                    d5 in
+                                                                    Pulse_Typing_Metatheory_Base.comp_typing_inversion
+                                                                    g11 c2
+                                                                    uu___22 in
+                                                                    FStar_Pervasives_Native.fst
+                                                                    uu___21 in
+                                                                    Pulse_Typing_Metatheory_Base.st_comp_typing_inversion_cofinite
+                                                                    g11
+                                                                    (Pulse_Syntax_Base.st_comp_of_comp
+                                                                    c2)
+                                                                    uu___20 in
+                                                                    match uu___19
+                                                                    with
+                                                                    | 
+                                                                    (comp_res_typing_in_g1,
+                                                                    uu___20,
+                                                                    f) ->
+                                                                    FStar_Pervasives.Mkdtuple5
+                                                                    (x, g2,
+                                                                    (FStar_Pervasives.Mkdtuple3
+                                                                    ((Pulse_Syntax_Base.comp_u
+                                                                    c2), ty,
+                                                                    ())),
+                                                                    (Prims.Mkdtuple2
+                                                                    (ctxt',
+                                                                    ())), k2)))))
                                                                     uu___17)))
                                                                     uu___16)))
                                                                     uu___15)))

--- a/src/ocaml/plugin/generated/Pulse_Checker_Prover_ElimExists.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Prover_ElimExists.ml
@@ -38,6 +38,7 @@ let (mk :
                               Pulse_Syntax_Base.binder_attrs = uu___1;_},
                             p)
                            ->
+                           let x = Pulse_Typing_Env.fresh g in
                            FStar_Pervasives_Native.Some
                              (FStar_Pervasives.Mkdtuple4
                                 (nm,
@@ -50,23 +51,17 @@ let (mk :
                                             (Pulse_Syntax_Pure.tm_exists_sl
                                                (Pulse_Syntax_Base.comp_u
                                                   (Pulse_Typing.comp_elim_exists
-                                                     u t p
-                                                     (nm,
-                                                       (Pulse_Typing_Env.fresh
-                                                          g))))
+                                                     u t p (nm, x)))
                                                (Pulse_Syntax_Base.as_binder t)
                                                p)
                                         })),
                                   (Pulse_Typing.comp_elim_exists u t p
-                                     (nm, (Pulse_Typing_Env.fresh g))),
+                                     (nm, x)),
                                   (Pulse_Typing.T_ElimExists
                                      (g,
                                        (Pulse_Syntax_Base.comp_u
                                           (Pulse_Typing.comp_elim_exists u t
-                                             p
-                                             (nm, (Pulse_Typing_Env.fresh g)))),
-                                       t, p, (Pulse_Typing_Env.fresh g), (),
-                                       ()))))
+                                             p (nm, x))), t, p, x, (), ()))))
                        | uu___1 -> FStar_Pervasives_Native.None))) uu___2
           uu___1 uu___
 let (elim_exists_frame :

--- a/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_Pure.ml
@@ -3028,67 +3028,51 @@ let (instantiate_term_implicits_uvs :
                                                                     (namedv,
                                                                     namedvt))
                                                                     ->
-                                                                    FStar_Pervasives.Mkdtuple3
-                                                                    ((Pulse_Typing_Env.push_binding
-                                                                    uvs
-                                                                    (Pulse_Typing_Env.fresh
-                                                                    (Pulse_Typing_Env.push_env
-                                                                    g uvs))
+                                                                    let nview
+                                                                    =
+                                                                    FStar_Reflection_V2_Builtins.inspect_namedv
+                                                                    namedv in
+                                                                    let ppname
+                                                                    =
                                                                     {
                                                                     Pulse_Syntax_Base.name
                                                                     =
-                                                                    ((FStar_Reflection_V2_Builtins.inspect_namedv
-                                                                    namedv).FStar_Reflection_V2_Data.ppname);
+                                                                    (nview.FStar_Reflection_V2_Data.ppname);
                                                                     Pulse_Syntax_Base.range
                                                                     = rng
-                                                                    } namedvt),
+                                                                    } in
+                                                                    let x =
+                                                                    Pulse_Typing_Env.fresh
+                                                                    (Pulse_Typing_Env.push_env
+                                                                    g uvs) in
+                                                                    FStar_Pervasives.Mkdtuple3
+                                                                    ((Pulse_Typing_Env.push_binding
+                                                                    uvs x
+                                                                    ppname
+                                                                    namedvt),
                                                                     (Pulse_Syntax_Naming.subst_term
                                                                     t1
                                                                     [
                                                                     FStar_Reflection_Typing.NT
-                                                                    (((FStar_Reflection_V2_Builtins.inspect_namedv
-                                                                    namedv).FStar_Reflection_V2_Data.uniq),
+                                                                    ((nview.FStar_Reflection_V2_Data.uniq),
                                                                     (Pulse_Syntax_Pure.tm_var
                                                                     {
                                                                     Pulse_Syntax_Base.nm_index
-                                                                    =
-                                                                    (Pulse_Typing_Env.fresh
-                                                                    (Pulse_Typing_Env.push_env
-                                                                    g uvs));
+                                                                    = x;
                                                                     Pulse_Syntax_Base.nm_ppname
-                                                                    =
-                                                                    {
-                                                                    Pulse_Syntax_Base.name
-                                                                    =
-                                                                    ((FStar_Reflection_V2_Builtins.inspect_namedv
-                                                                    namedv).FStar_Reflection_V2_Data.ppname);
-                                                                    Pulse_Syntax_Base.range
-                                                                    = rng
-                                                                    }
+                                                                    = ppname
                                                                     }))]),
                                                                     (Pulse_Syntax_Naming.subst_term
                                                                     ty1
                                                                     [
                                                                     FStar_Reflection_Typing.NT
-                                                                    (((FStar_Reflection_V2_Builtins.inspect_namedv
-                                                                    namedv).FStar_Reflection_V2_Data.uniq),
+                                                                    ((nview.FStar_Reflection_V2_Data.uniq),
                                                                     (Pulse_Syntax_Pure.tm_var
                                                                     {
                                                                     Pulse_Syntax_Base.nm_index
-                                                                    =
-                                                                    (Pulse_Typing_Env.fresh
-                                                                    (Pulse_Typing_Env.push_env
-                                                                    g uvs));
+                                                                    = x;
                                                                     Pulse_Syntax_Base.nm_ppname
-                                                                    =
-                                                                    {
-                                                                    Pulse_Syntax_Base.name
-                                                                    =
-                                                                    ((FStar_Reflection_V2_Builtins.inspect_namedv
-                                                                    namedv).FStar_Reflection_V2_Data.ppname);
-                                                                    Pulse_Syntax_Base.range
-                                                                    = rng
-                                                                    }
+                                                                    = ppname
                                                                     }))])))))
                                                                     uu___9
                                                                     uu___8)

--- a/src/ocaml/plugin/generated/Pulse_Checker_STApp.ml
+++ b/src/ocaml/plugin/generated/Pulse_Checker_STApp.ml
@@ -1620,6 +1620,31 @@ let (apply_impure_function :
                                                                     (fun
                                                                     uu___15
                                                                     ->
+                                                                    let d =
+                                                                    Pulse_Typing.T_STApp
+                                                                    (g, head,
+                                                                    formal,
+                                                                    qual,
+                                                                    comp_typ,
+                                                                    arg1, (),
+                                                                    ()) in
+                                                                    let d1 =
+                                                                    canonicalize_st_typing
+                                                                    g
+                                                                    (Pulse_Typing.wrst
+                                                                    comp_typ
+                                                                    (Pulse_Syntax_Base.Tm_STApp
+                                                                    {
+                                                                    Pulse_Syntax_Base.head
+                                                                    = head;
+                                                                    Pulse_Syntax_Base.arg_qual
+                                                                    = qual;
+                                                                    Pulse_Syntax_Base.arg
+                                                                    = arg1
+                                                                    }))
+                                                                    (Pulse_Syntax_Naming.open_comp_with
+                                                                    comp_typ
+                                                                    arg1) d in
                                                                     FStar_Pervasives.Mkdtuple3
                                                                     ({
                                                                     Pulse_Syntax_Base.term1
@@ -1649,29 +1674,7 @@ let (apply_impure_function :
                                                                     (Pulse_Syntax_Naming.open_comp_with
                                                                     comp_typ
                                                                     arg1)),
-                                                                    (canonicalize_st_typing
-                                                                    g
-                                                                    (Pulse_Typing.wrst
-                                                                    comp_typ
-                                                                    (Pulse_Syntax_Base.Tm_STApp
-                                                                    {
-                                                                    Pulse_Syntax_Base.head
-                                                                    = head;
-                                                                    Pulse_Syntax_Base.arg_qual
-                                                                    = qual;
-                                                                    Pulse_Syntax_Base.arg
-                                                                    = arg1
-                                                                    }))
-                                                                    (Pulse_Syntax_Naming.open_comp_with
-                                                                    comp_typ
-                                                                    arg1)
-                                                                    (Pulse_Typing.T_STApp
-                                                                    (g, head,
-                                                                    formal,
-                                                                    qual,
-                                                                    comp_typ,
-                                                                    arg1, (),
-                                                                    ())))))))
+                                                                    d1))))
                                                                     | 
                                                                     Pulse_Syntax_Base.C_STAtomic
                                                                     (uu___15,
@@ -1683,6 +1686,31 @@ let (apply_impure_function :
                                                                     (fun
                                                                     uu___17
                                                                     ->
+                                                                    let d =
+                                                                    Pulse_Typing.T_STApp
+                                                                    (g, head,
+                                                                    formal,
+                                                                    qual,
+                                                                    comp_typ,
+                                                                    arg1, (),
+                                                                    ()) in
+                                                                    let d1 =
+                                                                    canonicalize_st_typing
+                                                                    g
+                                                                    (Pulse_Typing.wrst
+                                                                    comp_typ
+                                                                    (Pulse_Syntax_Base.Tm_STApp
+                                                                    {
+                                                                    Pulse_Syntax_Base.head
+                                                                    = head;
+                                                                    Pulse_Syntax_Base.arg_qual
+                                                                    = qual;
+                                                                    Pulse_Syntax_Base.arg
+                                                                    = arg1
+                                                                    }))
+                                                                    (Pulse_Syntax_Naming.open_comp_with
+                                                                    comp_typ
+                                                                    arg1) d in
                                                                     FStar_Pervasives.Mkdtuple3
                                                                     ({
                                                                     Pulse_Syntax_Base.term1
@@ -1712,29 +1740,7 @@ let (apply_impure_function :
                                                                     (Pulse_Syntax_Naming.open_comp_with
                                                                     comp_typ
                                                                     arg1)),
-                                                                    (canonicalize_st_typing
-                                                                    g
-                                                                    (Pulse_Typing.wrst
-                                                                    comp_typ
-                                                                    (Pulse_Syntax_Base.Tm_STApp
-                                                                    {
-                                                                    Pulse_Syntax_Base.head
-                                                                    = head;
-                                                                    Pulse_Syntax_Base.arg_qual
-                                                                    = qual;
-                                                                    Pulse_Syntax_Base.arg
-                                                                    = arg1
-                                                                    }))
-                                                                    (Pulse_Syntax_Naming.open_comp_with
-                                                                    comp_typ
-                                                                    arg1)
-                                                                    (Pulse_Typing.T_STApp
-                                                                    (g, head,
-                                                                    formal,
-                                                                    qual,
-                                                                    comp_typ,
-                                                                    arg1, (),
-                                                                    ())))))))
+                                                                    d1))))
                                                                     | 
                                                                     Pulse_Syntax_Base.C_STGhost
                                                                     (uu___15,
@@ -1969,8 +1975,8 @@ let (apply_impure_function :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Checker.STApp.fst"
-                                                                    (Prims.of_int (217))
-                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (53))
                                                                     (Prims.of_int (217))
                                                                     (Prims.of_int (23)))))
                                                                     (Obj.magic
@@ -1982,6 +1988,32 @@ let (apply_impure_function :
                                                                     (fun
                                                                     uu___20
                                                                     ->
+                                                                    let d =
+                                                                    Pulse_Typing.T_STGhostApp
+                                                                    (g, head,
+                                                                    formal,
+                                                                    qual,
+                                                                    comp_typ,
+                                                                    arg1, x,
+                                                                    (), (),
+                                                                    ()) in
+                                                                    let d1 =
+                                                                    canonicalize_st_typing
+                                                                    g
+                                                                    (Pulse_Typing.wrst
+                                                                    comp_typ
+                                                                    (Pulse_Syntax_Base.Tm_STApp
+                                                                    {
+                                                                    Pulse_Syntax_Base.head
+                                                                    = head;
+                                                                    Pulse_Syntax_Base.arg_qual
+                                                                    = qual;
+                                                                    Pulse_Syntax_Base.arg
+                                                                    = arg1
+                                                                    }))
+                                                                    (Pulse_Syntax_Naming.open_comp_with
+                                                                    comp_typ
+                                                                    arg1) d in
                                                                     FStar_Pervasives.Mkdtuple3
                                                                     ({
                                                                     Pulse_Syntax_Base.term1
@@ -2010,30 +2042,7 @@ let (apply_impure_function :
                                                                     (Pulse_Syntax_Naming.open_comp_with
                                                                     comp_typ
                                                                     arg1)),
-                                                                    (canonicalize_st_typing
-                                                                    g
-                                                                    (Pulse_Typing.wrst
-                                                                    comp_typ
-                                                                    (Pulse_Syntax_Base.Tm_STApp
-                                                                    {
-                                                                    Pulse_Syntax_Base.head
-                                                                    = head;
-                                                                    Pulse_Syntax_Base.arg_qual
-                                                                    = qual;
-                                                                    Pulse_Syntax_Base.arg
-                                                                    = arg1
-                                                                    }))
-                                                                    (Pulse_Syntax_Naming.open_comp_with
-                                                                    comp_typ
-                                                                    arg1)
-                                                                    (Pulse_Typing.T_STGhostApp
-                                                                    (g, head,
-                                                                    formal,
-                                                                    qual,
-                                                                    comp_typ,
-                                                                    arg1, x,
-                                                                    (), (),
-                                                                    ()))))))))
+                                                                    d1)))))
                                                                     uu___18)))
                                                                     uu___17)))
                                                                     | 

--- a/src/ocaml/plugin/generated/Pulse_Extract_Main.ml
+++ b/src/ocaml/plugin/generated/Pulse_Extract_Main.ml
@@ -53,10 +53,9 @@ let (extend_env' :
                Obj.magic
                  (FStar_Tactics_Effect.lift_div_tac
                     (fun uu___ ->
-                       ((Pulse_Typing_Env.push_binding g
-                           (Pulse_Typing_Env.fresh g) ppname ty),
-                         (ppname, (Pulse_Typing_Env.fresh g)))))) uu___2
-          uu___1 uu___
+                       let x = Pulse_Typing_Env.fresh g in
+                       ((Pulse_Typing_Env.push_binding g x ppname ty),
+                         (ppname, x))))) uu___2 uu___1 uu___
 let (extend_env'_binder :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.binder ->

--- a/src/ocaml/plugin/generated/Pulse_Typing_Combinators.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_Combinators.ml
@@ -316,7 +316,13 @@ let (try_lift_ghost_atomic :
       fun c ->
         fun d ->
           let uu___ =
-            Obj.magic (FStar_Tactics_Effect.lift_div_tac (fun uu___1 -> ())) in
+            Obj.magic
+              (FStar_Tactics_Effect.lift_div_tac
+                 (fun uu___1 ->
+                    let d1 =
+                      Pulse_Typing_Metatheory_Base.st_typing_correctness g e
+                        c d in
+                    ())) in
           FStar_Tactics_Effect.tac_bind
             (FStar_Sealed.seal
                (Obj.magic

--- a/src/ocaml/plugin/generated/Pulse_Typing_Env.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_Env.ml
@@ -122,22 +122,8 @@ let (lookup :
       if FStar_Map.contains m x
       then FStar_Pervasives_Native.Some (FStar_Map.sel m x)
       else FStar_Pervasives_Native.None
-let rec (max :
-  (Pulse_Syntax_Base.var * Pulse_Syntax_Base.typ) Prims.list ->
-    Pulse_Syntax_Base.var -> Pulse_Syntax_Base.var)
-  =
-  fun bs ->
-    fun current ->
-      match bs with
-      | [] -> current
-      | (x, t)::rest ->
-          let current1 = if x < current then current else x in
-          max rest current1
 let (fresh : env -> Pulse_Syntax_Base.var) =
-  fun g ->
-    match g.bs with
-    | [] -> Prims.int_one
-    | (x, uu___)::bs_rest -> let max1 = max bs_rest x in max1 + Prims.int_one
+  fun g -> let v = Pulse_RuntimeUtils.next_id () in v
 let (contains : env -> Pulse_Syntax_Base.var -> Prims.bool) =
   fun g -> fun x -> FStar_Map.contains (as_map g) x
 type ('g1, 'g2) disjoint = unit
@@ -307,12 +293,12 @@ let (range_of_env :
     FStar_Tactics_Effect.tac_bind
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (307))
-               (Prims.of_int (14)) (Prims.of_int (307)) (Prims.of_int (29)))))
+            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (297))
+               (Prims.of_int (14)) (Prims.of_int (297)) (Prims.of_int (29)))))
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (308))
-               (Prims.of_int (4)) (Prims.of_int (316)) (Prims.of_int (30)))))
+            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (298))
+               (Prims.of_int (4)) (Prims.of_int (306)) (Prims.of_int (30)))))
       (Obj.magic uu___)
       (fun uu___1 ->
          (fun ctx ->
@@ -343,13 +329,13 @@ let (range_of_env :
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                          (Prims.of_int (309)) (Prims.of_int (6))
-                          (Prims.of_int (314)) (Prims.of_int (66)))))
+                          (Prims.of_int (299)) (Prims.of_int (6))
+                          (Prims.of_int (304)) (Prims.of_int (66)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                          (Prims.of_int (308)) (Prims.of_int (4))
-                          (Prims.of_int (316)) (Prims.of_int (30)))))
+                          (Prims.of_int (298)) (Prims.of_int (4))
+                          (Prims.of_int (306)) (Prims.of_int (30)))))
                  (Obj.magic uu___1)
                  (fun uu___2 ->
                     FStar_Tactics_Effect.lift_div_tac
@@ -377,8 +363,8 @@ let (ctxt_elt_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                            (Prims.of_int (323)) (Prims.of_int (49))
-                            (Prims.of_int (323)) (Prims.of_int (70)))))
+                            (Prims.of_int (313)) (Prims.of_int (49))
+                            (Prims.of_int (313)) (Prims.of_int (70)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Prims.fst"
@@ -412,13 +398,13 @@ let (ctx_to_string :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (329)) (Prims.of_int (64))
-                              (Prims.of_int (329)) (Prims.of_int (92)))))
+                              (Prims.of_int (319)) (Prims.of_int (64))
+                              (Prims.of_int (319)) (Prims.of_int (92)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (329)) (Prims.of_int (42))
-                              (Prims.of_int (329)) (Prims.of_int (93)))))
+                              (Prims.of_int (319)) (Prims.of_int (42))
+                              (Prims.of_int (319)) (Prims.of_int (93)))))
                      (Obj.magic uu___2)
                      (fun uu___3 ->
                         FStar_Tactics_Effect.lift_div_tac
@@ -427,8 +413,8 @@ let (ctx_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                            (Prims.of_int (329)) (Prims.of_int (42))
-                            (Prims.of_int (329)) (Prims.of_int (93)))))
+                            (Prims.of_int (319)) (Prims.of_int (42))
+                            (Prims.of_int (319)) (Prims.of_int (93)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Prims.fst"
@@ -447,12 +433,12 @@ let (ctxt_to_list :
     FStar_Tactics_Effect.tac_bind
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (332))
-               (Prims.of_int (12)) (Prims.of_int (332)) (Prims.of_int (27)))))
+            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (322))
+               (Prims.of_int (12)) (Prims.of_int (322)) (Prims.of_int (27)))))
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (333))
-               (Prims.of_int (2)) (Prims.of_int (333)) (Prims.of_int (30)))))
+            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (323))
+               (Prims.of_int (2)) (Prims.of_int (323)) (Prims.of_int (30)))))
       (Obj.magic uu___)
       (fun uu___1 ->
          (fun ctx ->
@@ -464,12 +450,12 @@ let (print_context :
     FStar_Tactics_Effect.tac_bind
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (336))
-               (Prims.of_int (12)) (Prims.of_int (336)) (Prims.of_int (27)))))
+            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (326))
+               (Prims.of_int (12)) (Prims.of_int (326)) (Prims.of_int (27)))))
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (337))
-               (Prims.of_int (2)) (Prims.of_int (340)) (Prims.of_int (79)))))
+            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (327))
+               (Prims.of_int (2)) (Prims.of_int (330)) (Prims.of_int (79)))))
       (Obj.magic uu___)
       (fun uu___1 ->
          (fun ctx ->
@@ -487,13 +473,13 @@ let (print_context :
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                   (Prims.of_int (340)) (Prims.of_int (62))
-                                   (Prims.of_int (340)) (Prims.of_int (78)))))
+                                   (Prims.of_int (330)) (Prims.of_int (62))
+                                   (Prims.of_int (330)) (Prims.of_int (78)))))
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                   (Prims.of_int (340)) (Prims.of_int (40))
-                                   (Prims.of_int (340)) (Prims.of_int (79)))))
+                                   (Prims.of_int (330)) (Prims.of_int (40))
+                                   (Prims.of_int (330)) (Prims.of_int (79)))))
                           (Obj.magic uu___3)
                           (fun uu___4 ->
                              FStar_Tactics_Effect.lift_div_tac
@@ -503,8 +489,8 @@ let (print_context :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                 (Prims.of_int (340)) (Prims.of_int (40))
-                                 (Prims.of_int (340)) (Prims.of_int (79)))))
+                                 (Prims.of_int (330)) (Prims.of_int (40))
+                                 (Prims.of_int (330)) (Prims.of_int (79)))))
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "Prims.fst"
@@ -544,12 +530,12 @@ let (print_issue :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                 (Prims.of_int (344)) (Prims.of_int (30))
-                 (Prims.of_int (346)) (Prims.of_int (37)))))
+                 (Prims.of_int (334)) (Prims.of_int (30))
+                 (Prims.of_int (336)) (Prims.of_int (37)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                 (Prims.of_int (348)) (Prims.of_int (4)) (Prims.of_int (352))
+                 (Prims.of_int (338)) (Prims.of_int (4)) (Prims.of_int (342))
                  (Prims.of_int (101))))) (Obj.magic uu___)
         (fun uu___1 ->
            (fun range_opt_to_string ->
@@ -560,13 +546,13 @@ let (print_issue :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                             (Prims.of_int (352)) (Prims.of_int (23))
-                             (Prims.of_int (352)) (Prims.of_int (47)))))
+                             (Prims.of_int (342)) (Prims.of_int (23))
+                             (Prims.of_int (342)) (Prims.of_int (47)))))
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                             (Prims.of_int (352)) (Prims.of_int (22))
-                             (Prims.of_int (352)) (Prims.of_int (100)))))
+                             (Prims.of_int (342)) (Prims.of_int (22))
+                             (Prims.of_int (342)) (Prims.of_int (100)))))
                     (Obj.magic uu___3)
                     (fun uu___4 ->
                        (fun uu___4 ->
@@ -586,17 +572,17 @@ let (print_issue :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Typing.Env.fst"
-                                        (Prims.of_int (352))
+                                        (Prims.of_int (342))
                                         (Prims.of_int (50))
-                                        (Prims.of_int (352))
+                                        (Prims.of_int (342))
                                         (Prims.of_int (99)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Typing.Env.fst"
-                                        (Prims.of_int (352))
+                                        (Prims.of_int (342))
                                         (Prims.of_int (22))
-                                        (Prims.of_int (352))
+                                        (Prims.of_int (342))
                                         (Prims.of_int (100)))))
                                (Obj.magic uu___5)
                                (fun uu___6 ->
@@ -608,13 +594,13 @@ let (print_issue :
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                           (Prims.of_int (352)) (Prims.of_int (22))
-                           (Prims.of_int (352)) (Prims.of_int (100)))))
+                           (Prims.of_int (342)) (Prims.of_int (22))
+                           (Prims.of_int (342)) (Prims.of_int (100)))))
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                           (Prims.of_int (352)) (Prims.of_int (7))
-                           (Prims.of_int (352)) (Prims.of_int (101)))))
+                           (Prims.of_int (342)) (Prims.of_int (7))
+                           (Prims.of_int (342)) (Prims.of_int (101)))))
                   (Obj.magic uu___2)
                   (fun uu___3 ->
                      (fun uu___3 -> Obj.magic (ctx_to_string uu___3)) uu___3) in
@@ -623,13 +609,13 @@ let (print_issue :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                            (Prims.of_int (352)) (Prims.of_int (7))
-                            (Prims.of_int (352)) (Prims.of_int (101)))))
+                            (Prims.of_int (342)) (Prims.of_int (7))
+                            (Prims.of_int (342)) (Prims.of_int (101)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                            (Prims.of_int (348)) (Prims.of_int (4))
-                            (Prims.of_int (352)) (Prims.of_int (101)))))
+                            (Prims.of_int (338)) (Prims.of_int (4))
+                            (Prims.of_int (342)) (Prims.of_int (101)))))
                    (Obj.magic uu___1)
                    (fun uu___2 ->
                       (fun uu___2 ->
@@ -644,9 +630,9 @@ let (print_issue :
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Typing.Env.fst"
-                                          (Prims.of_int (349))
+                                          (Prims.of_int (339))
                                           (Prims.of_int (7))
-                                          (Prims.of_int (349))
+                                          (Prims.of_int (339))
                                           (Prims.of_int (47)))))
                                  (FStar_Sealed.seal
                                     (Obj.magic
@@ -677,17 +663,17 @@ let (print_issue :
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Typing.Env.fst"
-                                        (Prims.of_int (348))
+                                        (Prims.of_int (338))
                                         (Prims.of_int (4))
-                                        (Prims.of_int (352))
+                                        (Prims.of_int (342))
                                         (Prims.of_int (101)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "Pulse.Typing.Env.fst"
-                                        (Prims.of_int (348))
+                                        (Prims.of_int (338))
                                         (Prims.of_int (4))
-                                        (Prims.of_int (352))
+                                        (Prims.of_int (342))
                                         (Prims.of_int (101)))))
                                (Obj.magic uu___5)
                                (fun uu___6 ->
@@ -699,15 +685,15 @@ let (print_issue :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Typing.Env.fst"
-                                      (Prims.of_int (348)) (Prims.of_int (4))
-                                      (Prims.of_int (352))
+                                      (Prims.of_int (338)) (Prims.of_int (4))
+                                      (Prims.of_int (342))
                                       (Prims.of_int (101)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Typing.Env.fst"
-                                      (Prims.of_int (348)) (Prims.of_int (4))
-                                      (Prims.of_int (352))
+                                      (Prims.of_int (338)) (Prims.of_int (4))
+                                      (Prims.of_int (342))
                                       (Prims.of_int (101)))))
                              (Obj.magic uu___4)
                              (fun uu___5 ->
@@ -720,17 +706,17 @@ let (print_issue :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Typing.Env.fst"
-                                       (Prims.of_int (348))
+                                       (Prims.of_int (338))
                                        (Prims.of_int (4))
-                                       (Prims.of_int (352))
+                                       (Prims.of_int (342))
                                        (Prims.of_int (101)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Typing.Env.fst"
-                                       (Prims.of_int (348))
+                                       (Prims.of_int (338))
                                        (Prims.of_int (4))
-                                       (Prims.of_int (352))
+                                       (Prims.of_int (342))
                                        (Prims.of_int (101)))))
                               (Obj.magic uu___3)
                               (fun uu___4 ->
@@ -749,12 +735,12 @@ let (print_issues :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                 (Prims.of_int (356)) (Prims.of_int (24))
-                 (Prims.of_int (356)) (Prims.of_int (49)))))
+                 (Prims.of_int (346)) (Prims.of_int (24))
+                 (Prims.of_int (346)) (Prims.of_int (49)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                 (Prims.of_int (356)) (Prims.of_int (5)) (Prims.of_int (356))
+                 (Prims.of_int (346)) (Prims.of_int (5)) (Prims.of_int (346))
                  (Prims.of_int (49))))) (Obj.magic uu___)
         (fun uu___1 ->
            FStar_Tactics_Effect.lift_div_tac
@@ -768,13 +754,13 @@ let (env_to_string :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                 (Prims.of_int (361)) (Prims.of_int (4)) (Prims.of_int (361))
+                 (Prims.of_int (351)) (Prims.of_int (4)) (Prims.of_int (351))
                  (Prims.of_int (24)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                 (Prims.of_int (359)) (Prims.of_int (11))
-                 (Prims.of_int (361)) (Prims.of_int (24)))))
+                 (Prims.of_int (349)) (Prims.of_int (11))
+                 (Prims.of_int (351)) (Prims.of_int (24)))))
         (Obj.magic uu___1)
         (fun uu___2 ->
            (fun uu___2 ->
@@ -789,15 +775,15 @@ let (env_to_string :
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "Pulse.Typing.Env.fst"
-                                     (Prims.of_int (360)) (Prims.of_int (72))
-                                     (Prims.of_int (360))
+                                     (Prims.of_int (350)) (Prims.of_int (72))
+                                     (Prims.of_int (350))
                                      (Prims.of_int (111)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "Pulse.Typing.Env.fst"
-                                     (Prims.of_int (360)) (Prims.of_int (24))
-                                     (Prims.of_int (360))
+                                     (Prims.of_int (350)) (Prims.of_int (24))
+                                     (Prims.of_int (350))
                                      (Prims.of_int (111)))))
                             (Obj.magic uu___4)
                             (fun uu___5 ->
@@ -812,9 +798,9 @@ let (env_to_string :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "Pulse.Typing.Env.fst"
-                                                 (Prims.of_int (360))
+                                                 (Prims.of_int (350))
                                                  (Prims.of_int (52))
-                                                 (Prims.of_int (360))
+                                                 (Prims.of_int (350))
                                                  (Prims.of_int (69)))))
                                         (FStar_Sealed.seal
                                            (Obj.magic
@@ -844,17 +830,17 @@ let (env_to_string :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Typing.Env.fst"
-                                               (Prims.of_int (360))
+                                               (Prims.of_int (350))
                                                (Prims.of_int (24))
-                                               (Prims.of_int (360))
+                                               (Prims.of_int (350))
                                                (Prims.of_int (111)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Typing.Env.fst"
-                                               (Prims.of_int (360))
+                                               (Prims.of_int (350))
                                                (Prims.of_int (24))
-                                               (Prims.of_int (360))
+                                               (Prims.of_int (350))
                                                (Prims.of_int (111)))))
                                       (Obj.magic uu___7)
                                       (fun uu___8 ->
@@ -866,17 +852,17 @@ let (env_to_string :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Typing.Env.fst"
-                                                (Prims.of_int (360))
+                                                (Prims.of_int (350))
                                                 (Prims.of_int (24))
-                                                (Prims.of_int (360))
+                                                (Prims.of_int (350))
                                                 (Prims.of_int (111)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "Pulse.Typing.Env.fst"
-                                                (Prims.of_int (360))
+                                                (Prims.of_int (350))
                                                 (Prims.of_int (24))
-                                                (Prims.of_int (360))
+                                                (Prims.of_int (350))
                                                 (Prims.of_int (111)))))
                                        (Obj.magic uu___6)
                                        (fun uu___7 ->
@@ -886,12 +872,12 @@ let (env_to_string :
     FStar_Tactics_Effect.tac_bind
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (359))
-               (Prims.of_int (11)) (Prims.of_int (361)) (Prims.of_int (24)))))
+            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (349))
+               (Prims.of_int (11)) (Prims.of_int (351)) (Prims.of_int (24)))))
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (362))
-               (Prims.of_int (2)) (Prims.of_int (362)) (Prims.of_int (25)))))
+            (FStar_Range.mk_range "Pulse.Typing.Env.fst" (Prims.of_int (352))
+               (Prims.of_int (2)) (Prims.of_int (352)) (Prims.of_int (25)))))
       (Obj.magic uu___)
       (fun bs ->
          FStar_Tactics_Effect.lift_div_tac
@@ -924,13 +910,13 @@ let rec separate_map :
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                    (Prims.of_int (373)) (Prims.of_int (13))
-                                    (Prims.of_int (373)) (Prims.of_int (16)))))
+                                    (Prims.of_int (363)) (Prims.of_int (13))
+                                    (Prims.of_int (363)) (Prims.of_int (16)))))
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                    (Prims.of_int (373)) (Prims.of_int (13))
-                                    (Prims.of_int (373)) (Prims.of_int (49)))))
+                                    (Prims.of_int (363)) (Prims.of_int (13))
+                                    (Prims.of_int (363)) (Prims.of_int (49)))))
                            (Obj.magic uu___)
                            (fun uu___1 ->
                               (fun uu___1 ->
@@ -941,17 +927,17 @@ let rec separate_map :
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Typing.Env.fst"
-                                              (Prims.of_int (373))
+                                              (Prims.of_int (363))
                                               (Prims.of_int (28))
-                                              (Prims.of_int (373))
+                                              (Prims.of_int (363))
                                               (Prims.of_int (49)))))
                                      (FStar_Sealed.seal
                                         (Obj.magic
                                            (FStar_Range.mk_range
                                               "Pulse.Typing.Env.fst"
-                                              (Prims.of_int (373))
+                                              (Prims.of_int (363))
                                               (Prims.of_int (20))
-                                              (Prims.of_int (373))
+                                              (Prims.of_int (363))
                                               (Prims.of_int (49)))))
                                      (Obj.magic uu___3)
                                      (fun uu___4 ->
@@ -965,17 +951,17 @@ let rec separate_map :
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Typing.Env.fst"
-                                               (Prims.of_int (373))
+                                               (Prims.of_int (363))
                                                (Prims.of_int (20))
-                                               (Prims.of_int (373))
+                                               (Prims.of_int (363))
                                                (Prims.of_int (49)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "Pulse.Typing.Env.fst"
-                                               (Prims.of_int (373))
+                                               (Prims.of_int (363))
                                                (Prims.of_int (13))
-                                               (Prims.of_int (373))
+                                               (Prims.of_int (363))
                                                (Prims.of_int (49)))))
                                       (Obj.magic uu___2)
                                       (fun uu___3 ->
@@ -1007,8 +993,8 @@ let (env_to_doc' :
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "Pulse.Typing.Env.fst"
-                                     (Prims.of_int (379)) (Prims.of_int (24))
-                                     (Prims.of_int (379)) (Prims.of_int (39)))))
+                                     (Prims.of_int (369)) (Prims.of_int (24))
+                                     (Prims.of_int (369)) (Prims.of_int (39)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range "Prims.fst"
@@ -1025,13 +1011,13 @@ let (env_to_doc' :
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                   (Prims.of_int (379)) (Prims.of_int (23))
-                                   (Prims.of_int (379)) (Prims.of_int (64)))))
+                                   (Prims.of_int (369)) (Prims.of_int (23))
+                                   (Prims.of_int (369)) (Prims.of_int (64)))))
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                   (Prims.of_int (379)) (Prims.of_int (8))
-                                   (Prims.of_int (379)) (Prims.of_int (65)))))
+                                   (Prims.of_int (369)) (Prims.of_int (8))
+                                   (Prims.of_int (369)) (Prims.of_int (65)))))
                           (Obj.magic uu___4)
                           (fun uu___5 ->
                              FStar_Tactics_Effect.lift_div_tac
@@ -1041,13 +1027,13 @@ let (env_to_doc' :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                 (Prims.of_int (379)) (Prims.of_int (8))
-                                 (Prims.of_int (379)) (Prims.of_int (65)))))
+                                 (Prims.of_int (369)) (Prims.of_int (8))
+                                 (Prims.of_int (369)) (Prims.of_int (65)))))
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                 (Prims.of_int (378)) (Prims.of_int (6))
-                                 (Prims.of_int (380)) (Prims.of_int (52)))))
+                                 (Prims.of_int (368)) (Prims.of_int (6))
+                                 (Prims.of_int (370)) (Prims.of_int (52)))))
                         (Obj.magic uu___3)
                         (fun uu___4 ->
                            (fun uu___4 ->
@@ -1059,17 +1045,17 @@ let (env_to_doc' :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Typing.Env.fst"
-                                           (Prims.of_int (380))
+                                           (Prims.of_int (370))
                                            (Prims.of_int (15))
-                                           (Prims.of_int (380))
+                                           (Prims.of_int (370))
                                            (Prims.of_int (51)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Typing.Env.fst"
-                                           (Prims.of_int (380))
+                                           (Prims.of_int (370))
                                            (Prims.of_int (8))
-                                           (Prims.of_int (380))
+                                           (Prims.of_int (370))
                                            (Prims.of_int (52)))))
                                   (Obj.magic uu___6)
                                   (fun uu___7 ->
@@ -1082,17 +1068,17 @@ let (env_to_doc' :
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Typing.Env.fst"
-                                            (Prims.of_int (380))
+                                            (Prims.of_int (370))
                                             (Prims.of_int (8))
-                                            (Prims.of_int (380))
+                                            (Prims.of_int (370))
                                             (Prims.of_int (52)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "Pulse.Typing.Env.fst"
-                                            (Prims.of_int (378))
+                                            (Prims.of_int (368))
                                             (Prims.of_int (6))
-                                            (Prims.of_int (380))
+                                            (Prims.of_int (370))
                                             (Prims.of_int (52)))))
                                    (Obj.magic uu___5)
                                    (fun uu___6 ->
@@ -1106,12 +1092,12 @@ let (env_to_doc' :
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                 (Prims.of_int (377)) (Prims.of_int (4)) (Prims.of_int (380))
+                 (Prims.of_int (367)) (Prims.of_int (4)) (Prims.of_int (370))
                  (Prims.of_int (52)))))
         (FStar_Sealed.seal
            (Obj.magic
               (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                 (Prims.of_int (381)) (Prims.of_int (4)) (Prims.of_int (393))
+                 (Prims.of_int (371)) (Prims.of_int (4)) (Prims.of_int (383))
                  (Prims.of_int (62))))) (Obj.magic uu___)
         (fun uu___1 ->
            (fun pp1 ->
@@ -1146,17 +1132,17 @@ let (env_to_doc' :
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Typing.Env.fst"
-                                                           (Prims.of_int (385))
+                                                           (Prims.of_int (375))
                                                            (Prims.of_int (22))
-                                                           (Prims.of_int (385))
+                                                           (Prims.of_int (375))
                                                            (Prims.of_int (63)))))
                                                   (FStar_Sealed.seal
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "Pulse.Typing.Env.fst"
-                                                           (Prims.of_int (385))
+                                                           (Prims.of_int (375))
                                                            (Prims.of_int (66))
-                                                           (Prims.of_int (388))
+                                                           (Prims.of_int (378))
                                                            (Prims.of_int (32)))))
                                                   (Obj.magic uu___4)
                                                   (fun uu___5 ->
@@ -1172,17 +1158,17 @@ let (env_to_doc' :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Typing.Env.fst"
-                                                                    (Prims.of_int (386))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (386))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (26)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "Pulse.Typing.Env.fst"
-                                                                    (Prims.of_int (386))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (32)))))
                                                              (Obj.magic
                                                                 uu___5)
@@ -1199,17 +1185,17 @@ let (env_to_doc' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Env.fst"
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Env.fst"
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (43)))))
                                                                     (Obj.magic
                                                                     uu___7)
@@ -1226,17 +1212,17 @@ let (env_to_doc' :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Env.fst"
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (387))
+                                                                    (Prims.of_int (377))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "Pulse.Typing.Env.fst"
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (32)))))
                                                                     (Obj.magic
                                                                     uu___6)
@@ -1263,13 +1249,13 @@ let (env_to_doc' :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                            (Prims.of_int (383)) (Prims.of_int (4))
-                            (Prims.of_int (391)) (Prims.of_int (10)))))
+                            (Prims.of_int (373)) (Prims.of_int (4))
+                            (Prims.of_int (381)) (Prims.of_int (10)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                            (Prims.of_int (393)) (Prims.of_int (2))
-                            (Prims.of_int (393)) (Prims.of_int (62)))))
+                            (Prims.of_int (383)) (Prims.of_int (2))
+                            (Prims.of_int (383)) (Prims.of_int (62)))))
                    (Obj.magic uu___1)
                    (fun uu___2 ->
                       (fun maybe_filter ->
@@ -1280,15 +1266,15 @@ let (env_to_doc' :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Typing.Env.fst"
-                                      (Prims.of_int (393)) (Prims.of_int (2))
-                                      (Prims.of_int (393))
+                                      (Prims.of_int (383)) (Prims.of_int (2))
+                                      (Prims.of_int (383))
                                       (Prims.of_int (20)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "Pulse.Typing.Env.fst"
-                                      (Prims.of_int (393)) (Prims.of_int (2))
-                                      (Prims.of_int (393))
+                                      (Prims.of_int (383)) (Prims.of_int (2))
+                                      (Prims.of_int (383))
                                       (Prims.of_int (36)))))
                              (Obj.magic uu___3)
                              (fun uu___4 ->
@@ -1300,17 +1286,17 @@ let (env_to_doc' :
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Typing.Env.fst"
-                                       (Prims.of_int (393))
+                                       (Prims.of_int (383))
                                        (Prims.of_int (2))
-                                       (Prims.of_int (393))
+                                       (Prims.of_int (383))
                                        (Prims.of_int (36)))))
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range
                                        "Pulse.Typing.Env.fst"
-                                       (Prims.of_int (393))
+                                       (Prims.of_int (383))
                                        (Prims.of_int (2))
-                                       (Prims.of_int (393))
+                                       (Prims.of_int (383))
                                        (Prims.of_int (62)))))
                               (Obj.magic uu___2)
                               (fun uu___3 ->
@@ -1339,13 +1325,13 @@ let (get_range :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                     (Prims.of_int (401)) (Prims.of_int (9))
-                     (Prims.of_int (401)) (Prims.of_int (27)))))
+                     (Prims.of_int (391)) (Prims.of_int (9))
+                     (Prims.of_int (391)) (Prims.of_int (27)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                     (Prims.of_int (401)) (Prims.of_int (6))
-                     (Prims.of_int (403)) (Prims.of_int (12)))))
+                     (Prims.of_int (391)) (Prims.of_int (6))
+                     (Prims.of_int (393)) (Prims.of_int (12)))))
             (Obj.magic uu___)
             (fun uu___1 ->
                (fun uu___1 ->
@@ -1373,13 +1359,13 @@ let fail_doc_env :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                     (Prims.of_int (406)) (Prims.of_int (10))
-                     (Prims.of_int (406)) (Prims.of_int (23)))))
+                     (Prims.of_int (396)) (Prims.of_int (10))
+                     (Prims.of_int (396)) (Prims.of_int (23)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                     (Prims.of_int (406)) (Prims.of_int (26))
-                     (Prims.of_int (419)) (Prims.of_int (43)))))
+                     (Prims.of_int (396)) (Prims.of_int (26))
+                     (Prims.of_int (409)) (Prims.of_int (43)))))
             (Obj.magic uu___)
             (fun uu___1 ->
                (fun r1 ->
@@ -1397,13 +1383,13 @@ let fail_doc_env :
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                               (Prims.of_int (408)) (Prims.of_int (19))
-                               (Prims.of_int (408)) (Prims.of_int (47)))))
+                               (Prims.of_int (398)) (Prims.of_int (19))
+                               (Prims.of_int (398)) (Prims.of_int (47)))))
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                               (Prims.of_int (408)) (Prims.of_int (50))
-                               (Prims.of_int (415)) (Prims.of_int (12)))))
+                               (Prims.of_int (398)) (Prims.of_int (50))
+                               (Prims.of_int (405)) (Prims.of_int (12)))))
                       (Obj.magic uu___2)
                       (fun uu___3 ->
                          (fun indent ->
@@ -1424,17 +1410,17 @@ let fail_doc_env :
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Typing.Env.fst"
-                                          (Prims.of_int (410))
+                                          (Prims.of_int (400))
                                           (Prims.of_int (6))
-                                          (Prims.of_int (411))
+                                          (Prims.of_int (401))
                                           (Prims.of_int (47)))))
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Typing.Env.fst"
-                                          (Prims.of_int (413))
+                                          (Prims.of_int (403))
                                           (Prims.of_int (4))
-                                          (Prims.of_int (415))
+                                          (Prims.of_int (405))
                                           (Prims.of_int (12)))))
                                  (Obj.magic uu___3)
                                  (fun uu___4 ->
@@ -1453,17 +1439,17 @@ let fail_doc_env :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Typing.Env.fst"
-                                                                (Prims.of_int (414))
+                                                                (Prims.of_int (404))
                                                                 (Prims.of_int (65))
-                                                                (Prims.of_int (414))
+                                                                (Prims.of_int (404))
                                                                 (Prims.of_int (79)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "Pulse.Typing.Env.fst"
-                                                                (Prims.of_int (414))
+                                                                (Prims.of_int (404))
                                                                 (Prims.of_int (58))
-                                                                (Prims.of_int (414))
+                                                                (Prims.of_int (404))
                                                                 (Prims.of_int (79)))))
                                                        (Obj.magic uu___7)
                                                        (fun uu___8 ->
@@ -1475,17 +1461,17 @@ let fail_doc_env :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Typing.Env.fst"
-                                                              (Prims.of_int (414))
+                                                              (Prims.of_int (404))
                                                               (Prims.of_int (58))
-                                                              (Prims.of_int (414))
+                                                              (Prims.of_int (404))
                                                               (Prims.of_int (79)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "Pulse.Typing.Env.fst"
-                                                              (Prims.of_int (414))
+                                                              (Prims.of_int (404))
                                                               (Prims.of_int (16))
-                                                              (Prims.of_int (414))
+                                                              (Prims.of_int (404))
                                                               (Prims.of_int (79)))))
                                                      (Obj.magic uu___6)
                                                      (fun uu___7 ->
@@ -1500,17 +1486,17 @@ let fail_doc_env :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Typing.Env.fst"
-                                                            (Prims.of_int (414))
+                                                            (Prims.of_int (404))
                                                             (Prims.of_int (16))
-                                                            (Prims.of_int (414))
+                                                            (Prims.of_int (404))
                                                             (Prims.of_int (79)))))
                                                    (FStar_Sealed.seal
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "Pulse.Typing.Env.fst"
-                                                            (Prims.of_int (414))
+                                                            (Prims.of_int (404))
                                                             (Prims.of_int (15))
-                                                            (Prims.of_int (414))
+                                                            (Prims.of_int (404))
                                                             (Prims.of_int (80)))))
                                                    (Obj.magic uu___5)
                                                    (fun uu___6 ->
@@ -1522,17 +1508,17 @@ let fail_doc_env :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Typing.Env.fst"
-                                                          (Prims.of_int (414))
+                                                          (Prims.of_int (404))
                                                           (Prims.of_int (15))
-                                                          (Prims.of_int (414))
+                                                          (Prims.of_int (404))
                                                           (Prims.of_int (80)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "Pulse.Typing.Env.fst"
-                                                          (Prims.of_int (414))
+                                                          (Prims.of_int (404))
                                                           (Prims.of_int (9))
-                                                          (Prims.of_int (414))
+                                                          (Prims.of_int (404))
                                                           (Prims.of_int (80)))))
                                                  (Obj.magic uu___4)
                                                  (fun uu___5 ->
@@ -1551,13 +1537,13 @@ let fail_doc_env :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                (Prims.of_int (407)) (Prims.of_int (11))
-                                (Prims.of_int (415)) (Prims.of_int (12)))))
+                                (Prims.of_int (397)) (Prims.of_int (11))
+                                (Prims.of_int (405)) (Prims.of_int (12)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                (Prims.of_int (416)) (Prims.of_int (4))
-                                (Prims.of_int (419)) (Prims.of_int (43)))))
+                                (Prims.of_int (406)) (Prims.of_int (4))
+                                (Prims.of_int (409)) (Prims.of_int (43)))))
                        (Obj.magic uu___1)
                        (fun uu___2 ->
                           (fun msg1 ->
@@ -1568,17 +1554,17 @@ let fail_doc_env :
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Typing.Env.fst"
-                                          (Prims.of_int (417))
+                                          (Prims.of_int (407))
                                           (Prims.of_int (65))
-                                          (Prims.of_int (417))
+                                          (Prims.of_int (407))
                                           (Prims.of_int (81)))))
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range
                                           "Pulse.Typing.Env.fst"
-                                          (Prims.of_int (417))
+                                          (Prims.of_int (407))
                                           (Prims.of_int (14))
-                                          (Prims.of_int (417))
+                                          (Prims.of_int (407))
                                           (Prims.of_int (81)))))
                                  (Obj.magic uu___3)
                                  (fun uu___4 ->
@@ -1595,17 +1581,17 @@ let fail_doc_env :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Typing.Env.fst"
-                                           (Prims.of_int (417))
+                                           (Prims.of_int (407))
                                            (Prims.of_int (14))
-                                           (Prims.of_int (417))
+                                           (Prims.of_int (407))
                                            (Prims.of_int (81)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "Pulse.Typing.Env.fst"
-                                           (Prims.of_int (418))
+                                           (Prims.of_int (408))
                                            (Prims.of_int (2))
-                                           (Prims.of_int (419))
+                                           (Prims.of_int (409))
                                            (Prims.of_int (43)))))
                                   (Obj.magic uu___2)
                                   (fun uu___3 ->
@@ -1619,17 +1605,17 @@ let fail_doc_env :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Typing.Env.fst"
-                                                      (Prims.of_int (418))
+                                                      (Prims.of_int (408))
                                                       (Prims.of_int (2))
-                                                      (Prims.of_int (418))
+                                                      (Prims.of_int (408))
                                                       (Prims.of_int (22)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "Pulse.Typing.Env.fst"
-                                                      (Prims.of_int (419))
+                                                      (Prims.of_int (409))
                                                       (Prims.of_int (2))
-                                                      (Prims.of_int (419))
+                                                      (Prims.of_int (409))
                                                       (Prims.of_int (43)))))
                                              (Obj.magic uu___3)
                                              (fun uu___4 ->
@@ -1659,13 +1645,13 @@ let (warn_doc :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (422)) (Prims.of_int (10))
-                   (Prims.of_int (422)) (Prims.of_int (23)))))
+                   (Prims.of_int (412)) (Prims.of_int (10))
+                   (Prims.of_int (412)) (Prims.of_int (23)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (422)) (Prims.of_int (26))
-                   (Prims.of_int (424)) (Prims.of_int (22)))))
+                   (Prims.of_int (412)) (Prims.of_int (26))
+                   (Prims.of_int (414)) (Prims.of_int (22)))))
           (Obj.magic uu___)
           (fun uu___1 ->
              (fun r1 ->
@@ -1675,13 +1661,13 @@ let (warn_doc :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                             (Prims.of_int (423)) (Prims.of_int (67))
-                             (Prims.of_int (423)) (Prims.of_int (83)))))
+                             (Prims.of_int (413)) (Prims.of_int (67))
+                             (Prims.of_int (413)) (Prims.of_int (83)))))
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                             (Prims.of_int (423)) (Prims.of_int (14))
-                             (Prims.of_int (423)) (Prims.of_int (83)))))
+                             (Prims.of_int (413)) (Prims.of_int (14))
+                             (Prims.of_int (413)) (Prims.of_int (83)))))
                     (Obj.magic uu___2)
                     (fun uu___3 ->
                        FStar_Tactics_Effect.lift_div_tac
@@ -1694,13 +1680,13 @@ let (warn_doc :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (423)) (Prims.of_int (14))
-                              (Prims.of_int (423)) (Prims.of_int (83)))))
+                              (Prims.of_int (413)) (Prims.of_int (14))
+                              (Prims.of_int (413)) (Prims.of_int (83)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (424)) (Prims.of_int (2))
-                              (Prims.of_int (424)) (Prims.of_int (22)))))
+                              (Prims.of_int (414)) (Prims.of_int (2))
+                              (Prims.of_int (414)) (Prims.of_int (22)))))
                      (Obj.magic uu___1)
                      (fun uu___2 ->
                         (fun issue ->
@@ -1721,13 +1707,13 @@ let (info_doc :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (427)) (Prims.of_int (10))
-                   (Prims.of_int (427)) (Prims.of_int (23)))))
+                   (Prims.of_int (417)) (Prims.of_int (10))
+                   (Prims.of_int (417)) (Prims.of_int (23)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (427)) (Prims.of_int (26))
-                   (Prims.of_int (429)) (Prims.of_int (22)))))
+                   (Prims.of_int (417)) (Prims.of_int (26))
+                   (Prims.of_int (419)) (Prims.of_int (22)))))
           (Obj.magic uu___)
           (fun uu___1 ->
              (fun r1 ->
@@ -1737,13 +1723,13 @@ let (info_doc :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                             (Prims.of_int (428)) (Prims.of_int (64))
-                             (Prims.of_int (428)) (Prims.of_int (80)))))
+                             (Prims.of_int (418)) (Prims.of_int (64))
+                             (Prims.of_int (418)) (Prims.of_int (80)))))
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                             (Prims.of_int (428)) (Prims.of_int (14))
-                             (Prims.of_int (428)) (Prims.of_int (80)))))
+                             (Prims.of_int (418)) (Prims.of_int (14))
+                             (Prims.of_int (418)) (Prims.of_int (80)))))
                     (Obj.magic uu___2)
                     (fun uu___3 ->
                        FStar_Tactics_Effect.lift_div_tac
@@ -1756,13 +1742,13 @@ let (info_doc :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (428)) (Prims.of_int (14))
-                              (Prims.of_int (428)) (Prims.of_int (80)))))
+                              (Prims.of_int (418)) (Prims.of_int (14))
+                              (Prims.of_int (418)) (Prims.of_int (80)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (429)) (Prims.of_int (2))
-                              (Prims.of_int (429)) (Prims.of_int (22)))))
+                              (Prims.of_int (419)) (Prims.of_int (2))
+                              (Prims.of_int (419)) (Prims.of_int (22)))))
                      (Obj.magic uu___1)
                      (fun uu___2 ->
                         (fun issue ->
@@ -1790,13 +1776,13 @@ let (info_doc_env :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (432)) (Prims.of_int (17))
-                   (Prims.of_int (432)) (Prims.of_int (45)))))
+                   (Prims.of_int (422)) (Prims.of_int (17))
+                   (Prims.of_int (422)) (Prims.of_int (45)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                   (Prims.of_int (433)) (Prims.of_int (2))
-                   (Prims.of_int (435)) (Prims.of_int (3)))))
+                   (Prims.of_int (423)) (Prims.of_int (2))
+                   (Prims.of_int (425)) (Prims.of_int (3)))))
           (Obj.magic uu___)
           (fun uu___1 ->
              (fun indent ->
@@ -1809,13 +1795,13 @@ let (info_doc_env :
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                   (Prims.of_int (434)) (Prims.of_int (54))
-                                   (Prims.of_int (434)) (Prims.of_int (68)))))
+                                   (Prims.of_int (424)) (Prims.of_int (54))
+                                   (Prims.of_int (424)) (Prims.of_int (68)))))
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                   (Prims.of_int (434)) (Prims.of_int (47))
-                                   (Prims.of_int (434)) (Prims.of_int (68)))))
+                                   (Prims.of_int (424)) (Prims.of_int (47))
+                                   (Prims.of_int (424)) (Prims.of_int (68)))))
                           (Obj.magic uu___5)
                           (fun uu___6 ->
                              FStar_Tactics_Effect.lift_div_tac
@@ -1824,13 +1810,13 @@ let (info_doc_env :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                 (Prims.of_int (434)) (Prims.of_int (47))
-                                 (Prims.of_int (434)) (Prims.of_int (68)))))
+                                 (Prims.of_int (424)) (Prims.of_int (47))
+                                 (Prims.of_int (424)) (Prims.of_int (68)))))
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                                 (Prims.of_int (434)) (Prims.of_int (5))
-                                 (Prims.of_int (434)) (Prims.of_int (68)))))
+                                 (Prims.of_int (424)) (Prims.of_int (5))
+                                 (Prims.of_int (424)) (Prims.of_int (68)))))
                         (Obj.magic uu___4)
                         (fun uu___5 ->
                            FStar_Tactics_Effect.lift_div_tac
@@ -1842,13 +1828,13 @@ let (info_doc_env :
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                               (Prims.of_int (434)) (Prims.of_int (5))
-                               (Prims.of_int (434)) (Prims.of_int (68)))))
+                               (Prims.of_int (424)) (Prims.of_int (5))
+                               (Prims.of_int (424)) (Prims.of_int (68)))))
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                               (Prims.of_int (434)) (Prims.of_int (4))
-                               (Prims.of_int (434)) (Prims.of_int (69)))))
+                               (Prims.of_int (424)) (Prims.of_int (4))
+                               (Prims.of_int (424)) (Prims.of_int (69)))))
                       (Obj.magic uu___3)
                       (fun uu___4 ->
                          FStar_Tactics_Effect.lift_div_tac
@@ -1857,13 +1843,13 @@ let (info_doc_env :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                             (Prims.of_int (434)) (Prims.of_int (4))
-                             (Prims.of_int (434)) (Prims.of_int (69)))))
+                             (Prims.of_int (424)) (Prims.of_int (4))
+                             (Prims.of_int (424)) (Prims.of_int (69)))))
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                             (Prims.of_int (433)) (Prims.of_int (15))
-                             (Prims.of_int (435)) (Prims.of_int (3)))))
+                             (Prims.of_int (423)) (Prims.of_int (15))
+                             (Prims.of_int (425)) (Prims.of_int (3)))))
                     (Obj.magic uu___2)
                     (fun uu___3 ->
                        FStar_Tactics_Effect.lift_div_tac
@@ -1873,13 +1859,13 @@ let (info_doc_env :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (433)) (Prims.of_int (15))
-                              (Prims.of_int (435)) (Prims.of_int (3)))))
+                              (Prims.of_int (423)) (Prims.of_int (15))
+                              (Prims.of_int (425)) (Prims.of_int (3)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "Pulse.Typing.Env.fst"
-                              (Prims.of_int (433)) (Prims.of_int (2))
-                              (Prims.of_int (435)) (Prims.of_int (3)))))
+                              (Prims.of_int (423)) (Prims.of_int (2))
+                              (Prims.of_int (425)) (Prims.of_int (3)))))
                      (Obj.magic uu___1)
                      (fun uu___2 ->
                         (fun uu___2 -> Obj.magic (info_doc g r uu___2))

--- a/src/ocaml/plugin/generated/Pulse_Typing_Metatheory_Base.ml
+++ b/src/ocaml/plugin/generated/Pulse_Typing_Metatheory_Base.ml
@@ -5,7 +5,8 @@ let (admit_st_comp_typing :
   =
   fun g ->
     fun st ->
-      Pulse_Typing.STC (g, st, (Pulse_Typing_Env.fresh g), (), (), ())
+      let x = Pulse_Typing_Env.fresh g in
+      Pulse_Typing.STC (g, st, x, (), (), ())
 let (admit_comp_typing :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.comp_st -> (unit, unit) Pulse_Typing.comp_typing_u)
@@ -14,13 +15,14 @@ let (admit_comp_typing :
     fun c ->
       match c with
       | Pulse_Syntax_Base.C_ST st ->
-          Pulse_Typing.CT_ST (g, st, (admit_st_comp_typing g st))
+          let uu___ = admit_st_comp_typing g st in
+          Pulse_Typing.CT_ST (g, st, uu___)
       | Pulse_Syntax_Base.C_STAtomic (inames, obs, st) ->
-          Pulse_Typing.CT_STAtomic
-            (g, inames, obs, st, (), (admit_st_comp_typing g st))
+          let uu___ = admit_st_comp_typing g st in
+          Pulse_Typing.CT_STAtomic (g, inames, obs, st, (), uu___)
       | Pulse_Syntax_Base.C_STGhost (inames, st) ->
-          Pulse_Typing.CT_STGhost
-            (g, inames, st, (), (admit_st_comp_typing g st))
+          let uu___ = admit_st_comp_typing g st in
+          Pulse_Typing.CT_STGhost (g, inames, st, (), uu___)
 let (st_typing_correctness_ctot :
   Pulse_Typing_Env.env ->
     Pulse_Syntax_Base.st_term ->
@@ -351,9 +353,9 @@ let rec (st_typing_weakening :
                     Pulse_Typing_Env.fresh
                       (Pulse_Typing_Env.push_env
                          (Pulse_Typing_Env.push_env g2 g1) g') in
-                  Pulse_Typing.T_Abs
-                    (g2, x1, q, b, u, body, c1, (),
-                      (st_typing_weakening g2 g' body c1 body_typing g1))
+                  let uu___ =
+                    st_typing_weakening g2 g' body c1 body_typing g1 in
+                  Pulse_Typing.T_Abs (g2, x1, q, b, u, body, c1, (), uu___)
               | Pulse_Typing.T_STApp
                   (uu___, head, ty, q, res, arg, uu___1, uu___2) ->
                   Pulse_Typing.T_STApp
@@ -385,11 +387,11 @@ let rec (st_typing_weakening :
                         (Pulse_Typing_Env.push_env g g1) g'), c1, use_eq, u,
                       t1, e, post, x, (), (), ())
               | Pulse_Typing.T_Lift (uu___, e, c1, c2, d_c1, d_lift) ->
+                  let uu___1 = st_typing_weakening g g' e c1 d_c1 g1 in
                   Pulse_Typing.T_Lift
                     ((Pulse_Typing_Env.push_env
                         (Pulse_Typing_Env.push_env g g1) g'), e, c1, c2,
-                      (st_typing_weakening g g' e c1 d_c1 g1),
-                      (lift_comp_weakening g g' c1 c2 d_lift g1))
+                      uu___1, (lift_comp_weakening g g' c1 c2 d_lift g1))
               | Pulse_Typing.T_Bind
                   (uu___, e1, e2, c1, c2, b, x, c3, d_e1, uu___1, d_e2, d_bc)
                   ->
@@ -468,22 +470,23 @@ let rec (st_typing_weakening :
                         (Pulse_Typing_Env.push_env g g1) g'), sc_u, sc_ty,
                       sc, (), (), c1, (), brs, d_brs, d_pats_complete)
               | Pulse_Typing.T_Frame (uu___, e, c1, frame, uu___1, d_e) ->
+                  let uu___2 = st_typing_weakening g g' e c1 d_e g1 in
                   Pulse_Typing.T_Frame
                     ((Pulse_Typing_Env.push_env
                         (Pulse_Typing_Env.push_env g g1) g'), e, c1, frame,
-                      (), (st_typing_weakening g g' e c1 d_e g1))
+                      (), uu___2)
               | Pulse_Typing.T_Equiv (uu___, e, c1, c', d_e, d_eq) ->
+                  let uu___1 = st_typing_weakening g g' e c1 d_e g1 in
                   Pulse_Typing.T_Equiv
                     ((Pulse_Typing_Env.push_env
                         (Pulse_Typing_Env.push_env g g1) g'), e, c1, c',
-                      (st_typing_weakening g g' e c1 d_e g1),
-                      (st_equiv_weakening g g' c1 c' d_eq g1))
+                      uu___1, (st_equiv_weakening g g' c1 c' d_eq g1))
               | Pulse_Typing.T_Sub (uu___, e, c1, c', d_e, d_sub) ->
+                  let uu___1 = st_typing_weakening g g' e c1 d_e g1 in
                   Pulse_Typing.T_Sub
                     ((Pulse_Typing_Env.push_env
                         (Pulse_Typing_Env.push_env g g1) g'), e, c1, c',
-                      (st_typing_weakening g g' e c1 d_e g1),
-                      (st_sub_weakening g g' c1 c' d_sub g1))
+                      uu___1, (st_sub_weakening g g' c1 c' d_sub g1))
               | Pulse_Typing.T_IntroPure (uu___, p, uu___1, token) ->
                   Pulse_Typing.T_IntroPure
                     ((Pulse_Typing_Env.push_env
@@ -503,22 +506,24 @@ let rec (st_typing_weakening :
               | Pulse_Typing.T_While
                   (uu___, inv, cond, body, uu___1, cond_typing, body_typing)
                   ->
+                  let uu___2 =
+                    st_typing_weakening g g' cond
+                      (Pulse_Typing.comp_while_cond
+                         Pulse_Syntax_Base.ppname_default inv) cond_typing g1 in
+                  let uu___3 =
+                    st_typing_weakening g g' body
+                      (Pulse_Typing.comp_while_body
+                         Pulse_Syntax_Base.ppname_default inv) body_typing g1 in
                   Pulse_Typing.T_While
                     ((Pulse_Typing_Env.push_env
                         (Pulse_Typing_Env.push_env g g1) g'), inv, cond,
-                      body, (),
-                      (st_typing_weakening g g' cond
-                         (Pulse_Typing.comp_while_cond
-                            Pulse_Syntax_Base.ppname_default inv) cond_typing
-                         g1),
-                      (st_typing_weakening g g' body
-                         (Pulse_Typing.comp_while_body
-                            Pulse_Syntax_Base.ppname_default inv) body_typing
-                         g1))
+                      body, (), uu___2, uu___3)
               | Pulse_Typing.T_Par
                   (uu___, eL, cL, eR, cR, x, cL_typing, cR_typing, eL_typing,
                    eR_typing)
                   ->
+                  let uu___1 = st_typing_weakening g g' eL cL eL_typing g1 in
+                  let uu___2 = st_typing_weakening g g' eR cR eR_typing g1 in
                   Pulse_Typing.T_Par
                     ((Pulse_Typing_Env.push_env
                         (Pulse_Typing_Env.push_env g g1) g'), eL, cL, eR, cR,
@@ -527,8 +532,7 @@ let rec (st_typing_weakening :
                          (Pulse_Syntax_Base.universe_of_comp cL) cL_typing g1),
                       (comp_typing_weakening g g' cR
                          (Pulse_Syntax_Base.universe_of_comp cR) cR_typing g1),
-                      (st_typing_weakening g g' eL cL eL_typing g1),
-                      (st_typing_weakening g g' eR cR eR_typing g1))
+                      uu___1, uu___2)
               | Pulse_Typing.T_WithLocal
                   (uu___, ppname, init, body, init_t, c1, x, uu___1, uu___2,
                    d_c, d_body)
@@ -595,13 +599,13 @@ let rec (st_typing_weakening :
                   (uu___, uu___1, uu___2, uu___3, uu___4, i_typing, p_typing,
                    body_typing, tok)
                   ->
+                  let uu___5 =
+                    st_typing_weakening g g' uu___3
+                      (Pulse_Typing.add_frame_l uu___4 uu___2) body_typing g1 in
                   Pulse_Typing.T_WithInv
                     ((Pulse_Typing_Env.push_env
                         (Pulse_Typing_Env.push_env g g1) g'), uu___1, uu___2,
-                      uu___3, uu___4, (), (),
-                      (st_typing_weakening g g' uu___3
-                         (Pulse_Typing.add_frame_l uu___4 uu___2) body_typing
-                         g1), ())
+                      uu___3, uu___4, (), (), uu___5, ())
 let (nt :
   Pulse_Syntax_Base.var ->
     Pulse_Syntax_Base.term -> FStar_Reflection_Typing.subst_elt Prims.list)


### PR DESCRIPTION
In Pulse, we create free variables to open terms (mainly to check abs terms) and then expect to be able to call F* on those opened terms containing free variables created in Pulse (to normalize, to check equivalence, and to check typing).  For this to work, F* must not create variables that clash with Pulse's.  (Otherwise the names can clash and we get bugs like #234.)

This PR changes the `fresh` function in `Pulse.Typing.Env` to use the F* gensym.

The typing of `fresh` is a bit questionable now.  It promises to return a variable not present in the Pulse environment but that will only be true if all variables were created with `fresh`.  But I suspect that the reflection API requires changes to address the name clash issue (e.g. equiv tokens probably allow you to derive false from a name clash) and this fix here should be workable until we have a proper solution across the board.

The `fresh` function also has the `Dv` effect now since it is non-deterministic; this propagates quite a bit (since typing judgements contain free variables) but it doesn't change much since those functions are used from tactics.

Fixes #234.