### PR TITLE
Do not ship _cache and _output for share/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,10 @@ do-install: plugin lib-pulse
 	# Set up fstar.include so users only include lib/pulse
 	echo 'lib' > $(PREFIX)/lib/pulse/fstar.include
 
-	# Install share/ too, as-is.
+	# Install share/ too, as-is, but remove _cache and _output
 	cp -p -t $(PREFIX) -r share/
+	find $(PREFIX)/share/ -path '**/_cache*' -delete
+	find $(PREFIX)/share/ -path '**/_output*' -delete
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Wondering about this patch, which I left out of the previous PR. Do we want to ship checked files for the examples in share? What exactly is the expectation for the files there?