### PR TITLE
--ext fstar:no_absolute_paths in tests/error_messages

### DIFF
--- a/test/bug-reports/error-messages/Makefile
+++ b/test/bug-reports/error-messages/Makefile
@@ -1,2 +1,3 @@
 PULSE_ROOT ?= ../../..
 include $(PULSE_ROOT)/mk/test.mk
+OTHERFLAGS += --ext fstar:no_absolute_paths


### PR DESCRIPTION
Following F* tests/error_messages