### PR TITLE
Implement Pulse.Lib.SeqMatch

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.SeqMatch.fst
+++ b/lib/pulse/lib/Pulse.Lib.SeqMatch.fst
@@ -1,0 +1,902 @@
+module Pulse.Lib.SeqMatch
+#lang-pulse
+open Pulse.Lib.OnRange
+open Pulse.Lib.Stick.Util
+
+module Seq = FStar.Seq
+module SZ = FStar.SizeT
+
+(* `seq_list_match` describes how to match a sequence of low-level
+values (the low-level contents of an array) with a list of high-level
+values. `seq_list_match` is carefully designed to be usable within
+(mutually) recursive definitions of matching functions on the type of
+high-level values.  *)
+
+let rec seq_list_match
+  (#t #t': Type)
+  (c: Seq.seq t)
+  (v: list t')
+  (item_match: (t -> (v': t' { v' << v }) -> slprop))
+: Tot slprop
+  (decreases v)
+= match v with
+  | [] -> pure (c `Seq.equal` Seq.empty)
+  | a :: q -> exists* c1 c2 .
+    item_match c1 a **
+    seq_list_match c2 q item_match **
+    pure (c `Seq.equal` Seq.cons c1 c2)
+
+ghost
+fn seq_list_match_nil_intro
+  (#t: Type0) (#t': Type0)
+  (c: Seq.seq t)
+  (v: list t')
+  (item_match: (t -> (v': t' { v' << v }) -> slprop))
+requires
+    (pure (c `Seq.equal` Seq.empty /\
+      Nil? v))
+ensures
+    seq_list_match c v item_match
+{
+  fold (seq_list_match c [] item_match)
+}
+
+ghost
+fn seq_list_match_nil_elim
+  (#t #t': Type0)
+  (c: Seq.seq t)
+  (v: list t')
+  (item_match: (t -> (v': t' { v' << v }) -> slprop))
+requires
+    (seq_list_match c v item_match ** pure (
+      c `Seq.equal` Seq.empty \/
+      Nil? v
+    ))
+ensures
+    (pure (
+      c `Seq.equal` Seq.empty /\
+      Nil? v
+    ))
+{
+  match v {
+    Nil -> {
+      unfold (seq_list_match c [] item_match);
+    }
+    Cons a q -> {
+      unfold (seq_list_match c (a :: q) item_match);
+      fold (seq_list_match c (a :: q) item_match);
+      rewrite (seq_list_match c (a :: q) item_match) as emp // by contradiction
+    }
+  }
+}
+
+ghost
+fn seq_list_match_cons_intro
+  (#t #t': Type0)
+  (a: t)
+  (a' : t')
+  (c: Seq.seq t)
+  (v: list t')
+  (item_match: (t -> (v': t' { v' << a' :: v }) -> slprop))
+requires
+    (item_match a a' ** seq_list_match c v item_match)
+ensures
+    (seq_list_match (Seq.cons a c) (a' :: v) item_match)
+{
+  fold (seq_list_match (Seq.cons a c) (a' :: v) item_match)
+}
+
+ghost
+fn seq_list_match_cons_elim
+  (#t #t': Type0)
+  (c: Seq.seq t)
+  (v: list t' { Cons? v \/ Seq.length c > 0 })
+  (item_match: (t -> (v': t' { v' << v }) -> slprop))
+requires
+    (seq_list_match c v item_match)
+returns res: (squash (Cons? v /\ Seq.length c > 0))
+ensures
+    (item_match (Seq.head c) (List.Tot.hd v) **
+      seq_list_match (Seq.tail c) (List.Tot.tl v) item_match
+    )
+{
+  if (Seq.length c = 0 || Nil? v) {
+    seq_list_match_nil_elim c v item_match;
+    let res : squash (Cons? v /\ Seq.length c > 0) = (); // by contradiction
+    rewrite emp as (
+      item_match (Seq.head c) (List.Tot.hd v) **
+      seq_list_match (Seq.tail c) (List.Tot.tl v) item_match      
+    ); // by contradiction
+    res
+  } else {
+    let res : squash (Cons? v /\ Seq.length c > 0) = ();
+    unfold (seq_list_match c (List.Tot.hd v :: List.Tot.tl v) item_match);
+    with c1 . assert (item_match c1 (List.Tot.hd v));
+    with c2 . assert (seq_list_match c2 (List.Tot.tl v) item_match);
+    assert (pure (c2 `Seq.equal` Seq.tail c));
+    rewrite (item_match c1 (List.Tot.hd v)) as (item_match (Seq.head c) (List.Tot.hd v));
+    res
+  }
+}
+
+// this one cannot be proven with seq_seq_match because of the << refinement in the type of item_match
+ghost
+fn rec seq_list_match_weaken
+  (#t #t': Type0)
+  (c: Seq.seq t)
+  (v: list t')
+  (item_match1 item_match2: (t -> (v': t' { v' << v }) -> slprop))
+  (prf: (
+    (c': t) ->
+    (v': t' { v' << v }) ->
+    stt_ghost unit emp_inames
+      (item_match1 c' v')
+      (fun _ -> item_match2 c' v')
+  ))
+requires
+    (seq_list_match c v item_match1)
+ensures
+    (seq_list_match c v item_match2)
+decreases v
+{
+  if Nil? v {
+    seq_list_match_nil_elim c v item_match1;
+    seq_list_match_nil_intro c v item_match2;
+  } else {
+    list_cons_precedes (List.Tot.hd v) (List.Tot.tl v);
+    let _ : squash (List.Tot.tl v << v) = ();
+    seq_list_match_cons_elim c v item_match1;
+    prf (Seq.head c) (List.Tot.hd v);
+    ghost fn prf'
+      (c': t)
+      (v': t' { v' << List.Tot.tl v })
+    requires
+      item_match1 c' v'
+    ensures
+      item_match2 c' v'
+    {
+      prf c' v'
+    };
+    seq_list_match_weaken (Seq.tail c) (List.Tot.tl v) item_match1 item_match2 prf';
+    Seq.cons_head_tail c;
+    seq_list_match_cons_intro (Seq.head c) (List.Tot.hd v) (Seq.tail c) (List.Tot.tl v) item_match2;
+  }
+}
+
+(* `seq_seq_match` describes how to match a sequence of low-level
+values (the low-level contents of an array) with a sequence of high-level
+values. Contrary to `seq_list_match`, `seq_seq_match` is not meant to be usable within
+(mutually) recursive definitions of matching functions on the type of
+high-level values, because no lemma ensures that `Seq.index s i << s`  *)
+
+let seq_seq_match_item
+  (#t1 #t2: Type)
+  (p: t1 -> t2 -> slprop)
+  (c: Seq.seq t1)
+  (l: Seq.seq t2)
+  (i: nat)
+: Tot slprop
+= if i < Seq.length c && i < Seq.length l
+  then
+    p (Seq.index c i) (Seq.index l i)
+  else
+    pure False
+
+let seq_seq_match_item_tail
+  (#t1 #t2: Type)
+  (p: t1 -> t2 -> slprop)
+  (c: Seq.seq t1)
+  (l: Seq.seq t2)
+  (delta: nat)
+  (i: nat)
+: Lemma
+  (requires (
+    i + delta <= Seq.length c /\
+    i + delta <= Seq.length l
+  ))
+  (ensures (
+    seq_seq_match_item p (Seq.slice c delta (Seq.length c)) (Seq.slice l delta (Seq.length l)) i ==
+      seq_seq_match_item p c l (i + delta)
+  ))
+= ()
+
+let seq_seq_match
+  (#t1 #t2: Type)
+  (p: t1 -> t2 -> slprop)
+  (c: Seq.seq t1)
+  (l: Seq.seq t2)
+  (i j: nat)
+: Tot slprop
+= on_range (seq_seq_match_item p c l) i j
+
+ghost
+fn seq_seq_match_length
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (s1: Seq.seq t1)
+  (s2: Seq.seq t2)
+  (i j: nat)
+requires
+    (seq_seq_match p s1 s2 i j)
+ensures
+    (seq_seq_match p s1 s2 i j ** pure (i <= j /\ (i == j \/ (j <= Seq.length s1 /\ j <= Seq.length s2))))
+{
+  unfold (seq_seq_match p s1 s2 i j);
+  on_range_le (seq_seq_match_item p s1 s2) #i #j;
+  if (i = j) {
+    fold (seq_seq_match p s1 s2 i j)
+  } else {
+    let j' = j - 1;
+    if (j' < Seq.length s1 && j' < Seq.length s2) {
+      fold (seq_seq_match p s1 s2 i j);
+    } else {
+      on_range_unsnoc
+        ()
+        #(seq_seq_match_item p s1 s2)
+        #i #j;
+      rewrite
+        (seq_seq_match_item p s1 s2 (j - 1))
+        as
+        (pure False);
+      rewrite
+        (on_range (seq_seq_match_item p s1 s2) i (j - 1))
+        as
+        (seq_seq_match p s1 s2 i j); // by contradiction
+    }
+  }
+}
+
+ghost fn seq_seq_match_weaken
+  (#t1 #t2: Type0)
+  (p p': t1 -> t2 -> slprop)
+  (w: ((x1: t1) -> (x2: t2) -> stt_ghost unit emp_inames
+    (p x1 x2) (fun _ -> p' x1 x2)
+  ))
+  (c1 c1': Seq.seq t1)
+  (c2 c2': Seq.seq t2)
+  (i j: nat)
+requires
+    (seq_seq_match p c1 c2 i j ** pure (
+      (i <= j /\ (i == j \/ (
+        j <= Seq.length c1 /\ j <= Seq.length c2 /\
+        j <= Seq.length c1' /\ j <= Seq.length c2' /\
+        Seq.slice c1 i j `Seq.equal` Seq.slice c1' i j /\
+        Seq.slice c2 i j `Seq.equal` Seq.slice c2' i j
+      )))
+    ))
+ensures
+    (seq_seq_match p' c1' c2' i j)
+{
+  unfold (seq_seq_match p c1 c2 i j);
+  ghost fn aux
+    (k: (k: nat { i <= k /\ k < j }))
+  requires
+    seq_seq_match_item p c1 c2 k
+  ensures
+    seq_seq_match_item p' c1' c2' k
+  {
+    rewrite (seq_seq_match_item p c1 c2 k)
+      as (p (Seq.index (Seq.slice c1 i j) (k - i)) (Seq.index (Seq.slice c2 i j) (k - i)));
+    w _ _;
+    rewrite (p' (Seq.index (Seq.slice c1 i j) (k - i)) (Seq.index (Seq.slice c2 i j) (k - i)))
+      as (seq_seq_match_item p' c1' c2' k)
+  };
+  on_range_weaken
+    (seq_seq_match_item p c1 c2)
+    (seq_seq_match_item p' c1' c2')
+    i j
+    aux;
+  fold (seq_seq_match p' c1' c2' i j)
+}
+
+ghost fn seq_seq_match_weaken_with_implies
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (c1 c1': Seq.seq t1)
+  (c2 c2': Seq.seq t2)
+  (i j: nat)
+requires
+    (seq_seq_match p c1 c2 i j ** pure (
+      (i <= j /\ (i == j \/ (
+        j <= Seq.length c1 /\ j <= Seq.length c2 /\
+        j <= Seq.length c1' /\ j <= Seq.length c2' /\
+        Seq.slice c1 i j `Seq.equal` Seq.slice c1' i j /\
+        Seq.slice c2 i j `Seq.equal` Seq.slice c2' i j
+      )))
+    ))
+ensures
+    (seq_seq_match p c1' c2' i j **
+      (seq_seq_match p c1' c2' i j @==> seq_seq_match p c1 c2 i j)
+    )
+{
+  ghost fn aux1
+    (x1: t1) (x2: t2)
+  requires (p x1 x2)
+  ensures (p x1 x2)
+  {
+    ()
+  };
+  seq_seq_match_weaken
+    p p aux1
+    c1 c1'
+    c2 c2'
+    i j;
+  ghost fn aux2 (_: unit)
+    requires emp ** (seq_seq_match p c1' c2' i j)
+    ensures seq_seq_match p c1 c2 i j
+  {
+      seq_seq_match_weaken
+        p p aux1
+        c1' c1
+        c2' c2
+        i j
+  };
+  intro_stick
+    (seq_seq_match p c1' c2' i j)
+    (seq_seq_match p c1 c2 i j)
+    emp
+    aux2
+}
+
+(* Going between `seq_list_match` and `seq_seq_match` *)
+
+ghost fn seq_seq_match_tail_elim
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (c: Seq.seq t1)
+  (l: Seq.seq (t2))
+  (delta: nat {
+    delta <= Seq.length c /\
+    delta <= Seq.length l
+  })
+  (i j: nat)
+requires
+    (seq_seq_match p (Seq.slice c delta (Seq.length c)) (Seq.slice l delta (Seq.length l)) i j)
+ensures
+    (seq_seq_match p c l (i + delta) (j + delta))
+{
+  unfold (seq_seq_match p (Seq.slice c delta (Seq.length c)) (Seq.slice l delta (Seq.length l)) i j);
+  on_range_le (seq_seq_match_item p _ _);
+  ghost fn aux
+    (k: nat { i <= k /\ k < j })
+  requires
+    seq_seq_match_item p (Seq.slice c delta (Seq.length c)) (Seq.slice l delta (Seq.length l)) k
+  ensures
+    seq_seq_match_item p c l (k + delta)
+  {
+    if (k < Seq.length c - delta && k < Seq.length l - delta) {
+       seq_seq_match_item_tail p c l delta k;
+       rewrite
+         (seq_seq_match_item p (Seq.slice c delta (Seq.length c)) (Seq.slice l delta (Seq.length l)) k)
+       as
+       (seq_seq_match_item p c l (k + delta))
+    } else {
+      rewrite
+        (seq_seq_match_item p (Seq.slice c delta (Seq.length c)) (Seq.slice l delta (Seq.length l)) k)
+        as
+        (pure False);
+      rewrite
+        emp
+        as
+        (seq_seq_match_item p c l (k + delta)) // by contradiction
+    }
+  };
+  on_range_weaken_and_shift
+    (seq_seq_match_item p (Seq.slice c delta (Seq.length c)) (Seq.slice l delta (Seq.length l)))
+    (seq_seq_match_item p c l)
+    delta
+    i j
+    aux;
+  fold (seq_seq_match p c l (i + delta) (j + delta))
+}
+
+ghost fn seq_seq_match_tail_intro
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (c: Seq.seq t1)
+  (l: Seq.seq t2)
+  (delta: nat {
+    delta <= Seq.length c /\
+    delta <= Seq.length l
+  })
+  (i: nat {
+    delta <= i
+  })
+  (j: nat)
+requires
+    (seq_seq_match p c l i j)
+returns res: squash (i <= j)
+ensures
+    (seq_seq_match p (Seq.slice c delta (Seq.length c)) (Seq.slice l delta (Seq.length l)) (i - delta) (j - delta))
+{
+  unfold (seq_seq_match p c l i j);
+  on_range_le (seq_seq_match_item p _ _);
+  ghost fn aux
+    (k: nat { i <= k /\ k < j })
+  requires
+    seq_seq_match_item p c l k
+  ensures
+    seq_seq_match_item p (Seq.slice c delta (Seq.length c)) (Seq.slice l delta (Seq.length l)) (k + (0 - delta))
+  {
+      if (k < Seq.length c && k < Seq.length l) {
+        seq_seq_match_item_tail p c l delta (k - delta);
+        rewrite
+          (seq_seq_match_item p c l k)
+          as
+          (seq_seq_match_item p (Seq.slice c delta (Seq.length c)) (Seq.slice l delta (Seq.length l)) (k + (0 - delta)))
+      } else {
+        rewrite
+          (seq_seq_match_item p c l k)
+          as
+          (pure False);
+        rewrite
+          emp
+          as
+          (seq_seq_match_item p (Seq.slice c delta (Seq.length c)) (Seq.slice l delta (Seq.length l)) (k + (0 - delta))) // by contradiction
+      }
+  };
+  on_range_weaken_and_shift
+    (seq_seq_match_item p c l)
+    (seq_seq_match_item p (Seq.slice c delta (Seq.length c)) (Seq.slice l delta (Seq.length l)))
+    (0 - delta)
+    i j
+    aux;
+  fold (seq_seq_match p (Seq.slice c delta (Seq.length c)) (Seq.slice l delta (Seq.length l)) (i - delta) (j - delta));
+  ()
+}
+
+ghost fn rec seq_seq_match_seq_list_match
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (c: Seq.seq t1)
+  (l: list t2)
+requires
+    (seq_seq_match p c (Seq.seq_of_list l) 0 (List.Tot.length l) ** pure (
+      (Seq.length c == List.Tot.length l)
+    ))
+ensures
+    (seq_list_match c l p)
+decreases l
+{
+  match l {
+    Nil -> {
+      on_range_eq_emp (seq_seq_match_item p c (Seq.seq_of_list l)) 0 (List.Tot.length l);
+      rewrite (seq_seq_match p c (Seq.seq_of_list l) 0 (List.Tot.length l))
+        as emp;
+      seq_list_match_nil_intro c l p
+    }
+    Cons a q -> {
+      unfold (seq_seq_match p c (Seq.seq_of_list l) 0 (List.Tot.length l));
+      Seq.lemma_seq_of_list_induction (a :: q);
+      on_range_uncons ();
+      rewrite
+        (seq_seq_match_item p c (Seq.seq_of_list l) 0)
+        as
+        (p (Seq.head c) (List.Tot.hd l));
+      fold (seq_seq_match p c (Seq.seq_of_list l) 1 (List.Tot.length l));
+      let _ = seq_seq_match_tail_intro
+        p c (Seq.seq_of_list l) 1 1 (List.Tot.length l);
+      rewrite
+        (seq_seq_match p (Seq.slice c 1 (Seq.length c)) (Seq.slice (Seq.seq_of_list l) 1 (Seq.length (Seq.seq_of_list l))) (1 - 1) (List.Tot.length l - 1))
+        as
+        (seq_seq_match p (Seq.tail c) (Seq.seq_of_list (List.Tot.tl l)) 0 (List.Tot.length (List.Tot.tl l)));
+      seq_seq_match_seq_list_match p _ (List.Tot.tl l);
+      Seq.cons_head_tail c;
+      seq_list_match_cons_intro (Seq.head c) (List.Tot.hd l) (Seq.tail c) (List.Tot.tl l) p
+    }
+  }
+}
+
+ghost fn rec seq_list_match_seq_seq_match
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (c: Seq.seq t1)
+  (l: list t2)
+requires
+    (seq_list_match c l p)
+ensures
+    (seq_seq_match p c (Seq.seq_of_list l) 0 (List.Tot.length l) ** pure (
+      Seq.length c == List.Tot.length l
+    ))
+decreases l
+{
+  match l {
+    Nil -> {
+      seq_list_match_nil_elim c l p;
+    on_range_empty
+      (seq_seq_match_item p c (Seq.seq_of_list l))
+      0;
+    fold (seq_seq_match p c (Seq.seq_of_list l) 0 (List.Tot.length l))
+    }
+    Cons a q -> {
+      Seq.lemma_seq_of_list_induction (a :: q);
+      seq_list_match_cons_elim c l p;
+      Seq.cons_head_tail c;
+      seq_list_match_seq_seq_match p (Seq.tail c) (List.Tot.tl l);
+      rewrite
+        (seq_seq_match p (Seq.tail c) (Seq.seq_of_list (List.Tot.tl l)) 0 (List.Tot.length (List.Tot.tl l)))
+        as
+        (seq_seq_match p (Seq.slice c 1 (Seq.length c)) (Seq.slice (Seq.seq_of_list l) 1 (Seq.length (Seq.seq_of_list l))) 0 (List.Tot.length (List.Tot.tl l)));
+      let _ = seq_seq_match_tail_elim
+        p c (Seq.seq_of_list l) 1 0 (List.Tot.length (List.Tot.tl l))
+      ;
+      unfold (seq_seq_match p c (Seq.seq_of_list l) 1 (List.Tot.length l));
+      rewrite
+        (p (Seq.head c) (List.Tot.hd l))
+        as
+        (seq_seq_match_item p c (Seq.seq_of_list l) 0);
+      on_range_cons 0;
+      fold (seq_seq_match p c (Seq.seq_of_list l) 0 (List.Tot.length l))
+    }
+  }
+}
+
+ghost fn seq_seq_match_seq_list_match_with_implies
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (c: Seq.seq t1)
+  (l: list t2)
+requires
+    (seq_seq_match p c (Seq.seq_of_list l) 0 (List.Tot.length l) ** pure (
+      (Seq.length c == List.Tot.length l)
+    ))
+ensures
+    (seq_list_match c l p ** (seq_list_match c l p @==> seq_seq_match p c (Seq.seq_of_list l) 0 (List.Tot.length l)))
+{
+  seq_seq_match_seq_list_match p c l;
+  ghost fn aux (_: unit)
+  requires
+    emp ** seq_list_match c l p
+  ensures
+    seq_seq_match p c (Seq.seq_of_list l) 0 (List.Tot.length l)
+  {
+    seq_list_match_seq_seq_match p c l
+  };
+  intro_stick
+    (seq_list_match c l p)
+    (seq_seq_match p c (Seq.seq_of_list l) 0 (List.Tot.length l))
+    emp
+    aux
+}
+
+ghost fn seq_list_match_seq_seq_match_with_implies
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (c: Seq.seq t1)
+  (l: list t2)
+requires
+    (seq_list_match c l p)
+ensures
+    (seq_seq_match p c (Seq.seq_of_list l) 0 (List.Tot.length l) ** (seq_seq_match p c (Seq.seq_of_list l) 0 (List.Tot.length l) @==> seq_list_match c l p) ** pure (
+      Seq.length c == List.Tot.length l
+    ))
+{
+  seq_list_match_seq_seq_match p c l; 
+  ghost fn aux (_: unit)
+  requires
+    emp ** seq_seq_match p c (Seq.seq_of_list l) 0 (List.Tot.length l)
+  ensures
+    seq_list_match c l p
+  {
+    seq_seq_match_seq_list_match p c l
+  }; 
+  intro_stick
+    (seq_seq_match p c (Seq.seq_of_list l) 0 (List.Tot.length l))
+    (seq_list_match c l p)
+    emp
+    aux
+}
+
+ghost fn seq_list_match_length
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (c: Seq.seq t1)
+  (l: list t2)
+requires
+    (seq_list_match c l p)
+ensures
+    (seq_list_match c l p ** pure (
+      Seq.length c == List.Tot.length l
+    ))
+{
+  seq_list_match_seq_seq_match_with_implies p c l;
+  seq_seq_match_length p _ _ _ _;
+  elim_stick
+    (seq_seq_match p _ _ _ _)
+    (seq_list_match c l p)
+}
+
+ghost fn seq_list_match_index
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (s1: Seq.seq t1)
+  (s2: list t2)
+  (i: nat)
+requires
+    (seq_list_match s1 s2 p ** pure (
+      (i < Seq.length s1 \/ i < List.Tot.length s2)
+    ))
+returns res: (squash (i < Seq.length s1 /\ List.Tot.length s2 == Seq.length s1))
+ensures
+    (
+      p (Seq.index s1 i) (List.Tot.index s2 i) **
+      (p (Seq.index s1 i) (List.Tot.index s2 i) @==>
+        seq_list_match s1 s2 p)
+    )
+{
+  seq_list_match_seq_seq_match_with_implies p s1 s2;
+  let res : squash (i < Seq.length s1 /\ List.Tot.length s2 == Seq.length s1) = ();
+  rewrite_with_stick
+    (seq_seq_match p s1 (Seq.seq_of_list s2) 0 (List.Tot.length s2))
+    (on_range (seq_seq_match_item p s1 (Seq.seq_of_list s2)) 0 (List.Tot.length s2));
+  trans _ _ (seq_list_match s1 s2 p);
+  on_range_focus i;
+  trans _ _ (seq_list_match s1 s2 p);
+  rewrite_with_stick
+    (seq_seq_match_item p _ _ _)
+    (p (Seq.index s1 i) (List.Tot.index s2 i));
+  trans _ _ (seq_list_match s1 s2 p);
+  res
+}
+
+(* Random array access
+
+Since `seq_list_match` is defined recursively on the list of
+high-level values, it is used naturally left-to-right. By contrast,
+in practice, an application may populate an array in a different
+order, or even out-of-order. `seq_seq_match` supports that scenario
+better, as we show below.
+
+*)
+
+ghost fn seq_seq_match_item_match_option_elim
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (s1: Seq.seq t1)
+  (s2: Seq.seq t2)
+  (i j: nat)
+requires
+    (seq_seq_match (item_match_option p) s1 (seq_map Some s2) i j)
+ensures
+    (seq_seq_match p s1 s2 i j)
+{
+  ghost fn aux
+    (k: (k: nat { i <= k /\ k < j }))
+  requires
+    (seq_seq_match_item (item_match_option p) s1 (seq_map Some s2)) k
+  ensures
+    (seq_seq_match_item p s1 s2) k
+  {
+      rewrite
+        (seq_seq_match_item (item_match_option p) s1 (seq_map Some s2) k)
+        as
+        (seq_seq_match_item p s1 s2 k)
+  };
+  unfold (seq_seq_match (item_match_option p) s1 (seq_map Some s2) i j);
+  on_range_weaken
+    (seq_seq_match_item (item_match_option p) s1 (seq_map Some s2))
+    (seq_seq_match_item p s1 s2)
+    i j
+    aux;
+  fold (seq_seq_match p s1 s2 i j)
+}
+
+ghost fn seq_seq_match_item_match_option_intro
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (s1: Seq.seq t1)
+  (s2: Seq.seq t2)
+  (i j: nat)
+requires
+    (seq_seq_match p s1 s2 i j)
+ensures
+    (seq_seq_match (item_match_option p) s1 (seq_map Some s2) i j)
+{
+  ghost fn aux
+    (k: (k: nat { i <= k /\ k < j }))
+  requires
+    (seq_seq_match_item p s1 s2) k
+  ensures
+    (seq_seq_match_item (item_match_option p) s1 (seq_map Some s2)) k
+  {
+      rewrite
+        (seq_seq_match_item p s1 s2 k)
+        as
+        (seq_seq_match_item (item_match_option p) s1 (seq_map Some s2) k)
+  };
+  unfold (seq_seq_match p s1 s2 i j);
+  on_range_weaken
+    (seq_seq_match_item p s1 s2)
+    (seq_seq_match_item (item_match_option p) s1 (seq_map Some s2))
+    i j
+    aux;
+  fold (seq_seq_match (item_match_option p) s1 (seq_map Some s2) i j)
+}
+
+ghost fn rec seq_seq_match_item_match_option_init
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (s: Seq.seq t1)
+requires
+    emp
+ensures
+    (seq_seq_match (item_match_option p) s (Seq.create (Seq.length s) None) 0 (Seq.length s))
+decreases (Seq.length s)
+{
+  if (Seq.length s = 0) {
+    on_range_empty (seq_seq_match_item (item_match_option p) s (Seq.create (Seq.length s) None)) 0;
+    fold (seq_seq_match (item_match_option p) s (Seq.create (Seq.length s) None) 0 (Seq.length s))
+  } else {
+    seq_seq_match_item_match_option_init p (Seq.tail s);
+    unfold (seq_seq_match (item_match_option p) (Seq.tail s) (Seq.create (Seq.length (Seq.tail s)) None) 0 (Seq.length (Seq.tail s)));
+    ghost fn aux
+      (k: (k: nat { 0 <= k /\ k < Seq.length (Seq.tail s) }))
+    requires
+      (seq_seq_match_item (item_match_option p) (Seq.tail s) (Seq.create (Seq.length (Seq.tail s)) None)) k
+    ensures
+      (seq_seq_match_item (item_match_option p) s (Seq.create (Seq.length s) None)) (k + 1)
+    {
+        rewrite
+          (seq_seq_match_item (item_match_option p) (Seq.tail s) (Seq.create (Seq.length (Seq.tail s)) None) k)
+          as
+          (seq_seq_match_item (item_match_option p) s (Seq.create (Seq.length s) None) (k + 1))
+    };
+    on_range_weaken_and_shift
+      (seq_seq_match_item (item_match_option p) (Seq.tail s) (Seq.create (Seq.length (Seq.tail s)) None))
+      (seq_seq_match_item (item_match_option p) s (Seq.create (Seq.length s) None))
+      1
+      0
+      (Seq.length (Seq.tail s))
+      aux;
+    rewrite
+      emp
+      as
+      (seq_seq_match_item (item_match_option p) s (Seq.create (Seq.length s) None) 0);
+    on_range_cons 0;
+    fold (seq_seq_match (item_match_option p) s (Seq.create (Seq.length s) None) 0 (Seq.length s))
+  }
+}
+
+ghost fn seq_seq_match_upd
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (s1: Seq.seq t1)
+  (s2: Seq.seq t2)
+  (i j: nat)
+  (k: nat {
+    i <= j /\ j < k
+  })
+  (x1: t1)
+  (x2: t2)
+requires
+    (seq_seq_match p s1 s2 i k ** p x1 x2)
+returns res: (squash (j < Seq.length s1 /\ j < Seq.length s2))
+ensures
+    (
+      seq_seq_match p (Seq.upd s1 j x1) (Seq.upd s2 j x2) i k **
+      p (Seq.index s1 j) (Seq.index s2 j) // retrieve the occurrence before update
+    )
+{
+  seq_seq_match_length p s1 s2 i k;
+  unfold (seq_seq_match p s1 s2 i k);
+  on_range_get j;
+  let res : squash (j < Seq.length s1 /\ j < Seq.length s2) = ();
+  rewrite (seq_seq_match_item p s1 s2 j) as (p (Seq.index s1 j) (Seq.index s2 j));
+  rewrite
+    (p x1 x2)
+    as
+    (seq_seq_match_item p (Seq.upd s1 j x1) (Seq.upd s2 j x2) j);
+  ghost fn aux
+    (x1: t1)
+    (x2: t2)
+  requires p x1 x2
+  ensures p x1 x2
+  {
+    ()
+  };
+  fold (seq_seq_match p s1 s2 i j);
+  seq_seq_match_weaken
+    p p aux
+    s1 (Seq.upd s1 j x1)
+    s2 (Seq.upd s2 j x2)
+    i j;
+  fold (seq_seq_match p s1 s2 (j + 1) k);
+  seq_seq_match_weaken
+    p p aux
+    s1 (Seq.upd s1 j x1)
+    s2 (Seq.upd s2 j x2)
+    (j + 1) k;
+  unfold (seq_seq_match p (Seq.upd s1 j x1) (Seq.upd s2 j x2) i j);
+  unfold (seq_seq_match p (Seq.upd s1 j x1) (Seq.upd s2 j x2) (j + 1) k);
+  on_range_put
+    i j k;
+  fold (seq_seq_match p (Seq.upd s1 j x1) (Seq.upd s2 j x2) i k);
+  res
+}
+
+ghost fn seq_seq_match_item_match_option_upd_none
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (s1: Seq.seq t1)
+  (s2: Seq.seq (option t2))
+  (i j: nat)
+  (k: nat {
+    i <= j /\ j < k /\ 
+    (j < Seq.length s2 ==> None? (Seq.index s2 j)) // condition necessary to avoid resource leakage
+  })
+  (x1: t1)
+  (x2: t2)
+requires
+    (seq_seq_match (item_match_option p) s1 s2 i k ** p x1 x2)
+returns res: (squash (j < Seq.length s1 /\ j < Seq.length s2))
+ensures
+    (
+      seq_seq_match (item_match_option p) (Seq.upd s1 j x1) (Seq.upd s2 j (Some x2)) i k
+    )
+{
+  rewrite
+    (p x1 x2)
+    as
+    (item_match_option p x1 (Some x2));
+  seq_seq_match_upd (item_match_option p) s1 s2 i j k x1 (Some x2);
+  rewrite (item_match_option p (Seq.index s1 j) (Seq.index s2 j)) as emp
+}
+
+ghost fn seq_seq_match_item_match_option_index
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (s1: Seq.seq t1)
+  (s2: Seq.seq (option t2))
+  (i j: nat)
+  (k: nat {
+    i <= j /\ j < k /\
+    (j < Seq.length s2 ==> Some? (Seq.index s2 j))
+  })
+requires
+    (seq_seq_match (item_match_option p) s1 s2 i k)
+returns res: (squash (j < Seq.length s1 /\ j < Seq.length s2 /\ Some? (Seq.index s2 j)))
+ensures
+    (
+      seq_seq_match (item_match_option p) s1 (Seq.upd s2 j None) i k **
+      p (Seq.index s1 j) (Some?.v (Seq.index s2 j))
+    )
+{
+  seq_seq_match_length (item_match_option p) s1 s2 i k;
+  unfold (seq_seq_match (item_match_option p) s1 s2 i k);
+  on_range_get j;
+  let res : squash (j < Seq.length s1 /\ j < Seq.length s2 /\ Some? (Seq.index s2 j)) = ();
+  rewrite
+    (seq_seq_match_item (item_match_option p) s1 s2 j)
+    as
+    (p (Seq.index s1 j) (Some?.v (Seq.index s2 j)));
+  rewrite
+    emp
+    as
+    (seq_seq_match_item (item_match_option p) s1 (Seq.upd s2 j None) j);
+  ghost fn aux
+    (x1: t1)
+    (x2: option t2)
+  requires item_match_option p x1 x2
+  ensures item_match_option p x1 x2
+  {
+    ()
+  };
+  fold (seq_seq_match (item_match_option p) s1 s2 i j);
+  seq_seq_match_weaken
+    (item_match_option p) (item_match_option p) aux
+    s1 s1
+    s2 (Seq.upd s2 j None)
+    i j;
+  fold (seq_seq_match (item_match_option p) s1 s2 (j + 1) k);
+  seq_seq_match_weaken
+    (item_match_option p) (item_match_option p) aux
+    s1 s1
+    s2 (Seq.upd s2 j None)
+    (j + 1) k;
+  unfold (seq_seq_match (item_match_option p) s1 (Seq.upd s2 j None) i j);
+  unfold (seq_seq_match (item_match_option p) s1 (Seq.upd s2 j None) (j + 1) k);
+  on_range_put
+    i j k;
+  fold (seq_seq_match (item_match_option p) s1 (Seq.upd s2 j None) i k);
+  res
+}

--- a/lib/pulse/lib/Pulse.Lib.SeqMatch.fsti
+++ b/lib/pulse/lib/Pulse.Lib.SeqMatch.fsti
@@ -36,7 +36,7 @@ val seq_list_match
 : Tot slprop
 
 val seq_list_match_nil_intro
-  (#t #t': Type)
+  (#t #t': Type0)
   (c: Seq.seq t)
   (v: list t')
   (item_match: (t -> (v': t' { v' << v }) -> slprop))
@@ -46,16 +46,19 @@ val seq_list_match_nil_intro
     (fun _ -> seq_list_match c v item_match)
 
 val seq_list_match_nil_elim
-  (#t #t': Type)
+  (#t #t': Type0)
   (c: Seq.seq t)
   (v: list t')
   (item_match: (t -> (v': t' { v' << v }) -> slprop))
 : stt_ghost unit emp_inames
     (seq_list_match c v item_match ** pure (
+      c `Seq.equal` Seq.empty \/
+      Nil? v
+    ))
+    (fun _ -> pure (
       c `Seq.equal` Seq.empty /\
       Nil? v
     ))
-    (fun _ -> emp)
 
 let list_cons_precedes
   (#t: Type)
@@ -68,7 +71,7 @@ let list_cons_precedes
   assert (List.Tot.tl (a :: q) << (a :: q))
 
 val seq_list_match_cons_intro
-  (#t #t': Type)
+  (#t #t': Type0)
   (a: t)
   (a' : t')
   (c: Seq.seq t)
@@ -79,7 +82,7 @@ val seq_list_match_cons_intro
     (fun _ -> seq_list_match (Seq.cons a c) (a' :: v) item_match)
 
 val seq_list_match_cons_elim
-  (#t #t': Type)
+  (#t #t': Type0)
   (c: Seq.seq t)
   (v: list t' { Cons? v \/ Seq.length c > 0 })
   (item_match: (t -> (v': t' { v' << v }) -> slprop))
@@ -91,7 +94,7 @@ val seq_list_match_cons_elim
 
 // this one cannot be proven with seq_seq_match because of the << refinement in the type of item_match
 val seq_list_match_weaken
-  (#t #t': Type)
+  (#t #t': Type0)
   (c: Seq.seq t)
   (v: list t')
   (item_match1 item_match2: (t -> (v': t' { v' << v }) -> slprop))
@@ -121,7 +124,7 @@ val seq_seq_match
 : Tot slprop
 
 val seq_seq_match_length
-  (#t1 #t2: Type)
+  (#t1 #t2: Type0)
   (p: t1 -> t2 -> slprop)
   (s1: Seq.seq t1)
   (s2: Seq.seq t2)
@@ -131,7 +134,7 @@ val seq_seq_match_length
     (fun _ -> seq_seq_match p s1 s2 i j ** pure (i <= j /\ (i == j \/ (j <= Seq.length s1 /\ j <= Seq.length s2))))
 
 val seq_seq_match_weaken
-  (#t1 #t2: Type)
+  (#t1 #t2: Type0)
   (p p': t1 -> t2 -> slprop)
   (w: ((x1: t1) -> (x2: t2) -> stt_ghost unit emp_inames
     (p x1 x2) (fun _ -> p' x1 x2)
@@ -151,7 +154,7 @@ val seq_seq_match_weaken
     (fun _ -> seq_seq_match p' c1' c2' i j)
 
 val seq_seq_match_weaken_with_implies
-  (#t1 #t2: Type)
+  (#t1 #t2: Type0)
   (p: t1 -> t2 -> slprop)
   (c1 c1': Seq.seq t1)
   (c2 c2': Seq.seq t2)
@@ -172,7 +175,7 @@ val seq_seq_match_weaken_with_implies
 (* Going between `seq_list_match` and `seq_seq_match` *)
 
 val seq_seq_match_seq_list_match
-  (#t1 #t2: Type)
+  (#t1 #t2: Type0)
   (p: t1 -> t2 -> slprop)
   (c: Seq.seq t1)
   (l: list t2)
@@ -183,7 +186,7 @@ val seq_seq_match_seq_list_match
     (fun _ -> seq_list_match c l p)
 
 val seq_list_match_seq_seq_match
-  (#t1 #t2: Type)
+  (#t1 #t2: Type0)
   (p: t1 -> t2 -> slprop)
   (c: Seq.seq t1)
   (l: list t2)
@@ -194,7 +197,7 @@ val seq_list_match_seq_seq_match
     ))
 
 val seq_seq_match_seq_list_match_with_implies
-  (#t1 #t2: Type)
+  (#t1 #t2: Type0)
   (p: t1 -> t2 -> slprop)
   (c: Seq.seq t1)
   (l: list t2)
@@ -205,7 +208,7 @@ val seq_seq_match_seq_list_match_with_implies
     (fun _ -> seq_list_match c l p ** (seq_list_match c l p @==> seq_seq_match p c (Seq.seq_of_list l) 0 (List.Tot.length l)))
 
 val seq_list_match_seq_seq_match_with_implies
-  (#t1 #t2: Type)
+  (#t1 #t2: Type0)
   (p: t1 -> t2 -> slprop)
   (c: Seq.seq t1)
   (l: list t2)
@@ -216,7 +219,7 @@ val seq_list_match_seq_seq_match_with_implies
     ))
 
 val seq_list_match_length
-  (#t1 #t2: Type)
+  (#t1 #t2: Type0)
   (p: t1 -> t2 -> slprop)
   (c: Seq.seq t1)
   (l: list t2)
@@ -227,7 +230,7 @@ val seq_list_match_length
     ))
 
 val seq_list_match_index
-  (#t1 #t2: Type)
+  (#t1 #t2: Type0)
   (p: t1 -> t2 -> slprop)
   (s1: Seq.seq t1)
   (s2: list t2)
@@ -350,7 +353,7 @@ let item_match_option
   | Some x2' -> p x1 x2'
 
 val seq_seq_match_item_match_option_elim
-  (#t1 #t2: Type)
+  (#t1 #t2: Type0)
   (p: t1 -> t2 -> slprop)
   (s1: Seq.seq t1)
   (s2: Seq.seq t2)
@@ -360,7 +363,7 @@ val seq_seq_match_item_match_option_elim
     (fun _ -> seq_seq_match p s1 s2 i j)
 
 val seq_seq_match_item_match_option_intro
-  (#t1 #t2: Type)
+  (#t1 #t2: Type0)
   (p: t1 -> t2 -> slprop)
   (s1: Seq.seq t1)
   (s2: Seq.seq t2)
@@ -370,7 +373,7 @@ val seq_seq_match_item_match_option_intro
     (fun _ -> seq_seq_match (item_match_option p) s1 (seq_map Some s2) i j)
 
 val seq_seq_match_item_match_option_init
-  (#t1 #t2: Type)
+  (#t1 #t2: Type0)
   (p: t1 -> t2 -> slprop)
   (s: Seq.seq t1)
 : stt_ghost unit emp_inames
@@ -378,7 +381,7 @@ val seq_seq_match_item_match_option_init
     (fun _ -> seq_seq_match (item_match_option p) s (Seq.create (Seq.length s) None) 0 (Seq.length s))
 
 val seq_seq_match_upd
-  (#t1 #t2: Type)
+  (#t1 #t2: Type0)
   (p: t1 -> t2 -> slprop)
   (s1: Seq.seq t1)
   (s2: Seq.seq t2)
@@ -392,17 +395,19 @@ val seq_seq_match_upd
     emp_inames
     (seq_seq_match p s1 s2 i k ** p x1 x2)
     (fun _ -> 
-      seq_seq_match p (Seq.upd s1 j x1) (Seq.upd s2 j x2) i k
+      seq_seq_match p (Seq.upd s1 j x1) (Seq.upd s2 j x2) i k **
+      p (Seq.index s1 j) (Seq.index s2 j) // retrieve the occurrence before update
     )
     
-val seq_seq_match_item_match_option_upd
-  (#t1 #t2: Type)
+val seq_seq_match_item_match_option_upd_none
+  (#t1 #t2: Type0)
   (p: t1 -> t2 -> slprop)
   (s1: Seq.seq t1)
   (s2: Seq.seq (option t2))
   (i j: nat)
   (k: nat {
-    i <= j /\ j < k
+    i <= j /\ j < k /\ 
+    (j < Seq.length s2 ==> None? (Seq.index s2 j)) // condition necessary to avoid resource leakage
   })
   (x1: t1)
   (x2: t2)
@@ -414,7 +419,7 @@ val seq_seq_match_item_match_option_upd
     )
 
 val seq_seq_match_item_match_option_index
-  (#t1 #t2: Type)
+  (#t1 #t2: Type0)
   (p: t1 -> t2 -> slprop)
   (s1: Seq.seq t1)
   (s2: Seq.seq (option t2))
@@ -430,3 +435,30 @@ val seq_seq_match_item_match_option_index
       seq_seq_match (item_match_option p) s1 (Seq.upd s2 j None) i k **
       p (Seq.index s1 j) (Some?.v (Seq.index s2 j))
     )
+
+ghost fn seq_seq_match_item_match_option_upd_some
+  (#t1 #t2: Type0)
+  (p: t1 -> t2 -> slprop)
+  (s1: Seq.seq t1)
+  (s2: Seq.seq (option t2))
+  (i j: nat)
+  (k: nat {
+    i <= j /\ j < k /\ 
+    (j < Seq.length s2 ==> Some? (Seq.index s2 j))
+  })
+  (x1: t1)
+  (x2: t2)
+requires
+    (seq_seq_match (item_match_option p) s1 s2 i k ** p x1 x2)
+returns res: squash (j < Seq.length s1 /\ j < Seq.length s2 /\ Some? (Seq.index s2 j))
+ensures
+    (
+      seq_seq_match (item_match_option p) (Seq.upd s1 j x1) (Seq.upd s2 j (Some x2)) i k **
+      p (Seq.index s1 j) (Some?.v (Seq.index s2 j))      
+    )
+{
+  seq_seq_match_item_match_option_index p s1 s2 i j k;
+  seq_seq_match_item_match_option_upd_none p s1 (Seq.upd s2 j None) i j k x1 x2;
+  assert (pure (Seq.upd (Seq.upd s2 j None) j (Some x2) `Seq.equal` Seq.upd s2 j (Some x2)));
+  ()
+}

--- a/lib/pulse/lib/Pulse.Lib.Stick.Util.fst
+++ b/lib/pulse/lib/Pulse.Lib.Stick.Util.fst
@@ -187,3 +187,20 @@ fn elim_hyp_r (p q r:slprop)
     elim _ _;
 }
 
+ghost
+fn rewrite_with_stick
+  (p1 p2: slprop)
+  requires p1 ** pure (p1 == p2)
+  ensures p2 ** (p2 @==> p1)
+{
+  rewrite p1 as p2;
+  ghost
+  fn aux
+    (_: unit)
+    requires emp ** p2
+    ensures p1
+  {
+    rewrite p2 as p1
+  };
+  intro_stick _ _ _ aux
+}


### PR DESCRIPTION
This PR gives a `.fst` implementation for `Pulse.Lib.SeqMatch.fsti`

It is inspired from the existing Steel implementation (cf. https://github.com/FStarLang/steel/blob/92f1f3761373d1c4b8ee91f12bec007515dfce1d/lib/steel/Steel.ST.SeqMatch.fst ), but is tidied up to avoid resource leakage by no longer using `drop`.

With this PR, the following changes in the interface have become necessary:
* We lose universe polymorphism. This PR sets everything to universe 0.
* `seq_list_match_nil_elim` is strengthened by weakening its precondition
* to avoid resource leakage, `seq_seq_match_item_match_option_upd` is split into a `_none` and a `_some` cases.
