### PR TITLE
Use Iris definition of later and prove Löb induction

### DIFF
--- a/lib/common/Pulse.Lib.Core.fsti
+++ b/lib/common/Pulse.Lib.Core.fsti
@@ -492,13 +492,10 @@ val later (p: slprop) : slprop
 val later_intro (p: slprop) : stt_ghost unit emp_inames p fun _ -> later p
 val later_elim (p: slprop) : stt_ghost unit emp_inames (later p ** later_credit 1) fun _ -> p
 
-val timeless_iff p : squash (timeless p <==> p == later p)
-let later_elim_timeless (p: slprop { timeless p }) : stt_ghost unit emp_inames (later p) (fun _ -> p) =
-  timeless_iff p;
-  lift_neutral_ghost (return_neutral_noeq _ _)
+val later_elim_timeless (p: slprop { timeless p }) : stt_ghost unit emp_inames (later p) (fun _ -> p)
 
 val later_star p q : squash (later (p ** q) == later p ** later q)
-val later_exists #t (f:t->slprop) : squash (later (exists* x. f x) == (exists* x. later (f x)))
+//val later_exists (#t: Type {t}) (f:t->slprop) : squash (later (exists* x. f x) `equiv_pos` (exists* x. later (f x)))
 
 //////////////////////////////////////////////////////////////////////////
 // Equivalence

