### PR TITLE
Parser: Use structured errors

### DIFF
--- a/src/ml/PulseSyntaxExtension_Parser.ml
+++ b/src/ml/PulseSyntaxExtension_Parser.ml
@@ -227,10 +227,10 @@ let parse_decl (s:string) (r:range) =
   | e ->
     let pos = FStarC_Parser_Util.pos_of_lexpos (lexbuf.cur_p) in
     let r = FStarC_Range.mk_range fn pos pos in
-    Inr (Some ("Syntax error", r))
+    Inr (Some (FStarC_Errors_Msg.mkmsg "Syntax error", r))
 
  
-let parse_peek_id (s:string) (r:range) : (string, string * range) either =
+let parse_peek_id (s:string) (r:range) : (string, FStarC_Pprint.document list * range) either =
   (* print_string ("About to parse <" ^ s ^ ">"); *)
   let fn = file_of_range r in
   let lexbuf, lexer = lexbuf_and_lexer s r in
@@ -241,7 +241,7 @@ let parse_peek_id (s:string) (r:range) : (string, string * range) either =
   | e ->
     let pos = FStarC_Parser_Util.pos_of_lexpos (lexbuf.cur_p) in
     let r = FStarC_Range.mk_range fn pos pos in
-    Inr ("Syntax error", r)
+    Inr (FStarC_Errors_Msg.mkmsg "Syntax error", r)
 
 
 let parse_lang (s:string) (r:range) =
@@ -259,4 +259,4 @@ let parse_lang (s:string) (r:range) =
   | e ->
     let pos = FStarC_Parser_Util.pos_of_lexpos (lexbuf.cur_p) in
     let r = FStarC_Range.mk_range fn pos pos in
-    Inr (Some ("#lang-pulse: Syntax error", r))
+    Inr (Some (FStarC_Errors_Msg.mkmsg "#lang-pulse: Syntax error", r))

--- a/src/syntax_extension/PulseSyntaxExtension.ASTBuilder.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.ASTBuilder.fst
@@ -127,7 +127,7 @@ let maybe_report_error first_error decls =
     in
     if should_fail_on_error
     then (
-      Inl { message = FStarC.Errors.Msg.rendermsg msg; range = r }
+      Inl { message = msg; range = r }
     )
     else (
       // FStarC.Errors.log_issue_doc r (raw_error, msg);
@@ -139,7 +139,7 @@ let parse_extension_lang (contents:string) (r:FStarC.Range.range)
 : either AU.error_message (list decl)
 = match Parser.parse_lang contents r with
   | Inr None ->
-    Inl { message = "#lang-pulse: Parsing failed"; range = r }
+    Inl { message = [Errors.text "#lang-pulse: Parsing failed"]; range = r }
   | Inr (Some (err,r)) -> 
     Inl { message = err; range = r }
   | Inl (decls, first_error) -> (
@@ -211,7 +211,7 @@ let desugar_pulse (env:TcEnv.env)
                   (namespaces:list string)
                   (module_abbrevs:list (string & string))
                   (sugar:sugar_decl)
-: either PulseSyntaxExtension.SyntaxWrapper.decl (option (string & R.range))
+: either PulseSyntaxExtension.SyntaxWrapper.decl (option (list Pprint.document & R.range))
 = let namespaces = L.map Ident.path_of_text namespaces in
   let module_abbrevs = L.map (fun (x, l) -> x, Ident.path_of_text l) module_abbrevs in
   let env = D.reinitialize_env env.dsenv (TcEnv.current_module env) namespaces module_abbrevs in
@@ -252,7 +252,7 @@ let parse_pulse (env:TcEnv.env)
                 (content:string)
                 (file_name:string)
                 (line col:int)
-  : either PulseSyntaxExtension.SyntaxWrapper.decl (option (string & R.range))
+  : either PulseSyntaxExtension.SyntaxWrapper.decl (option (list Pprint.document & R.range))
   = let range = 
       let p = R.mk_pos line col in
       R.mk_range file_name p p

--- a/src/syntax_extension/PulseSyntaxExtension.Desugar.fsti
+++ b/src/syntax_extension/PulseSyntaxExtension.Desugar.fsti
@@ -25,7 +25,7 @@ module R = FStarC.Range
 
 // An error can be "None", which means all relevant
 // errors were already logged via the error API.
-type error = option (string & R.range)
+type error = option (list Pprint.document & R.range)
 
 let err a = nat -> either a error & nat
 

--- a/src/syntax_extension/PulseSyntaxExtension.Err.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.Err.fst
@@ -32,7 +32,7 @@ instance hasRange_lident : hasRange lident = {
 }
 // An error can be "None", which means all relevant
 // errors were already logged via the error API.
-type error = option (string & R.range)
+type error = option (list Pprint.document & R.range)
 
 let err a = nat -> either a error & nat
 
@@ -50,7 +50,7 @@ instance err_monad : monad err = {
 }
 
 let fail #a (message:string) (range:R.range) : err a =
-  fun ctr -> Inr (Some (message, range)), ctr
+  fun ctr -> Inr (Some (FStarC.Errors.mkmsg message, range)), ctr
 
 let fail_if (b:bool) (message:string) (range:R.range) : err unit =
   if b then fail message range else return ()

--- a/src/syntax_extension/PulseSyntaxExtension.Parser.fsti
+++ b/src/syntax_extension/PulseSyntaxExtension.Parser.fsti
@@ -20,14 +20,14 @@ open FStarC
 val parse_peek_id (contents:string)
                   (r:FStarC.Range.range)
   : either string
-           (string & FStarC.Range.range)
+           (list FStarC.Pprint.document & FStarC.Range.range)
 
 val parse_decl (contents:string)
                (r:FStarC.Range.range)
   : either PulseSyntaxExtension.Sugar.decl
-           (option (string & FStarC.Range.range))
+           (option (list FStarC.Pprint.document & FStarC.Range.range))
 
 val parse_lang (contents:string)
                (r:FStarC.Range.range)
   : either (list (either PulseSyntaxExtension.Sugar.decl FStarC.Parser.AST.decl) & option FStarC.Parser.ParseIt.parse_error)
-           (option (string & FStarC.Range.range))
+           (option (list FStarC.Pprint.document & FStarC.Range.range))


### PR DESCRIPTION
Needed after https://github.com/FStarLang/FStar/pull/3763, and an improvement in the reporting of syntax errors (whitespace is no longer messed up).