### PR TITLE
Convert slices to/from ArrayPtr (C only)

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.Slice.fst
+++ b/lib/pulse/lib/Pulse.Lib.Slice.fst
@@ -97,6 +97,68 @@ ensures    (A.pts_to a #p v)
     AP.to_array s.elt a
 }
 
+let arrayptr_to_slice
+  #t a s
+= pure (s.elt == a)
+
+fn arrayptr_to_slice_intro
+  (#t: Type) (a: AP.ptr t) (#p: perm) (alen: SZ.t) (#v: Ghost.erased (Seq.seq t))
+  requires
+    (pts_to a #p v ** pure (SZ.v alen == Seq.length v))
+  returns s: slice t
+  ensures
+    (pts_to s #p v ** arrayptr_to_slice a s)
+{
+  let s : slice t = {
+    elt = a;
+    len = alen;
+  };
+  fold_pts_to s #p v;
+  fold arrayptr_to_slice a s;
+  s
+}
+
+ghost
+fn arrayptr_to_slice_elim
+  (#t: Type) (s: slice t) (#p: perm) (#v: Seq.seq t) (#a: AP.ptr t)
+requires
+  (pts_to s #p v ** arrayptr_to_slice a s)
+ensures
+  (pts_to a #p v)
+{
+  unfold (arrayptr_to_slice a s);
+  unfold_pts_to s #p v;
+}
+
+let slice_to_arrayptr
+  #t s a
+= pure (s.elt == a)
+
+fn slice_to_arrayptr_intro
+  (#t: Type) (s: slice t) (#p: perm) (#v: Ghost.erased (Seq.seq t))
+requires
+  (pts_to s #p v)
+returns a: AP.ptr t
+ensures
+  (pts_to a #p v ** slice_to_arrayptr s a)
+{
+  unfold_pts_to s #p v;
+  fold (slice_to_arrayptr s s.elt);
+  s.elt
+}
+
+ghost
+fn slice_to_arrayptr_elim
+  (#t: Type) (a: AP.ptr t) (#p: perm) (#v: Seq.seq t) (#s: slice t)
+requires
+  (pts_to a #p v ** slice_to_arrayptr s a ** pure (Seq.length v == SZ.v (len s)))
+ensures
+  (pts_to s #p v)
+{
+  unfold (slice_to_arrayptr s a);
+  fold_pts_to s #p v
+}
+
 fn op_Array_Access
         (#t: Type)
         (a: slice t)

--- a/lib/pulse/lib/Pulse.Lib.Slice.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Slice.fsti
@@ -44,6 +44,42 @@ val to_array (#t: Type) (s: slice t) (#p: perm) (#v: Seq.seq t) (#a: array t) : 
     (pts_to s #p v ** is_from_array a s)
     (fun _ -> A.pts_to a #p v)
 
+(* BEGIN C only: conversions to/from Pulse.Lib.ArrayPtr. Those are
+   meant to design "clean" C APIs without the need to monomorphize
+   the slice type in the extracted .h file. *)
+
+module AP = Pulse.Lib.ArrayPtr
+
+val arrayptr_to_slice
+  (#t: Type)
+  (a: AP.ptr t)
+  (s: slice t)
+: slprop
+
+val arrayptr_to_slice_intro (#t: Type) (a: AP.ptr t) (#p: perm) (alen: SZ.t) (#v: Ghost.erased (Seq.seq t)) : stt (slice t)
+    (pts_to a #p v ** pure (SZ.v alen == Seq.length v))
+    (fun s -> pts_to s #p v ** arrayptr_to_slice a s)
+
+val arrayptr_to_slice_elim (#t: Type) (s: slice t) (#p: perm) (#v: Seq.seq t) (#a: AP.ptr t) : stt_ghost unit emp_inames
+    (pts_to s #p v ** arrayptr_to_slice a s)
+    (fun _ -> pts_to a #p v)
+
+val slice_to_arrayptr
+  (#t: Type)
+  (s: slice t)
+  (a: AP.ptr t)
+: slprop
+
+val slice_to_arrayptr_intro (#t: Type) (s: slice t) (#p: perm) (#v: Ghost.erased (Seq.seq t)) : stt (AP.ptr t)
+    (pts_to s #p v)
+    (fun a -> pts_to a #p v ** slice_to_arrayptr s a)
+
+val slice_to_arrayptr_elim (#t: Type) (a: AP.ptr t) (#p: perm) (#v: Seq.seq t) (#s: slice t) : stt_ghost unit emp_inames
+    (pts_to a #p v ** slice_to_arrayptr s a ** pure (Seq.length v == SZ.v (len s)))
+    (fun _ -> pts_to s #p v)
+
+(* END C only *)
+
 (* Written x.(i) *)
 val op_Array_Access
         (#t: Type)


### PR DESCRIPTION
This PR adds a few functions to convert from Pulse.Lib.Slice.slice to Pulse.Lib.ArrayPtr.ptr and conversely: `slice_to_arrayptr_intro`, `elim`, and `arrayptr_to_slice_intro`, `elim`

**Any Pulse code making use of these functions is supposed to be extracted to C only. These functions WILL NOT extract to Rust.**

The purpose of these functions is to avoid having slices as arguments or return values of functions in a C API. This is helpful to avoid double definitions of types due to Karamel monomorphizations when separately extracting a library and an application.
