### PR TITLE
Checker.Rewrite: warn if a rewrite each was a no-op

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.Deque.fst
+++ b/lib/pulse/lib/Pulse.Lib.Deque.fst
@@ -955,8 +955,8 @@ fn push_back_cons (#t:Type0) (l : deque t)
   
   is_deque_cons_not_none l;
   unfold_is_deque_cons l;
-  let headp = Some?.v l.head;    rewrite each l.head as (Some headp);
-  let tailp = Some?.v l.tail;    rewrite each l.tail as (Some tailp);
+  let headp = Some?.v l.head;
+  let tailp = Some?.v l.tail;
   
   let newnodev = {
     value = x;
@@ -1021,8 +1021,8 @@ fn pop_back_cons (#t:Type0) (l : deque t)
 {
   is_deque_cons_not_none l;
   unfold_is_deque_cons l;
-  let headp = Some?.v l.head;    rewrite each l.head as (Some headp);
-  let tailp = Some?.v l.tail;    rewrite each l.tail as (Some tailp);
+  let headp = Some?.v l.head;
+  let tailp = Some?.v l.tail;
 
   let g_tailp' = sep_last headp tailp #x #xs #None #None;
   

--- a/lib/pulse/lib/Pulse.Lib.Task.fst
+++ b/lib/pulse/lib/Pulse.Lib.Task.fst
@@ -565,8 +565,6 @@ fn spawn (p:pool)
   release p.lk;
   fold (pool_alive #pf p);
   
-  rewrite each task.post as post_ref;
-
   task.h;
 }
 

--- a/share/pulse/examples/by-example/PulseTutorial.PCMParallelIncrement.fst
+++ b/share/pulse/examples/by-example/PulseTutorial.PCMParallelIncrement.fst
@@ -403,8 +403,6 @@ ensures  R.pts_to r ('i + 2)
   later_credit_buy 1;
   CI.gather2 ci; CI.cancel ci; // Collect back permission to the invariant and then cancel it
   drop_ (inv _ _); //drop the other copy of the invariant; it is now useless
-  // ugly! reveal/hide rewrite
-  rewrite each (reveal #nat (hide #nat 2)) as 2;
   // collect up the has_given predicates from each thread
   gather_has_given gs;
   // recover the postcondition by the main ghost state eliminator lemma

--- a/src/checker/Pulse.Checker.Prover.fsti
+++ b/src/checker/Pulse.Checker.Prover.fsti
@@ -27,13 +27,6 @@ module PS = Pulse.Checker.Prover.Substs
 include Pulse.Checker.Prover.Base
 include Pulse.Checker.Prover.Util
 
-val elim_exists_and_pure (#g:env) (#ctxt:slprop)
-  (ctxt_typing:tot_typing g ctxt tm_slprop)
-  : T.Tac (g':env { env_extends g' g } &
-           ctxt':term &
-           tot_typing g' ctxt' tm_slprop &
-           continuation_elaborator g ctxt g' ctxt')
-
 val normalize_slprop
   (g:env)
   (v:slprop)
@@ -44,6 +37,13 @@ val normalize_slprop_welltyped
   (v:slprop)
   (v_typing:tot_typing g v tm_slprop)
   : T.Tac (v':slprop & slprop_equiv g v v' & tot_typing g v' tm_slprop)
+
+val elim_exists_and_pure (#g:env) (#ctxt:slprop)
+  (ctxt_typing:tot_typing g ctxt tm_slprop)
+  : T.Tac (g':env { env_extends g' g } &
+           ctxt':term &
+           tot_typing g' ctxt' tm_slprop &
+           continuation_elaborator g ctxt g' ctxt')
 
 val prove
   (allow_ambiguous : bool)


### PR DESCRIPTION
If a rewrite each doesn't do anything, it is silently accepted. This will make it raise a warning.