### PR TITLE
Slice.subslice

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.ArrayPtr.fsti
+++ b/lib/pulse/lib/Pulse.Lib.ArrayPtr.fsti
@@ -106,11 +106,23 @@ val gather
 let adjacent #t (a: ptr t) (sz: nat) (b: ptr t) : prop =
   base a == base b /\ offset a + sz == offset b
 
-val split (#t: Type) (s: ptr t) (#p: perm) (#v: Ghost.erased (Seq.seq t)) (i: SZ.t { SZ.v i <= Seq.length v }) : stt (ptr t)
+val split (#t: Type) (s: ptr t) (#p: perm) (i: SZ.t)
+  (#v: Ghost.erased (Seq.seq t) { SZ.v i <= Seq.length v })
+  : stt (ptr t)
     (requires pts_to s #p v)
     (ensures fun s' ->
         pts_to s #p (Seq.slice v 0 (SZ.v i)) **
         pts_to s' #p (Seq.slice v (SZ.v i) (Seq.length v)) **
+        pure (adjacent s (SZ.v i) s')
+    )
+
+val ghost_split (#t: Type) (s: ptr t) (#p: perm) (i: SZ.t)
+  (#v: Ghost.erased (Seq.seq t) { SZ.v i <= Seq.length v })
+  : stt_ghost (erased (ptr t)) []
+    (requires pts_to s #p v)
+    (ensures fun s' ->
+        pts_to s #p (Seq.slice v 0 (SZ.v i)) **
+        pts_to (reveal s') #p (Seq.slice v (SZ.v i) (Seq.length v)) **
         pure (adjacent s (SZ.v i) s')
     )
 

--- a/lib/pulse/lib/Pulse.Lib.Slice.fst
+++ b/lib/pulse/lib/Pulse.Lib.Slice.fst
@@ -184,7 +184,7 @@ fn split (#t: Type) (s: slice t) (#p: perm) (i: SZ.t)
 {
     unfold_pts_to s #p v;
     Seq.lemma_split v (SZ.v i);
-    let elt' = AP.split s.elt #p #v i;
+    let elt' = AP.split s.elt #p i;
     let s1 = {
         elt = s.elt;
         len = i;
@@ -209,6 +209,27 @@ fn join (#t: Type) (s1: slice t) (#p: perm) (#v1: Seq.seq t) (s2: slice t) (#v2:
     unfold_pts_to s2 #p v2;
     AP.join s1.elt s2.elt;
     fold_pts_to s #p (Seq.append v1 v2)
+}
+
+fn subslice #t (s: slice t) #p (i j: SZ.t) (#v: erased (Seq.seq t) { SZ.v i <= SZ.v j /\ SZ.v j <= Seq.length v })
+  requires pts_to s #p v
+  returns res: slice t
+  ensures pts_to res #p (Seq.slice v (SZ.v i) (SZ.v j)) ** subslice_rest res s p i j v
+{
+  unfold_pts_to s #p v;
+  let elt' = AP.split s.elt i;
+  let elt'' = AP.ghost_split elt' (SZ.sub j i);
+  let s1 = hide { elt = s.elt; len = i };
+  let s2 = hide { elt = elt'; len = SZ.sub s.len i };
+  fold is_split s s1 s2;
+  let res = hide { elt = elt'; len = SZ.sub j i };
+  let s3 = hide { elt = elt''; len = SZ.sub s.len j };
+  fold is_split s2 res s3;
+  fold_pts_to s1 #p (Seq.slice v 0 (SZ.v i));
+  fold_pts_to res #p (Seq.slice v (SZ.v i) (SZ.v j));
+  fold_pts_to s3 #p (Seq.slice v (SZ.v j) (Seq.length v));
+  fold subslice_rest;
+  ({ elt = elt'; len = SZ.sub j i })
 }
 
 fn copy

--- a/lib/pulse/lib/Pulse.Lib.Slice.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Slice.fsti
@@ -110,6 +110,18 @@ val join (#t: Type) (s1: slice t) (#p: perm) (#v1: Seq.seq t) (s2: slice t) (#v2
     (pts_to s1 #p v1 ** pts_to s2 #p v2 ** is_split s s1 s2)
     (fun _ -> pts_to s #p (Seq.append v1 v2))
 
+(* `subslice_rest r s p i j v` is the resource remaining after taking the subslice `r = s[i..j]` *)
+let subslice_rest #t (r: slice t) (s: slice t) p (i j: SZ.t) (v: erased (Seq.seq t) { SZ.v i <= SZ.v j /\ SZ.v j <= Seq.length v }) : slprop =
+  exists* s1 s2 s3.
+    is_split s s1 s2 **
+    is_split s2 r s3 **
+    pts_to s1 #p (Seq.slice v 0 (SZ.v i)) **
+    pts_to s3 #p (Seq.slice v (SZ.v j) (Seq.length v))
+
+val subslice #t (s: slice t) #p (i j: SZ.t) (#v: erased (Seq.seq t) { SZ.v i <= SZ.v j /\ SZ.v j <= Seq.length v }) :
+  stt (slice t) (pts_to s #p v)
+    fun res -> pts_to res #p (Seq.slice v (SZ.v i) (SZ.v j)) ** subslice_rest res s p i j v
+
 val copy (#t: Type) (dst: slice t) (#p: perm) (src: slice t) (#v: Ghost.erased (Seq.seq t)) : stt unit
     (exists* v_dst . pts_to dst v_dst ** pts_to src #p v ** pure (len src == len dst))
     (fun _ -> pts_to dst v ** pts_to src #p v)

--- a/pulse2rust/src/Pulse2Rust.Extract.fst
+++ b/pulse2rust/src/Pulse2Rust.Extract.fst
@@ -660,6 +660,10 @@ and extract_mlexpr (g:env) (e:S.mlexpr) : expr =
   | S.MLE_App ({expr=S.MLE_TApp ({expr=S.MLE_Name p}, [_])}, e::_::i::_)
     when S.string_of_mlpath p = "Pulse.Lib.Slice.split" ->
     mk_method_call (extract_mlexpr g e) "split_at_mut" [extract_mlexpr g i]
+  | S.MLE_App ({expr=S.MLE_TApp ({expr=S.MLE_Name p}, [_])}, s::_::a::b::_)
+    when S.string_of_mlpath p = "Pulse.Lib.Slice.subslice" ->
+    let mutb = true in
+    mk_reference_expr true (mk_expr_index (extract_mlexpr g s) (mk_range (Some (extract_mlexpr g a)) RangeLimitsHalfOpen (Some (extract_mlexpr g b))))
   | S.MLE_App ({expr=S.MLE_TApp ({expr=S.MLE_Name p}, [_])}, a::_::b::_)
     when S.string_of_mlpath p = "Pulse.Lib.Slice.copy" ->
     mk_method_call (extract_mlexpr g a) "copy_from_slice" [extract_mlexpr g b]

--- a/pulse2rust/src/Pulse2Rust.Rust.Syntax.fst
+++ b/pulse2rust/src/Pulse2Rust.Rust.Syntax.fst
@@ -189,6 +189,13 @@ let mk_cast (e:expr) (ty:typ) : expr =
     expr_cast_type = ty;
   }
 
+let mk_range (s:option expr) (l:range_limits) (e:option expr) : expr =
+  Expr_range {
+    expr_range_start = s;
+    expr_range_limits = l;
+    expr_range_end = e;
+  }
+
 let mk_new_mutex (e:expr) =
   mk_call
     (mk_expr_path ["std"; "sync"; "Mutex"; "new"])

--- a/pulse2rust/src/Pulse2Rust.Rust.Syntax.fsti
+++ b/pulse2rust/src/Pulse2Rust.Rust.Syntax.fsti
@@ -112,6 +112,7 @@ and expr =
   | Expr_tuple of list expr
   | Expr_method_call of expr_method_call
   | Expr_cast of expr_cast
+  | Expr_range of expr_range
 
 and expr_bin = {
   expr_bin_left : expr;
@@ -196,6 +197,16 @@ and expr_cast = {
   expr_cast_expr : expr;
   expr_cast_type : typ;
 }
+
+and expr_range = {
+  expr_range_start: option expr;
+  expr_range_limits: range_limits;
+  expr_range_end: option expr;
+}
+
+and range_limits =
+  | RangeLimitsHalfOpen
+  | RangeLimitsClosed
 
 and local_stmt = {
   local_stmt_pat : option pat;
@@ -358,6 +369,7 @@ val mk_expr_tuple (l:list expr) : expr
 val mk_mem_replace (t:typ) (e:expr) (new_v:expr) : expr
 val mk_method_call (receiver:expr) (name:string) (args:list expr) : expr
 val mk_cast (e:expr) (ty:typ) : expr
+val mk_range (s:option expr) (l:range_limits) (e:option expr) : expr
 
 val mk_new_mutex (e:expr) : expr
 val mk_lock_mutex (e:expr) : expr

--- a/pulse2rust/src/ocaml/generated/Pulse2Rust_Extract.ml
+++ b/pulse2rust/src/ocaml/generated/Pulse2Rust_Extract.ml
@@ -1252,6 +1252,36 @@ and (extract_mlexpr :
                 uu___2::[]);
              FStarC_Extraction_ML_Syntax.mlty = uu___3;
              FStarC_Extraction_ML_Syntax.loc = uu___4;_},
+           s::uu___5::a::b::uu___6)
+          when
+          let uu___7 = FStarC_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___7 = "Pulse.Lib.Slice.subslice" ->
+          let mutb = true in
+          let uu___7 =
+            let uu___8 = extract_mlexpr g s in
+            let uu___9 =
+              let uu___10 =
+                let uu___11 = extract_mlexpr g a in
+                FStar_Pervasives_Native.Some uu___11 in
+              let uu___11 =
+                let uu___12 = extract_mlexpr g b in
+                FStar_Pervasives_Native.Some uu___12 in
+              Pulse2Rust_Rust_Syntax.mk_range uu___10
+                Pulse2Rust_Rust_Syntax.RangeLimitsHalfOpen uu___11 in
+            Pulse2Rust_Rust_Syntax.mk_expr_index uu___8 uu___9 in
+          Pulse2Rust_Rust_Syntax.mk_reference_expr true uu___7
+      | FStarC_Extraction_ML_Syntax.MLE_App
+          ({
+             FStarC_Extraction_ML_Syntax.expr =
+               FStarC_Extraction_ML_Syntax.MLE_TApp
+               ({
+                  FStarC_Extraction_ML_Syntax.expr =
+                    FStarC_Extraction_ML_Syntax.MLE_Name p;
+                  FStarC_Extraction_ML_Syntax.mlty = uu___;
+                  FStarC_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2::[]);
+             FStarC_Extraction_ML_Syntax.mlty = uu___3;
+             FStarC_Extraction_ML_Syntax.loc = uu___4;_},
            a::uu___5::b::uu___6)
           when
           let uu___7 = FStarC_Extraction_ML_Syntax.string_of_mlpath p in

--- a/pulse2rust/src/ocaml/generated/Pulse2Rust_Rust_Syntax.ml
+++ b/pulse2rust/src/ocaml/generated/Pulse2Rust_Rust_Syntax.ml
@@ -163,6 +163,7 @@ and expr =
   | Expr_tuple of expr Prims.list 
   | Expr_method_call of expr_method_call 
   | Expr_cast of expr_cast 
+  | Expr_range of expr_range 
 and expr_bin =
   {
   expr_bin_left: expr ;
@@ -221,6 +222,14 @@ and expr_method_call =
 and expr_cast = {
   expr_cast_expr: expr ;
   expr_cast_type: typ }
+and expr_range =
+  {
+  expr_range_start: expr FStar_Pervasives_Native.option ;
+  expr_range_limits: range_limits ;
+  expr_range_end: expr FStar_Pervasives_Native.option }
+and range_limits =
+  | RangeLimitsHalfOpen 
+  | RangeLimitsClosed 
 and local_stmt =
   {
   local_stmt_pat: pat FStar_Pervasives_Native.option ;
@@ -406,6 +415,11 @@ let (uu___is_Expr_cast : expr -> Prims.bool) =
     match projectee with | Expr_cast _0 -> true | uu___ -> false
 let (__proj__Expr_cast__item___0 : expr -> expr_cast) =
   fun projectee -> match projectee with | Expr_cast _0 -> _0
+let (uu___is_Expr_range : expr -> Prims.bool) =
+  fun projectee ->
+    match projectee with | Expr_range _0 -> true | uu___ -> false
+let (__proj__Expr_range__item___0 : expr -> expr_range) =
+  fun projectee -> match projectee with | Expr_range _0 -> _0
 let (__proj__Mkexpr_bin__item__expr_bin_left : expr_bin -> expr) =
   fun projectee ->
     match projectee with
@@ -567,6 +581,30 @@ let (__proj__Mkexpr_cast__item__expr_cast_type : expr_cast -> typ) =
   fun projectee ->
     match projectee with
     | { expr_cast_expr; expr_cast_type;_} -> expr_cast_type
+let (__proj__Mkexpr_range__item__expr_range_start :
+  expr_range -> expr FStar_Pervasives_Native.option) =
+  fun projectee ->
+    match projectee with
+    | { expr_range_start; expr_range_limits; expr_range_end;_} ->
+        expr_range_start
+let (__proj__Mkexpr_range__item__expr_range_limits :
+  expr_range -> range_limits) =
+  fun projectee ->
+    match projectee with
+    | { expr_range_start; expr_range_limits; expr_range_end;_} ->
+        expr_range_limits
+let (__proj__Mkexpr_range__item__expr_range_end :
+  expr_range -> expr FStar_Pervasives_Native.option) =
+  fun projectee ->
+    match projectee with
+    | { expr_range_start; expr_range_limits; expr_range_end;_} ->
+        expr_range_end
+let (uu___is_RangeLimitsHalfOpen : range_limits -> Prims.bool) =
+  fun projectee ->
+    match projectee with | RangeLimitsHalfOpen -> true | uu___ -> false
+let (uu___is_RangeLimitsClosed : range_limits -> Prims.bool) =
+  fun projectee ->
+    match projectee with | RangeLimitsClosed -> true | uu___ -> false
 let (__proj__Mklocal_stmt__item__local_stmt_pat :
   local_stmt -> pat FStar_Pervasives_Native.option) =
   fun projectee ->
@@ -1088,6 +1126,15 @@ let (mk_method_call : expr -> Prims.string -> expr Prims.list -> expr) =
           }
 let (mk_cast : expr -> typ -> expr) =
   fun e -> fun ty -> Expr_cast { expr_cast_expr = e; expr_cast_type = ty }
+let (mk_range :
+  expr FStar_Pervasives_Native.option ->
+    range_limits -> expr FStar_Pervasives_Native.option -> expr)
+  =
+  fun s ->
+    fun l ->
+      fun e ->
+        Expr_range
+          { expr_range_start = s; expr_range_limits = l; expr_range_end = e }
 let (mk_new_mutex : expr -> expr) =
   fun e ->
     let uu___ = mk_expr_path ["std"; "sync"; "Mutex"; "new"] in

--- a/pulse2rust/tests/src/example_slice.rs
+++ b/pulse2rust/tests/src/example_slice.rs
@@ -9,7 +9,11 @@ pub fn test(arr: &mut [u8]) -> () {
     let _letpattern = slice.split_at_mut(2);
     match _letpattern {
         (mut s1, mut s2) => {
-            let x = s2[s1.len()];
+            let s2_ = {
+                let res = &mut s2[1..4];
+                res
+            };
+            let x = s2_[s1.len()];
             s1[1] = x;
             let _letpattern1 = s2.split_at_mut(2);
             match _letpattern1 {

--- a/share/pulse/examples/Example.Slice.fst
+++ b/share/pulse/examples/Example.Slice.fst
@@ -16,19 +16,22 @@
 module Example.Slice
 #lang-pulse
 open Pulse
-open Pulse.Lib.Slice
+open Pulse.Lib.Trade
+open Pulse.Lib.Slice.Util
 module A = Pulse.Lib.Array
 
 fn test (arr: A.array UInt8.t)
     requires pts_to arr seq![0uy; 1uy; 2uy; 3uy; 4uy; 5uy]
-    ensures exists* s. pts_to arr s ** pure (s `Seq.equal` seq![0uy; 4uy; 4uy; 5uy; 4uy; 5uy]) {
+    ensures exists* s. pts_to arr s ** pure (s `Seq.equal` seq![0uy; 5uy; 4uy; 5uy; 4uy; 5uy]) {
   A.pts_to_len arr;
   let slice = from_array arr 6sz;
   let SlicePair s1 s2 = split slice 2sz;
   pts_to_len s1;
   share s2;
-  let x = s2.(len s1);
+  let s2' = subslice_trade s2 1sz 4sz;
+  let x = s2'.(len s1);
   s1.(1sz) <- x;
+  elim_trade _ _;
   gather s2;
   let SlicePair s3 s4 = split s2 2sz;
   pts_to_len s3;

--- a/src/extraction/ExtractPulse.fst
+++ b/src/extraction/ExtractPulse.fst
@@ -128,7 +128,7 @@ let pulse_translate_expr : translate_expr_t = fun env e ->
     when string_of_mlpath p = "Pulse.Lib.ArrayPtr.from_array" ->
     translate_expr env x
 
-  | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ a; _p; _w; i ])
+  | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ a; _p; i; _w ])
     when string_of_mlpath p = "Pulse.Lib.ArrayPtr.split" ->
     EBufSub (translate_expr env a, translate_expr env i)
 

--- a/src/ocaml/plugin/generated/ExtractPulse.ml
+++ b/src/ocaml/plugin/generated/ExtractPulse.ml
@@ -455,7 +455,7 @@ let (pulse_translate_expr : FStarC_Extraction_Krml.translate_expr_t) =
                  uu___3);
               FStarC_Extraction_ML_Syntax.mlty = uu___4;
               FStarC_Extraction_ML_Syntax.loc = uu___5;_},
-            a::_p::_w::i::[])
+            a::_p::i::_w::[])
            when
            let uu___6 = FStarC_Extraction_ML_Syntax.string_of_mlpath p in
            uu___6 = "Pulse.Lib.ArrayPtr.split" ->


### PR DESCRIPTION
This extends the new slice API with a new `subslice` function extracting to `&s[a..b]` in Rust.