### PR TITLE
Fix postcondition of `Pulse.Lib.Slice.Util.split_trade`

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.Slice.Util.fst
+++ b/lib/pulse/lib/Pulse.Lib.Slice.Util.fst
@@ -89,7 +89,7 @@ fn split_trade (#t: Type) (s: S.slice t) (#p: perm) (i: SZ.t) (#v: Ghost.erased 
       let v2 = Seq.slice v (SZ.v i) (Seq.length v) in
       pts_to s1 #p v1 ** pts_to s2 #p v2 **
       trade (pts_to s1 #p v1 ** pts_to s2 #p v2)
-        (pts_to s #p (v1 `Seq.append` v2)))
+        (pts_to s #p v))
 {
   Seq.lemma_split v (SZ.v i);
   let SlicePair s1 s2 = S.split s i;


### PR DESCRIPTION
The RHS of the trade should be the same as the precondition of the function.