### PR TITLE
Parsing: relax ordering/need for annotations in computation types

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.CancellableInvariant.fst
+++ b/lib/pulse/lib/Pulse.Lib.CancellableInvariant.fst
@@ -46,9 +46,9 @@ let iname_of c = c.i
 ghost
 fn new_cancellable_invariant (v:slprop)
   requires v
+  opens []
   returns c:cinv
   ensures inv (iname_of c) (cinv_vp c v) ** active c 1.0R
-  opens []
 {
   let r = GR.alloc true;
   rewrite v as (if true then v else emp);

--- a/share/pulse/examples/by-example/PulseTutorial.ParallelIncrement.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.ParallelIncrement.fst
@@ -325,9 +325,9 @@ ensures inv (C.iname_of c) (C.cinv_vp c (exists* v. pts_to x v ** refine v)) ** 
   atomic
   fn read ()
   requires inv (C.iname_of c) (C.cinv_vp c (exists* v. pts_to x v ** refine v)) ** C.active c p ** later_credit 1
+  opens [C.iname_of c]
   returns v:int
   ensures inv (C.iname_of c) (C.cinv_vp c (exists* v. pts_to x v ** refine v)) ** C.active c p
-  opens [C.iname_of c]
   {
     with_invariants (C.iname_of c)
     {

--- a/src/ml/FStarC_Parser_Parse.mly
+++ b/src/ml/FStarC_Parser_Parse.mly
@@ -1317,7 +1317,8 @@ tmEqWith(X):
 %inline recordTerm:
   | LBRACE e=recordExp RBRACE { e }
 
-tmNoEqWith(X):
+%public
+tmNoEqNoRecordWith(X):
   | e1=tmNoEqWith(X) COLON_COLON e2=tmNoEqWith(X)
       { consTerm (rr $loc) e1 e2 }
   | e1=tmNoEqWith(X) AMP e2=tmNoEqWith(X)
@@ -1344,12 +1345,15 @@ tmNoEqWith(X):
       { mkApp op [ e1, Infix; e2, Nothing ] (rr $loc) }
  | e1=tmNoEqWith(X) op=OPINFIX4 e2=tmNoEqWith(X)
       { mk_term (Op(mk_ident(op, rr $loc(op)), [e1; e2])) (rr $loc) Un}
-  | e=recordTerm { e }
   | BACKTICK_PERC e=atomicTerm
       { mk_term (VQuote e) (rr $loc) Un }
   | op=TILDE e=atomicTerm
       { mk_term (Op(mk_ident (op, rr $loc(op)), [e])) (rr $loc) Formula }
   | e=X { e }
+
+tmNoEqWith(X):
+  | e=tmNoEqNoRecordWith(X) { e }
+  | e=recordTerm { e }
 
 binop_name:
   | o=OPINFIX0a              { mk_ident (o, rr $loc) }

--- a/src/ml/pulseparser.mly
+++ b/src/ml/pulseparser.mly
@@ -92,8 +92,6 @@ maybeRec:
 peekFnId:
   | q=option(qual) FN maybeRec id=lident
       { FStarC_Ident.string_of_id id }
-  | q=option(qual) VAL FN id=lident
-      { FStarC_Ident.string_of_id id }
 
 qual:
   | GHOST { PulseSyntaxExtension_Sugar.STGhost }
@@ -168,15 +166,6 @@ pulseDeclEOF:
   | p=pulseDecl EOF
     {
       p
-    }
-  | q=option(qual)
-    VAL FN lid=lident bs=pulseBinderList
-    ascription=pulseComputationType
-    EOF
-    {
-      let open PulseSyntaxExtension_Sugar in
-      let ascription = with_computation_tag ascription q in
-      FnDecl (mk_fn_decl lid (List.flatten bs) (Inl ascription) [] (rr $loc))
     }
 
 pulseBinderList:

--- a/src/ml/pulseparser.mly
+++ b/src/ml/pulseparser.mly
@@ -44,10 +44,6 @@ let as_aqual (q:unit option) =
 
 let pos_of_lexpos (p:Lexing.position) = FStarC_Parser_Util.pos_of_lexpos p
 
-let default_return =
-    gen dummyRange,
-    mk_term (Var (lid_of_ids [(mk_ident("unit", dummyRange))])) dummyRange Un
-
 let with_computation_tag (c:PulseSyntaxExtension_Sugar.computation_type) t =
   match t with
   | None -> c
@@ -192,20 +188,28 @@ fnBody:
   | COLON typ=option(appTerm) EQUALS lambda=pulseLambda
     { Inr (lambda, typ) }
 
-pulseComputationType:
-  | REQUIRES t=pulseSLProp
-    ret=option(RETURNS i=lidentOrUnderscore COLON r=term { (i, r) })
-    ENSURES t2=pulseSLProp
-    maybe_opens=option(OPENS inv=appTermNoRecordExp { inv })
-    {
-        let i, r =
-          match ret with
-          | Some (i, r) -> i, r
-          | None -> default_return
-        in
-        PulseSyntaxExtension_Sugar.mk_comp ST t i r t2 maybe_opens (rr $loc)
-    }
 
+ret_ty:
+  | r=tmNoEqNoRecordWith(appTermNoRecordExp) {r}
+
+returns:
+  | RETURNS i=lidentOrUnderscore COLON r=ret_ty { PulseSyntaxExtension_Sugar.Returns (Some i, r) }
+  | RETURNS r=ret_ty { PulseSyntaxExtension_Sugar.Returns (None, r) }
+
+pulseComputationAnnot1_:
+  | REQUIRES t=pulseSLProp { PulseSyntaxExtension_Sugar.Requires t }
+  | ENSURES t=pulseSLProp { PulseSyntaxExtension_Sugar.Ensures t }
+  | r=returns {r}
+  | OPENS inv=appTermNoRecordExp { PulseSyntaxExtension_Sugar.Opens inv }
+
+pulseComputationAnnot1:
+  | a=pulseComputationAnnot1_ { (a, rr $loc) }
+
+pulseComputationType:
+  | annots=list(pulseComputationAnnot1)
+    {
+        PulseSyntaxExtension_Sugar.mk_comp ST annots (rr $loc)
+    }
 
 pulseStmtNoSeq:
   | OPEN i=quident

--- a/test/nolib/Annots.fst
+++ b/test/nolib/Annots.fst
@@ -1,0 +1,131 @@
+module Annots
+
+#lang-pulse
+open Pulse.Nolib
+
+assume val res : int -> slprop
+
+(* Relaxed syntax for computation types, allowing to omit requires/ensures/returns,
+   and imposing a less strict order between them. *)
+
+fn foo1 ()
+{
+  ();
+}
+
+fn foo2 ()
+  returns int
+{
+  1
+}
+
+fn foo2' ()
+  returns _ : int
+{
+  1
+}
+
+[@@expect_failure]
+fn no_multiple_ret ()
+  requires res 1
+  requires res 2
+  returns int
+  returns int
+  ensures res 2
+  ensures res 1
+{
+  1
+}
+
+[@@expect_failure]
+fn wrong_order1 ()
+  ensures res 1
+  returns int
+  requires res 1
+{
+  1
+}
+
+[@@expect_failure]
+fn wrong_order2 ()
+  ensures res 1
+  requires res 1
+{
+  1
+}
+
+[@@expect_failure]
+fn wrong_order3 ()
+  returns bool
+  requires res 1
+{
+  1
+}
+
+(* Reject! It would refer to the argument x
+and not the return value! *)
+[@@expect_failure]
+ghost
+fn wrong_order4 (x:iname)
+  returns x : iname
+  opens [x]
+{
+  admit()
+}
+
+[@@expect_failure]
+fn wrong_order2 ()
+  ensures res 1
+  requires res 1
+{
+  1
+}
+
+[@@expect_failure]
+fn wrong_order3 ()
+  returns bool
+  requires res 1
+{
+  1
+}
+
+
+fn foo4 ()
+  requires res 1
+  requires res 2
+  returns int
+  ensures res 2 ** res 1
+{
+  1
+}
+
+fn foo5 ()
+  requires res 1
+  returns v : int
+  ensures res v
+{
+  1
+}
+
+[@@expect_failure [168]] // desugaring failure, precondition
+fn foo6 ()
+  requires res v
+  returns v : int
+  ensures res v
+{
+  1
+}
+
+(* tuples *)
+
+fn tup1 ()
+  returns int & int
+{
+  (1,2)
+}
+
+fn tup2 ()
+  returns t : int & int
+{
+  (1,2)
+}

--- a/test/nolib/Annots.fst.output.expected
+++ b/test/nolib/Annots.fst.output.expected
@@ -1,0 +1,40 @@
+>> Got issues: [
+* Error 168 at Annots.fst(33,2-33,13):
+  - Multiple returns are not allowed.
+
+>>]
+>> Got issues: [
+* Error 168 at Annots.fst(43,2-43,13):
+  - returns must come before ensures (the name returned is in scope for the ensures clause)
+
+>>]
+>> Got issues: [
+* Error 168 at Annots.fst(52,2-52,16):
+  - requires must come before any ensures
+
+>>]
+>> Got issues: [
+* Error 168 at Annots.fst(60,2-60,16):
+  - requires must come before the return
+
+>>]
+>> Got issues: [
+* Error 168 at Annots.fst(71,2-71,11):
+  - opens must come before the return (the name returned is *not* in scope for the opens clause)
+
+>>]
+>> Got issues: [
+* Error 168 at Annots.fst(79,2-79,16):
+  - requires must come before any ensures
+
+>>]
+>> Got issues: [
+* Error 168 at Annots.fst(87,2-87,16):
+  - requires must come before the return
+
+>>]
+>> Got issues: [
+* Error 168 at Annots.fst(112,15-112,16):
+  - Identifiers (v) not found, consider adding them as binders
+
+>>]


### PR DESCRIPTION
This makes the parser just parse a list (any list) of annotations (requires, ensures, returns, opens) for computation types, and it's the desugaring that checks for their ordering, does defaulting when one is not present, and even combines multiples requires/ensures.

This allows things like:
```fstar
fn foo1 ()
{ (); }

fn foo2 ()
  returns int
{ 1 }

fn foo2' ()
  returns _ : int
{ 1 }

fn multiple_req ()
  requires res 1
  requires res 2
  ensures res 2 ** res 1
{ () }
```
And makes sure to forbid wrongly ordered annotations, or multiple returns/opens. It also makes sure opens comes before returns, since the name returned in *not* in scope for the opens, and our current syntax is very misleading in that aspect.