--- a/lib/common/Pulse.Lib.Core.fsti
+++ b/lib/common/Pulse.Lib.Core.fsti
@@ -495,7 +495,7 @@ val later_elim (p: slprop) : stt_ghost unit emp_inames (later p ** later_credit 
 val later_elim_timeless (p: slprop { timeless p }) : stt_ghost unit emp_inames (later p) (fun _ -> p)
 
 val later_star p q : squash (later (p ** q) == later p ** later q)
-//val later_exists (#t: Type {t}) (f:t->slprop) : squash (later (exists* x. f x) `equiv_pos` (exists* x. later (f x)))
+val later_exists (#t: Type) (f:t->slprop) : stt_ghost unit emp_inames (later (exists* x. f x)) (fun _ -> exists* x. later (f x))
 
 //////////////////////////////////////////////////////////////////////////
 // Equivalence

--- a/lib/core/Pulse.Lib.Core.fst
+++ b/lib/core/Pulse.Lib.Core.fst
@@ -36,7 +36,7 @@ let timeless_emp = Sep.timeless_emp ()
 let pure = pure
 let timeless_pure p = Sep.timeless_pure p
 let op_Star_Star = op_Star_Star
-let timeless_star p q = Sep.later_star p q
+let timeless_star p q = Sep.timeless_star p q
 let op_exists_Star = op_exists_Star
 let exists_extensional (#a:Type u#a) (p q: a -> slprop)
   (_:squash (forall x. p x == q x))
@@ -46,22 +46,12 @@ let exists_extensional (#a:Type u#a) (p q: a -> slprop)
         slprop_equiv_refl (p x)
     );
     I.slprop_equiv_exists p q ()
-let timeless_exists (#a:Type u#a) (p: a -> slprop)
-: Lemma
-    (requires forall x. timeless (p x))
-    (ensures timeless (op_exists_Star p))
-    [SMTPat (timeless (op_exists_Star p))]
-= calc (==) {
-    later (op_exists_Star p);
-  (==) { exists_extensional p (fun x -> p x) () }
-    later (exists* x. p x);
-  (==) { Sep.later_exists p }
-    (exists* x. later (p x));
-  (==) { exists_extensional (fun x -> later (p x)) (fun x -> p x) () }
-    (exists* x. p x);
-  (==) { exists_extensional (fun x -> p x) p () }
-    op_exists_Star p;
-  }
+let timeless_exists #a p =
+  exists_extensional p (fun x -> p x) ();
+  Sep.timeless_exists p;
+  let h: squash (Sep.timeless Sep.(exists* x. p x)) = () in
+  let h: squash (Sep.timeless (exists* x. p x)) = h in
+  ()
 let slprop_equiv = slprop_equiv
 let elim_slprop_equiv #p #q pf = slprop_equiv_elim p q
 let slprop_post_equiv = slprop_post_equiv
@@ -216,9 +206,11 @@ let rec later_credit_buy n =
 let later = later
 let later_intro p = A.later_intro p
 let later_elim p = A.later_elim p
-let timeless_iff p = ()
+
+let later_elim_timeless p = A.later_elim_timeless p
+
 let later_star = Sep.later_star
-let later_exists = Sep.later_exists
+// let later_exists = Sep.later_exists
 
 //////////////////////////////////////////////////////////////////////////
 // Equivalence

--- a/lib/core/Pulse.Lib.Core.fst
+++ b/lib/core/Pulse.Lib.Core.fst
@@ -207,10 +207,13 @@ let later = later
 let later_intro p = A.later_intro p
 let later_elim p = A.later_elim p
 
-let later_elim_timeless p = A.later_elim_timeless p
+let later_elim_timeless p = A.implies_elim (later p) p
 
 let later_star = Sep.later_star
-// let later_exists = Sep.later_exists
+let later_exists #t f =
+  let h: squash Sep.(later (exists* x. f x) `implies` exists* x. later (f x)) = Sep.later_exists #t f in
+  let h: squash (later (exists* x. f x) `implies` exists* x. later (f x)) = h in
+  A.implies_elim _ _
 
 //////////////////////////////////////////////////////////////////////////
 // Equivalence

--- a/lib/core/PulseCore.Action.fst
+++ b/lib/core/PulseCore.Action.fst
@@ -393,9 +393,9 @@ let later_elim (p:slprop)
 : act unit Ghost emp_inames (later p ** later_credit 1) (fun _ -> p)
 = fun #ictx -> ITA.later_elim ictx p
 
-let later_elim_timeless (p:slprop { timeless p })
-: act unit Ghost emp_inames (later p) (fun _ -> p)
-= fun #ictx -> ITA.later_elim_timeless ictx p
+let implies_elim (p:slprop) (q:slprop { implies p q })
+: act unit Ghost emp_inames p (fun _ -> q)
+= fun #ictx -> ITA.implies_elim ictx p q
 
 let buy1 ()
 : stt unit emp (fun _ -> later_credit 1)

--- a/lib/core/PulseCore.Action.fst
+++ b/lib/core/PulseCore.Action.fst
@@ -393,6 +393,10 @@ let later_elim (p:slprop)
 : act unit Ghost emp_inames (later p ** later_credit 1) (fun _ -> p)
 = fun #ictx -> ITA.later_elim ictx p
 
+let later_elim_timeless (p:slprop { timeless p })
+: act unit Ghost emp_inames (later p) (fun _ -> p)
+= fun #ictx -> ITA.later_elim_timeless ictx p
+
 let buy1 ()
 : stt unit emp (fun _ -> later_credit 1)
 = stt_of_action0 (ITA.buy emp_inames)

--- a/lib/core/PulseCore.Action.fsti
+++ b/lib/core/PulseCore.Action.fsti
@@ -191,8 +191,8 @@ val later_intro (p:slprop)
 val later_elim (p:slprop)
 : act unit Ghost emp_inames (later p ** later_credit 1) (fun _ -> p)
 
-val later_elim_timeless (p:slprop { timeless p })
-: act unit Ghost emp_inames (later p) (fun _ -> p)
+val implies_elim (p:slprop) (q:slprop { implies p q })
+: act unit Ghost emp_inames p (fun _ -> q)
 
 val buy1 ()
 : stt unit emp (fun _ -> later_credit 1)

--- a/lib/core/PulseCore.Action.fsti
+++ b/lib/core/PulseCore.Action.fsti
@@ -191,6 +191,9 @@ val later_intro (p:slprop)
 val later_elim (p:slprop)
 : act unit Ghost emp_inames (later p ** later_credit 1) (fun _ -> p)
 
+val later_elim_timeless (p:slprop { timeless p })
+: act unit Ghost emp_inames (later p) (fun _ -> p)
+
 val buy1 ()
 : stt unit emp (fun _ -> later_credit 1)
 

--- a/lib/core/PulseCore.Atomic.fst
+++ b/lib/core/PulseCore.Atomic.fst
@@ -316,6 +316,7 @@ let invariant_name_identifies_invariant p q i j =
     (lift_neutral_ghost (A.invariant_name_identifies_invariant p q i))
 let later_intro p = lift_neutral_ghost (A.later_intro p)
 let later_elim p = lift_neutral_ghost (A.later_elim p)
+let later_elim_timeless p = lift_neutral_ghost (A.later_elim_timeless p)
 let buy1 = A.buy1
 
 let pts_to_not_null #a #p r v = lift_neutral_ghost (A.pts_to_not_null #a #p r v)

--- a/lib/core/PulseCore.Atomic.fst
+++ b/lib/core/PulseCore.Atomic.fst
@@ -316,7 +316,7 @@ let invariant_name_identifies_invariant p q i j =
     (lift_neutral_ghost (A.invariant_name_identifies_invariant p q i))
 let later_intro p = lift_neutral_ghost (A.later_intro p)
 let later_elim p = lift_neutral_ghost (A.later_elim p)
-let later_elim_timeless p = lift_neutral_ghost (A.later_elim_timeless p)
+let implies_elim p q = lift_neutral_ghost (A.implies_elim p q)
 let buy1 = A.buy1
 
 let pts_to_not_null #a #p r v = lift_neutral_ghost (A.pts_to_not_null #a #p r v)

--- a/lib/core/PulseCore.Atomic.fsti
+++ b/lib/core/PulseCore.Atomic.fsti
@@ -327,8 +327,8 @@ val later_intro (p:slprop)
 val later_elim (p:slprop)
 : stt_ghost unit emp_inames (later p ** later_credit 1) (fun _ -> p)
 
-val later_elim_timeless (p: slprop { timeless p })
-: stt_ghost unit emp_inames (later p) (fun _ -> p)
+val implies_elim (p: slprop) (q: slprop { implies p q })
+: stt_ghost unit emp_inames p (fun _ -> q)
 
 val buy1 ()
 : stt unit emp (fun _ -> later_credit 1)

--- a/lib/core/PulseCore.Atomic.fsti
+++ b/lib/core/PulseCore.Atomic.fsti
@@ -327,6 +327,9 @@ val later_intro (p:slprop)
 val later_elim (p:slprop)
 : stt_ghost unit emp_inames (later p ** later_credit 1) (fun _ -> p)
 
+val later_elim_timeless (p: slprop { timeless p })
+: stt_ghost unit emp_inames (later p) (fun _ -> p)
+
 val buy1 ()
 : stt unit emp (fun _ -> later_credit 1)
 

--- a/lib/core/PulseCore.IndirectionTheoryActions.fst
+++ b/lib/core/PulseCore.IndirectionTheoryActions.fst
@@ -306,12 +306,12 @@ let later_elim (e:inames) (p:slprop)
     assert (is_full s2);
     (), s2
 
-let later_elim_timeless e p
+let implies_elim e p q
 = fun frame s0 ->
     sep_laws();
-    let m0, rest = split_mem (later p) (frame `star` mem_invariant e s0) s0 in
-    elim_later_timeless p m0;
-    intro_star p (frame `star` mem_invariant e s0) m0 rest;
+    let m0, rest = split_mem p (frame `star` mem_invariant e s0) s0 in
+    elim_implies p q m0;
+    intro_star q (frame `star` mem_invariant e s0) m0 rest;
     is_ghost_action_refl s0;
     (), s0
 
@@ -513,7 +513,7 @@ let invariant_name_identifies_invariant e i p q
                   s0
     in
     disjoint_join_levels m0 m1;
-    invariant_name_identifies_invariant i p q m0;
+    elim_implies' (invariant_name_identifies_invariant i p q) m0;
     intro_star (later (equiv p q))
                (inv i p `star` inv i q `star` frame `star` mem_invariant e s0)
                m0 m1;
@@ -679,7 +679,7 @@ let slprop_ref_gather #o x p1 p2
         (frame `star` mem_invariant o s0)
         (hide s0)
     in
-    slprop_ref_pts_to_gather x p1 p2 m1;
+    elim_implies' (slprop_ref_pts_to_gather x p1 p2) m1;
     intro_star (slprop_ref_pts_to x p1 `star` later (equiv p1 p2)) (frame `star` mem_invariant o s0) m1 m2;
     is_ghost_action_refl s0;
     (), s0

--- a/lib/core/PulseCore.IndirectionTheoryActions.fst
+++ b/lib/core/PulseCore.IndirectionTheoryActions.fst
@@ -306,6 +306,15 @@ let later_elim (e:inames) (p:slprop)
     assert (is_full s2);
     (), s2
 
+let later_elim_timeless e p
+= fun frame s0 ->
+    sep_laws();
+    let m0, rest = split_mem (later p) (frame `star` mem_invariant e s0) s0 in
+    elim_later_timeless p m0;
+    intro_star p (frame `star` mem_invariant e s0) m0 rest;
+    is_ghost_action_refl s0;
+    (), s0
+
 let buy (e:inames)
 : act unit e emp (fun _ -> later_credit 1)
 = fun frame m0 -> (

--- a/lib/core/PulseCore.IndirectionTheoryActions.fsti
+++ b/lib/core/PulseCore.IndirectionTheoryActions.fsti
@@ -47,8 +47,8 @@ val later_intro (e:inames) (p:slprop)
 val later_elim (e:inames) (p:slprop) 
 : ghost_act unit e (later p `star` later_credit 1) (fun _ -> p)
 
-val later_elim_timeless (e:inames) (p:slprop { timeless p })
-: ghost_act unit e (later p) (fun _ -> p)
+val implies_elim (e:inames) (p: slprop) (q:slprop { implies p q })
+: ghost_act unit e p (fun _ -> q)
 
 val buy (e:inames)
 : act unit e emp (fun _ -> later_credit 1)

--- a/lib/core/PulseCore.IndirectionTheoryActions.fsti
+++ b/lib/core/PulseCore.IndirectionTheoryActions.fsti
@@ -47,6 +47,9 @@ val later_intro (e:inames) (p:slprop)
 val later_elim (e:inames) (p:slprop) 
 : ghost_act unit e (later p `star` later_credit 1) (fun _ -> p)
 
+val later_elim_timeless (e:inames) (p:slprop { timeless p })
+: ghost_act unit e (later p) (fun _ -> p)
+
 val buy (e:inames)
 : act unit e emp (fun _ -> later_credit 1)
 

--- a/lib/core/PulseCore.IndirectionTheorySep.fst
+++ b/lib/core/PulseCore.IndirectionTheorySep.fst
@@ -1236,3 +1236,11 @@ let slprop_ref_pts_to_gather x y1 y2 =
       (slprop_ref_pts_to x y1 `star` later (equiv y1 y2)) fun m ->
     let (m1, m2) = star_elim (slprop_ref_pts_to x y1) (slprop_ref_pts_to x y2) m in
     star_intro (slprop_ref_pts_to x y1) (later (equiv y1 y2)) m m1 m2
+
+let implies' (p q: slprop) : prop =
+  forall (m: premem). p m ==> q m
+
+let loeb (p: slprop { implies' (later p) p }) : squash (implies' emp p) =
+  let rec aux (m: premem) : Lemma (ensures p m) (decreases level_ m) =
+    if level_ m > 0 then aux (age1_ m) else () in
+  introduce forall m. p m with aux m

--- a/lib/core/PulseCore.IndirectionTheorySep.fst
+++ b/lib/core/PulseCore.IndirectionTheorySep.fst
@@ -530,13 +530,15 @@ let lift_star_eq p q =
       let (w1, w2) = star_elim (lift p) (lift q) w in
       ()
 
+let later_pred (p: slprop) (w: premem) : prop =
+  level_ w > 0 ==> p (age1_ w)
 let later (p: slprop) : slprop =
   reveal_slprop_ok ();
-  introduce forall a b. mem_le a b /\ p (age1_ a) ==> p (age1_ b) with (
+  introduce forall a b. mem_le a b /\ later_pred p a ==> later_pred p b with (
     mem_le_iff a b;
     mem_le_iff (age1_ a) (age1_ b)
   );
-  mk_slprop fun w -> p (age1_ w)
+  mk_slprop (later_pred p)
 
 let later_credit (n: nat) : slprop =
   reveal_mem_le ();
@@ -557,17 +559,26 @@ let later_credit_add (m n: nat) : squash (later_credit (m + n) == later_credit m
     introduce (later_credit m `star` later_credit n) w ==> later_credit (m+n) w with _.
       let (w1, w2) = star_elim (later_credit m) (later_credit n) w in ()
 
-let timeless_lift (p: PM.slprop) : squash (timeless (lift p)) =
-  mem_pred_ext (later (lift p)) (lift p) fun w -> ()
+let except0 (p: slprop) : slprop =
+  reveal_slprop_ok (); reveal_mem_le ();
+  mk_slprop fun m -> level_ m > 0 ==> p m
 
-let timeless_pure (p: prop) : squash (timeless (pure p)) =
-  mem_pred_ext (later (pure p)) (pure p) fun w -> ()
+let timeless (p: slprop) : prop =
+  forall (m: premem). level_ m > 0 ==> (later p m <==> p m)
+  // later p == except0 p
 
-let timeless_emp () : squash (timeless emp) =
-  mem_pred_ext (later emp) emp fun w -> ()
+let timeless_intro (p: slprop) (h: (m:premem { level_ m > 0 } -> squash (p m <==> later p m))) : squash (timeless p) =
+  introduce forall (m: premem). level_ m > 0 ==> (p m <==> later p m) with
+  introduce _ ==> _ with _. h m
+  // mem_pred_ext (later p) (except0 p) fun m -> if level_ m > 0 then h m else ()
 
-let timeless_later_credit n : squash (timeless (later_credit n)) =
-  mem_pred_ext (later (later_credit n)) (later_credit n) fun w -> ()
+let timeless_intro' (#p: slprop { forall (m:premem). level_ m > 0 ==> (p m <==> later p m) }) : squash (timeless p) =
+  timeless_intro p fun m -> ()
+
+let timeless_lift (p: PM.slprop) : squash (timeless (lift p)) = timeless_intro'
+let timeless_pure (p: prop) : squash (timeless (pure p)) = timeless_intro'
+let timeless_emp () : squash (timeless emp) = timeless_intro'
+let timeless_later_credit n : squash (timeless (later_credit n)) = timeless_intro'
 
 irreducible
 let rejuvenate1 (m: premem) (m': premem { mem_le m' (age1_ m) }) :
@@ -581,7 +592,7 @@ let rejuvenate1 (m: premem) (m': premem { mem_le m' (age1_ m) }) :
   mem_ext (age1_ m'') m' (fun _ -> ());
   m''
 
-#push-options "--z3rlimit 60 --query_stats"
+#push-options "--z3rlimit 100 --query_stats"
 #restart-solver
 irreducible
 let rejuvenate1_sep (m m1': premem) (m2': premem { disjoint_mem m1' m2' /\ age1_ m == join_premem m1' m2' }) :
@@ -598,18 +609,40 @@ let rejuvenate1_sep (m m1': premem) (m2': premem { disjoint_mem m1' m2' /\ age1_
 
 let later_star (p q: slprop) : squash (later (star p q) == star (later p) (later q)) =
   mem_pred_ext (later (star p q)) (star (later p) (later q)) fun w ->
-    introduce star p q (age1_ w) ==> star (later p) (later q) w with _. (
-      let (w1', w2') = star_elim p q (age1_ w) in
-      let (w1, w2) = rejuvenate1_sep w w1' w2' in
-      star_intro (later p) (later q) w w1 w2
-    );
-    introduce star (later p) (later q) w ==> star p q (age1_ w) with _. (
-      let (w1, w2) = star_elim (later p) (later q) w in
-      star_intro p q (age1_ w) (age1_ w1) (age1_ w2)
+    if level_ w > 0 then (
+      introduce star p q (age1_ w) ==> star (later p) (later q) w with _. (
+        let (w1', w2') = star_elim p q (age1_ w) in
+        let (w1, w2) = rejuvenate1_sep w w1' w2' in
+        star_intro (later p) (later q) w w1 w2
+      );
+      introduce star (later p) (later q) w ==> star p q (age1_ w) with _. (
+        let (w1, w2) = star_elim (later p) (later q) w in
+        star_intro p q (age1_ w) (age1_ w1) (age1_ w2)
+      )
+    ) else (
+      assert later (star p q) w;
+      join_empty w;
+      star_intro (later p) (later q) w (empty (level_ w)) w
     )
 
-let later_exists #t (f:t->slprop) : squash (later (exists* x. f x) == (exists* x. later (f x))) =
-  mem_pred_ext (later (exists* x. f x)) (exists* x. later (f x)) fun w -> ()
+let timeless_star p q =
+  later_star p q;
+  timeless_intro (star p q) fun m ->
+    introduce star (later p) (later q) m ==> star p q m with _. (
+      let (m1, m2) = star__elim (later p) (later q) m in
+      star__intro p q m m1 m2
+    );
+    introduce star p q m ==> star (later p) (later q) m with _. (
+      let (m1, m2) = star__elim p q m in
+      star__intro (later p) (later q) m m1 m2
+    )
+
+let later_exists #t (f:t->slprop) = ()
+
+let timeless_exists (#t: Type) (f: t->slprop) :
+    Lemma (requires forall x. timeless (f x)) (ensures timeless (exists* x. f x)) =
+  timeless_intro (exists* x. f x) fun m ->
+    assert (exists x. except0 (f x) m) <==> (exists x. later (f x) m)
 
 let equiv p q : slprop =
   reveal_mem_le ();
@@ -618,6 +651,12 @@ let equiv p q : slprop =
 let eq_at_elim n (p q: mem_pred) (w: premem) :
     Lemma (requires eq_at n p q /\ level_ w < n) (ensures p w <==> q w) =
   assert approx n p w == approx n q w
+
+let eq_at_intro (n: nat) (p q: mem_pred)
+    (h: (m: premem { level_ m < n } -> squash (p m <==> q m))) :
+    Lemma (eq_at n p q) =
+  mem_pred_ext (approx n p) (approx n q) fun m ->
+    if level_ m < n then h m else ()
 
 let intro_equiv p m = ()
 
@@ -652,15 +691,13 @@ let later_equiv (p q: slprop) =
       mem_pred_ext (approx (level_ m + 1) (later p)) (approx (level_ m + 1) (later q)) fun m' ->
         if level_ m' >= level_ m + 1 then () else
           if level_ m = 0 then
-            eq_at_elim 1 p q m'
+            ()
           else
             eq_at_elim (level_ m) p q (age1_ m')
     );
     introduce equiv (later p) (later q) m ==> later (equiv p q) m with _. (
       if level_ m = 0 then
-        mem_pred_ext (approx 1 p) (approx 1 q) fun m' ->
-          if level_ m' >= 1 then () else
-            eq_at_elim 1 (later p) (later q) m'
+        ()
       else
         mem_pred_ext (approx (level_ m) p) (approx (level_ m) q) fun m' ->
           if level_ m' >= level_ m then () else (
@@ -672,7 +709,7 @@ let later_equiv (p q: slprop) =
 
 let rec timeless_interp (a: slprop { timeless a }) (w: premem) :
     Lemma (ensures a w <==> a (age_to_ w 0)) (decreases level_ w) =
-  if level_ w = 0 then () else timeless_interp a (age1_ w)
+  if level_ w = 0 then (mem_ext w (age_to_ w 0) fun a -> ()) else timeless_interp a (age1_ w)
 
 let timeless_ext (a b: (p:slprop {timeless p})) (h: (w: premem { level_ w == 0 } -> squash (a w <==> b w))) :
     squash (a == b) =
@@ -686,6 +723,10 @@ let equiv_timeless (a b: slprop) :
       (ensures timeless (equiv a b) /\ equiv a b == pure (a == b)) =
   later_equiv a b;
   timeless_pure (a == b);
+  timeless_intro (equiv a b) (fun m ->
+    introduce later (equiv a b) m ==> equiv a b m with _.
+      eq_at_intro (level_ m + 1) a b fun m' ->
+        eq_at_elim (level_ m) a b (age1_ m'));
   timeless_ext (equiv a b) (pure (a == b)) fun w ->
     introduce equiv a b w ==> a == b with _.
       timeless_ext a b fun w' ->
@@ -709,6 +750,8 @@ let age_to_zero (w: premem { level_ w == 0 }) : Lemma (age_to_ w 0 == w) [SMTPat
   mem_ext (age_to_ w 0) w fun i -> ()
 
 let intro_later p m = reveal_slprop_ok ()
+
+let elim_later_timeless p m = ()
 
 let iref = address
 

--- a/lib/core/PulseCore.IndirectionTheorySep.fsti
+++ b/lib/core/PulseCore.IndirectionTheorySep.fsti
@@ -186,13 +186,15 @@ val later_credit (n:nat) : slprop
 val later_credit_zero () : squash (later_credit 0 == emp)
 val later_credit_add m n : squash (later_credit (m + n) == later_credit m `star` later_credit n)
 
-let timeless (p: slprop) = later p == p
+val timeless (p: slprop) : prop
 val timeless_lift p : squash (timeless (lift p))
 val timeless_pure p : squash (timeless (pure p))
 val timeless_emp () : squash (timeless emp)
 val timeless_later_credit n : squash (timeless (later_credit n))
 val later_star p q : squash (later (star p q) == star (later p) (later q))
-val later_exists #t (f:t->slprop) : squash (later (exists* x. f x) == (exists* x. later (f x)))
+val timeless_star p q : Lemma (requires timeless p /\ timeless q) (ensures timeless (star p q))
+// val later_exists (#t: Type) (f:t->slprop) : squash (later (exists* x. f x) `equiv_pos` (exists* x. later (f x)))
+val timeless_exists (#t: Type) (f: t->slprop) : Lemma (requires forall x. timeless (f x)) (ensures timeless (exists* x. f x))
 
 val equiv (p q:slprop) : slprop
 val intro_equiv (p: slprop) m : squash (interp (equiv p p) m)
@@ -205,6 +207,7 @@ val equiv_star_congr (p q r: slprop) : squash (equiv q r == equiv q r `star` equ
 
 val intro_later (p:slprop) (m:mem)
 : Lemma (interp p m ==> interp (later p) m)
+val elim_later_timeless (p: slprop {timeless p}) (m: mem { level m > 0 }) : squash (interp (later p) m ==> interp p m)
 
 (**** Memory invariants *)
 [@@erasable]
@@ -267,8 +270,8 @@ val age_disjoint (m0 m1:mem)
 val age_hereditary (p:slprop) (m:mem)
 : Lemma (interp p m ==> interp p (age1 m))
 val age_later (p:slprop) (m:mem)
-: Lemma 
-  (interp (later p) m <==> interp p (age1 m))
+: Lemma
+  (interp (later p) m <==> (level m > 0 ==> interp p (age1 m)))
 
 val spend_mem (m:mem) : m':mem { 
   is_ghost_action m m' /\

--- a/lib/core/PulseCore.InstantiatedSemantics.fst
+++ b/lib/core/PulseCore.InstantiatedSemantics.fst
@@ -49,6 +49,7 @@ let emp = emp
 let pure p = pure p
 let op_Star_Star = star
 let op_exists_Star #a p = op_exists_Star #a p
+let implies = implies
 let later_credit = later_credit
 let later = later
 let equiv = equiv

--- a/lib/core/PulseCore.InstantiatedSemantics.fsti
+++ b/lib/core/PulseCore.InstantiatedSemantics.fsti
@@ -22,6 +22,7 @@ val emp : slprop
 val pure (p:prop) : slprop
 val ( ** ) (p q : slprop) : slprop
 val ( exists* ) (#a:Type u#a) (p: a -> slprop) : slprop
+val implies (p q : slprop) : prop
 val later_credit (n:nat) : slprop
 val later (p:slprop) : slprop
 val equiv (p q:slprop) : slprop

--- a/lib/core/PulseCore.KnotInstantiation.fsti
+++ b/lib/core/PulseCore.KnotInstantiation.fsti
@@ -91,8 +91,8 @@ val approx_read (m: premem) a :
     Lemma (map_hogs_val (approx (level_ m)) (read m a) == read m a)
     [SMTPat (read m a)]
 
-val age_to_ (m: premem) (n: erased nat) :
-    n:premem { credits_ n == credits_ m /\ timeless_heap_of n == timeless_heap_of m }
+val age_to_ (m: premem) (i: erased nat) :
+    n:premem { credits_ n == credits_ m /\ timeless_heap_of n == timeless_heap_of m /\ level_ n == reveal i }
 
 val read_age_to_ (m: premem) (n: erased nat) a :
     Lemma (read (age_to_ m n) a == (map_hogs_val (approx n) (read m a)))


### PR DESCRIPTION
The only unexpected change is that `later_exists` no longer holds; you cannot commute existentials and later equationally.  You can still turn `later (exists* x. f x)` into `exists* x. later (f x)` using a ghost action though.