### PR TITLE
Fixes for autorewrite in matches/let

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.AVLTree.fst
+++ b/lib/pulse/lib/Pulse.Lib.AVLTree.fst
@@ -493,7 +493,6 @@ fn write_node
 {
   let n = { data = data; left = lp; right = rp };
   let Some p = tree;
-  rewrite each (Some?.v tree) as p;
   p := n;
   fold (is_tree tree (T.Node data lt rt))
 }

--- a/src/checker/Pulse.Checker.Match.fst
+++ b/src/checker/Pulse.Checker.Match.fst
@@ -186,8 +186,10 @@ let rec tot_typing_weakening_n bs d =
     let d = Pulse.Typing.Metatheory.tot_typing_weakening_single d x t in
     tot_typing_weakening_n bs d
 
-let samepat (b1 b2 : branch) : prop = fst b1 == fst b2
-let samepats (bs1 bs2 : list branch) : prop = L.map fst bs1 == L.map fst bs2
+let patof (b:branch) : pattern = b.pat
+let samepat (b1 b2 : branch) : prop = b1.pat == b2.pat
+let samepats (bs1 bs2 : list branch) : prop =
+  L.map patof bs1 == L.map patof bs2
 
 let open_st_term_bs (t:st_term) (bs:list binding) : st_term =
   let rec aux (bs:list binding) (i:nat) : subst =
@@ -214,6 +216,7 @@ let rec bindings_to_string (bs : list binding) : T.Tac string =
 #push-options "--z3rlimit 20"
 
 let check_branch
+        (norw:bool)
         (g:env)
         (pre:term)
         (pre_typing: tot_typing g pre tm_slprop)
@@ -244,22 +247,27 @@ let check_branch
     fail g (Some e.range) "Failed to elab pattern into term";
   if (R.Tv_Unknown? (R.inspect_ln (fst (Some?.v elab_p)))) then
     fail g (Some e.range) "should not happen: pattern elaborated to Tv_Unknown";
-  // T.print ("Elaborated pattern = " ^ T.term_to_string (fst (Some?.v elab_p)));
+  if Cons? (snd (Some?.v elab_p)) then
+    fail g (Some e.range) "should not happen: pattern elaboration missed some binders";
+  // T.print ("Elaborated pattern = " ^ Pulse.Show.show (fst (Some?.v elab_p)));
   let elab_p_tm = fst (Some?.v elab_p) in
   let eq_typ = mk_sq_eq2 sc_u sc_ty sc elab_p_tm in
   let g' = push_binding g' hyp_var ({name = Sealed.seal "branch equality"; range = Range.range_0 }) eq_typ in
   let e = open_st_term_bs e pulse_bs in
   let e =
-    let t =
-      mk_term (Tm_ProofHintWithBinders {
-                 binders = [];
-                 hint_type = RENAME { pairs = [(sc, elab_p_tm)];
-                                      goal = None;
-                                      tac_opt = Some Pulse.Reflection.Util.match_rewrite_tac_tm; };
-                 t = e; })
-              e.range
-    in
-    { t with effect_tag = e.effect_tag }
+    if norw
+    then e
+    else
+      let t =
+        mk_term (Tm_ProofHintWithBinders {
+                   binders = [];
+                   hint_type = RENAME { pairs = [(sc, elab_p_tm)];
+                                        goal = None;
+                                        tac_opt = Some Pulse.Reflection.Util.match_rewrite_tac_tm; };
+                   t = e; })
+                e.range
+      in
+      { t with effect_tag = e.effect_tag }
   in
   let pre_typing = tot_typing_weakening_n pulse_bs pre_typing in // weaken w/ binders
   let pre_typing = Pulse.Typing.Metatheory.tot_typing_weakening_single pre_typing hyp_var eq_typ in // weaken w/ branch eq
@@ -281,7 +289,7 @@ let check_branches_aux_t
         (sc : term)
 = (br:branch
    & c:comp_st{comp_pre c == pre /\ comp_post_matches_hint c (Some post_hint)}
-   & br_typing g sc_u sc_ty sc (fst br) (snd br) c)
+   & br_typing g sc_u sc_ty sc br.pat br.e c)
 
 let check_branches_aux
         (g:env)
@@ -301,10 +309,10 @@ let check_branches_aux
 = if L.isEmpty brs0 then fail g None "empty match";
   let tr1 (b: branch) (pbs:R.pattern & list R.binding)
     : T.Tac (check_branches_aux_t pre post_hint sc_u sc_ty sc)
-    = let (_, e) = b in
+    = let e = b.e in
       let (p, bs) = pbs in
-      let (| p, e, c, d |) = check_branch g pre pre_typing post_hint check sc_u sc_ty sc p e bs in
-      (| (p,e), c, d |)
+      let (| p, e, c, d |) = check_branch (T.unseal b.norw) g pre pre_typing post_hint check sc_u sc_ty sc p e bs in
+      (| {pat=p; e; norw=b.norw}, c, d |)
   in
   let r = zipWith tr1 brs0 bnds in
   assume (samepats brs0 (L.map Mkdtuple3?._1 r));
@@ -330,7 +338,7 @@ let weaken_branch_observability
           comp_observability c == obs
         })
       (checked_br : check_branches_aux_t #g pre post_hint sc_u sc_ty sc { ctag_of_br checked_br == STT_Atomic})
-: T.Tac (br:branch & br_typing g sc_u sc_ty sc (fst br) (snd br) c)
+: T.Tac (br:branch & br_typing g sc_u sc_ty sc br.pat br.e c)
 = let (| br, c0, typing |) = checked_br in
   match c0 with
   | C_STAtomic i obs' st ->
@@ -362,7 +370,7 @@ let join_branches (#g #pre #post_hint #sc_u #sc_ty #sc:_)
                   (ct:ctag)
                   (checked_brs : list (cbr:check_branches_aux_t #g pre post_hint sc_u sc_ty sc {ctag_of_br cbr == ct}))
 : T.Tac (c:comp_st { comp_pre c == pre /\ comp_post_matches_hint c (Some post_hint) } &
-         list (br:branch & br_typing g sc_u sc_ty sc (fst br) (snd br) c))
+         list (br:branch & br_typing g sc_u sc_ty sc br.pat br.e c))
 = match checked_brs with
   | [] -> T.fail "Impossible: empty match"
   | checked_br::rest ->
@@ -373,7 +381,7 @@ let join_branches (#g #pre #post_hint #sc_u #sc_ty #sc:_)
       let rest = 
         List.Tot.map 
           #(cbr:check_branches_aux_t #g pre post_hint sc_u sc_ty sc {ctag_of_br cbr==ct})
-          #(br:branch & br_typing g sc_u sc_ty sc (fst br) (snd br) c)
+          #(br:branch & br_typing g sc_u sc_ty sc br.pat br.e c)
           (fun (| br, c', d |) -> (| br, d |))
           rest
       in
@@ -404,7 +412,7 @@ let weaken_branch_tag_to
 = let (| pe, c, d|) = br in
   if ctag_of_comp_st c = ct then br
   else
-    let r = (snd pe).range in
+    let r = pe.e.range in
     match ct, c with
     | STT_Ghost, C_STAtomic _ _ _
     | STT_Ghost, C_ST _ -> T.fail "Unexpected least effect"
@@ -467,12 +475,13 @@ let check_branches
   let (| c0, checked_brs |) = join_branches ct checked_brs in
   let brs = List.Tot.map dfst checked_brs in
   let d : brs_typing g sc_u sc_ty sc brs c0 =
-    let rec aux (brs : list (br:branch & br_typing g sc_u sc_ty sc (fst br) (snd br) c0))
+    let rec aux (brs : list (br:branch & br_typing g sc_u sc_ty sc br.pat br.e c0))
       : brs_typing g sc_u sc_ty sc (List.Tot.map dfst brs) c0
       = match brs with
         | [] -> TBRS_0 c0
-        | (|(p,e), d|)::rest ->
-          TBRS_1 c0 p e d (List.Tot.map dfst rest) (aux rest)
+        | (| br, d|)::rest ->
+          let { pat; e } = br in
+          TBRS_1 c0 pat e d (List.Tot.map dfst rest) (aux rest)
     in
     aux checked_brs
   in
@@ -497,11 +506,11 @@ let check
   let nbr = L.length brs in
 
   let (| sc, sc_u, sc_ty, sc_ty_typing, sc_typing |) = compute_tot_term_type_and_u g sc in
-  let elab_pats = L.map elab_pat (L.map fst brs) in
+  let elab_pats = L.map elab_pat (L.map patof brs) in
 
   assertby (L.length elab_pats == L.length brs) (fun () ->
-    lemma_map_len fst brs;
-    lemma_map_len elab_pat (L.map fst brs)
+    lemma_map_len patof brs;
+    lemma_map_len elab_pat (L.map patof brs)
   );
 
   let (| elab_pats', bnds', complete_d |)
@@ -521,9 +530,9 @@ let check
   let new_pats = map_opt readback_pat elab_pats' in 
   if None? new_pats then
     fail g (Some sc_range) "failed to readback new patterns";
-  let brs = zipWith (fun p (_, e) -> (p,e)) (Some?.v new_pats) brs in
+  let brs = zipWith (fun p br -> { br with pat=p }) (Some?.v new_pats) brs in
   
-  assume (L.map fst brs == Some?.v new_pats);
+  assume (L.map patof brs == Some?.v new_pats);
   
   lemma_map_opt_lenx readback_pat elab_pats';
 
@@ -538,9 +547,9 @@ let check
 
   let (| brs, c, brs_d |) =
     check_branches g pre pre_typing post_hint check sc_u sc_ty sc brs (zip elab_pats' bnds') in
-  
+
   (* Provable *)
-  assume (L.map (fun (p, _) -> elab_pat p) brs == elab_pats');
+  assume (L.map (fun br -> elab_pat br.pat) brs == elab_pats');
   let c_typing = comp_typing_from_post_hint c pre_typing post_hint in
   let d = T_Match g sc_u sc_ty sc sc_ty_typing sc_typing c (E c_typing) brs brs_d complete_d in
   checker_result_for_st_typing (| _, _, d |) res_ppname

--- a/src/checker/Pulse.Simplify.fst
+++ b/src/checker/Pulse.Simplify.fst
@@ -4,6 +4,30 @@ open Pulse.Show
 open FStar.Reflection.V2
 module T       = FStar.Tactics.V2
 
+let is_Some (t:term) : T.Tac (option term) =
+  match T.hua t with
+  | Some (h, us, args) ->
+    if implode_qn (T.inspect_fv h) = `%Some
+    then
+      match args with
+      | [(_, Q_Implicit); (t, Q_Explicit)] -> Some t
+      | _ -> None
+    else
+    None
+  | _ -> None
+
+let is_Some_v (t:term) : T.Tac (option term) =
+  match T.hua t with
+  | Some (h, us, args) ->
+    if implode_qn (T.inspect_fv h) = `%Some?.v
+    then
+      match args with
+      | [(_, Q_Implicit); (t, Q_Explicit)] -> Some t
+      | _ -> None
+    else
+    None
+  | _ -> None
+
 let is_tuple2__1 (t:term) : T.Tac (option term) =
   match T.hua t with
   | Some (h, us, args) ->
@@ -111,9 +135,18 @@ let simpl_hide_reveal (t:term) : T.Tac term =
     end
   | None -> t
 
+let simpl_option (t:term) : T.Tac term =
+  match is_Some_v t with
+  | Some o ->
+    (match is_Some o with
+    | Some x -> x
+    | None -> t)
+  | None -> t
+
 let rec simplify (t0:term) : T.Tac term =
   let t = t0 in
   let t = simpl_proj t in
+  let t = simpl_option t in
   let t = simpl_hide_reveal t in
   let t = simpl_reveal_hide t in
   let t =

--- a/src/checker/Pulse.Soundness.Match.fst
+++ b/src/checker/Pulse.Soundness.Match.fst
@@ -36,13 +36,13 @@ let complete_soundness
   (brs:list branch)
   (c:comp_st)
   (d : brs_typing g sc_u sc_ty sc brs c)
-  (comp : pats_complete g sc sc_ty (L.map (fun (p, _) -> elab_pat p) brs))
+  (comp : pats_complete g sc sc_ty (L.map (fun br -> elab_pat br.pat) brs))
   (bs : list (list R.binding))
   : RT.match_is_complete (elab_env g) sc sc_ty
                                  (List.Tot.map fst (elab_branches d))
                                  bs
   = let PC_Elab _ _ _ _ bs' s = comp in
-    assume (L.map fst (elab_branches d) == L.map (fun (p, _) -> elab_pat p) brs); // FIXME
+    assume (L.map fst (elab_branches d) == L.map (fun br -> elab_pat br.pat) brs); // FIXME
     assume (bs == bs'); // FIXME
     s
 

--- a/src/checker/Pulse.Syntax.Base.fst
+++ b/src/checker/Pulse.Syntax.Base.fst
@@ -290,11 +290,10 @@ let rec eq_st_term (t1 t2:st_term)
 
     | _ -> false
 
-and eq_branch (b1 b2 : pattern & st_term)
+and eq_branch (b1 b2 : branch)
   : b:bool{b <==> (b1 == b2)}
-  = let (p1, e1) = b1 in
-    let (p2, e2) = b2 in
-    eq_pattern p1 p2 && eq_st_term e1 e2
+  = eq_pattern b1.pat b2.pat &&
+    eq_st_term b1.e   b2.e
 
 and eq_aqual (q1 q2 : qualifier) : b:bool{b <==> (q1 == q2)} =
   match q1, q2 with

--- a/src/checker/Pulse.Syntax.Base.fsti
+++ b/src/checker/Pulse.Syntax.Base.fsti
@@ -305,7 +305,11 @@ and st_term = {
     seq_lhs : Sealed.Inhabited.sealed #bool false; (* was this s1; ..? if so check that it types to unit *)
 } 
 
-and branch = pattern & st_term
+and branch = {
+  pat : pattern;
+  e : st_term;
+  norw: Sealed.Inhabited.sealed false; (* do not automatically rewrite strutinee to the pattern. *)
+}
 
 (* Create a term with default fields *)
 let mk_term (s : st_term') (r : range) : st_term =

--- a/src/checker/Pulse.Syntax.Builder.fst
+++ b/src/checker/Pulse.Syntax.Builder.fst
@@ -65,3 +65,4 @@ let mk_fn_defn id isrec bs comp meas body : decl' = FnDefn { id; isrec; bs; comp
 let mk_fn_decl id bs comp : decl' = FnDecl { id; bs; comp; }
 let mk_decl d range : decl = {d; range}
 let mark_statement_sequence (s : st_term) : st_term = { s with seq_lhs = Sealed.seal true }
+let mk_branch pat e norw = { pat; e; norw }

--- a/src/checker/Pulse.Syntax.Printer.fst
+++ b/src/checker/Pulse.Syntax.Printer.fst
@@ -440,9 +440,10 @@ and branches_to_string brs : T.Tac _ =
   | b::bs -> branch_to_string b ^ branches_to_string bs
 
 and branch_to_string br : T.Tac _ =
-  let (pat, e) = br in
-  Printf.sprintf "{ %s -> %s }"
+  let {pat; e; norw} = br in
+  Printf.sprintf "{ %s%s -> %s }"
     (pattern_to_string pat)
+    (if T.unseal norw then "(norw)" else "")
     (st_term_to_string' "" e)
 
 and pattern_to_string (p:pattern) : T.Tac string = 

--- a/src/checker/Pulse.Typing.FV.fst
+++ b/src/checker/Pulse.Typing.FV.fst
@@ -650,6 +650,7 @@ fun d cb ->
 #pop-options
 
 #push-options "--z3rlimit 40"
+#restart-solver // avoiding z3 crash on 4.13.3
 let st_typing_freevars_par : st_typing_freevars_case T_Par? =
 fun d cb ->
   match d with

--- a/src/checker/Pulse.Typing.LN.fst
+++ b/src/checker/Pulse.Typing.LN.fst
@@ -318,9 +318,9 @@ and open_branch_ln' (br : branch) (x:term) (i:index)
   : Lemma
     (requires ln_branch' (subst_branch [RT.DT i x] br) (i - 1))
     (ensures ln_branch' br i)
-  = let (p, e) = br in
-    open_pattern_ln p x i;
-    open_st_term_ln' e x (i + pattern_shift_n p)
+  = let {pat; e} = br in
+    open_pattern_ln pat x i;
+    open_st_term_ln' e x (i + pattern_shift_n pat)
 
 let open_term_ln (e:term) (v:var)
   : Lemma 

--- a/src/checker/Pulse.Typing.fst
+++ b/src/checker/Pulse.Typing.fst
@@ -887,9 +887,9 @@ type st_typing : env -> st_term -> comp -> Type =
       tot_typing g sc sc_ty ->
       c:comp_st ->
       my_erased (comp_typing_u g c) ->
-      brs:list (pattern & st_term) ->
+      brs:list branch ->
       brs_typing g sc_u sc_ty sc brs c ->
-      pats_complete g sc sc_ty (L.map (fun (p, _) -> elab_pat p) brs) ->
+      pats_complete g sc sc_ty (L.map (fun b -> elab_pat b.pat) brs) ->
       st_typing g (wrst c (Tm_Match {sc; returns_=None; brs})) c
 
   | T_Frame:
@@ -1079,12 +1079,12 @@ and brs_typing (g:env) (sc_u:universe) (sc_ty:typ) (sc:term) : list branch -> co
 
   | TBRS_1 :
       c:comp_st ->
-      p:pattern ->
+      pat:pattern ->
       e:st_term ->
-      br_typing g sc_u sc_ty sc p e c ->
+      br_typing g sc_u sc_ty sc pat e c ->
       rest:list branch ->
       brs_typing g sc_u sc_ty sc rest c ->
-      brs_typing g sc_u sc_ty sc ((p,e)::rest) c
+      brs_typing g sc_u sc_ty sc ({pat;e;norw=Sealed.seal false}::rest) c
 
 and br_typing : env -> universe -> typ -> term -> pattern -> st_term -> comp_st -> Type =
   | TBR :

--- a/src/ml/PulseSyntaxExtension_Parser.ml
+++ b/src/ml/PulseSyntaxExtension_Parser.ml
@@ -24,6 +24,7 @@ let rewrite_token (tok:FP.token)
     | IDENT "with_invariants" -> PP.WITH_INVS
     | IDENT "opens" -> PP.OPENS
     | IDENT "show_proof_state" -> PP.SHOW_PROOF_STATE
+    | IDENT "norewrite" -> PP.NOREWRITE
     (* the rest are just copied from FStarC_Parser_Parse *)
     | IDENT s -> PP.IDENT s
     | AMP -> PP.AMP

--- a/src/ml/PulseSyntaxExtension_SyntaxWrapper.ml
+++ b/src/ml/PulseSyntaxExtension_SyntaxWrapper.ml
@@ -109,6 +109,9 @@ let pat_cons fv vs _r = PSB.(pat_cons fv (List.map (fun v -> (v,false)) vs))
 type st_term = Pulse_Syntax_Base.st_term
 type branch = Pulse_Syntax_Base.branch
 
+let mk_branch (p:pattern) (t:st_term) (norw:bool) : branch =
+  PSB.mk_branch p t norw
+
 let tm_return (t:term) r : st_term = PSB.(with_range (tm_return (tm_unknown r) false t) r)
 
 let tm_ghost_return (t:term) r : st_term = PSB.(with_range (tm_return (tm_unknown r) false t) r)

--- a/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
+++ b/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
@@ -86,7 +86,8 @@ val pat_constant (c:constant) (_:range) : pattern
 val pat_cons (head:fv) (ps:list pattern) (_:range) : pattern
 
 new val st_term : Type0
-type branch = pattern & st_term
+type branch
+val mk_branch : pattern -> st_term -> norw:bool -> branch
 val tm_return (t:term) (_:range) : st_term
 val tm_ghost_return (t:term) (_:range) : st_term
 val tm_abs (b:binder) (q:option qualifier) (_:option comp) (body:st_term) (_:range) : st_term

--- a/src/syntax_extension/PulseSyntaxExtension.TransformRValues.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.TransformRValues.fst
@@ -120,7 +120,8 @@ let add_derefs_in_scope (n:needs_derefs) (p:Sugar.stmt)
        (fun (x, y) (p:Sugar.stmt) ->
          let lb : Sugar.stmt =
            let pat = A.mk_pattern (A.PatVar (y, None, [])) (range_of_id y) in
-           { s=Sugar.LetBinding { qualifier=None; pat=pat; typ=None;
+           { s=Sugar.LetBinding { norw=false;
+                                  qualifier=None; pat=pat; typ=None;
                                   init=Some (Sugar.Default_initializer (read x)) };
              range=p.range } in
          { s=Sugar.Sequence { s1=lb; s2=p }; range=p.range})
@@ -221,7 +222,7 @@ let rec transform_stmt_with_reads (m:menv) (p:Sugar.stmt)
       let p = { p with s=ArrayAssignment {arr;index;value} } in
       return (p, arr_needs@index_needs@value_needs, m)
 
-    | LetBinding { qualifier; pat; typ; init } -> (
+    | LetBinding { norw; qualifier; pat; typ; init } -> (
       let! init, needs, m =
           match init with
           | None -> return (None, [], m)
@@ -261,7 +262,7 @@ let rec transform_stmt_with_reads (m:menv) (p:Sugar.stmt)
       let! vs = pat_vars pat in
       let m = L.fold_left (fun m v -> menv_push_bv m v qualifier auto_deref_applicable) m vs in
 
-      let p = { p with s=LetBinding { qualifier; pat; typ; init } } in
+      let p = { p with s=LetBinding { norw; qualifier; pat; typ; init } } in
       return (p, needs, m)
       )
 
@@ -289,11 +290,11 @@ let rec transform_stmt_with_reads (m:menv) (p:Sugar.stmt)
       let! branches = 
         branches |>
         mapM
-          (fun (p, s) ->
+          (fun (norw, p, s) ->
             let! vs = pat_vars p in
             let m = menv_push_bvs m vs in
             let! s = transform_stmt m s in
-            return (p, s))
+            return (norw, p, s))
       in
       let p = { p with s = Match { head; returns_annot; branches } } in
       return (p, needs, m)

--- a/test/bug-reports/Bug94.fst.output.expected
+++ b/test/bug-reports/Bug94.fst.output.expected
@@ -10,7 +10,7 @@
 >> Got issues: [
 * Error 189 at Bug94.fst(20,16-20,17):
   - Expected expression of type Prims.nat got expression y of type Prims.string
-  - See also Bug94.fst(20,2-21,4)
+  - See also Bug94.fst(19,1-21,4)
 
 >>]
 >> Got issues: [

--- a/test/nolib/Bug357.fst
+++ b/test/nolib/Bug357.fst
@@ -1,0 +1,63 @@
+module Bug357
+
+#lang-pulse
+open Pulse.Nolib
+
+type t2 =
+  | C : x:int -> y:int{x > y} -> t2
+
+assume val foo : t2 -> slprop
+
+fn test1 (x : t2)
+  requires foo x
+  ensures  foo x
+{
+  match x {
+    norewrite C y z -> {
+      ();
+    }
+  }
+}
+
+fn test11 (x : t2)
+  requires foo x
+  ensures  foo x
+{
+  match x {
+    norewrite y -> {
+      admit();
+      ();
+    }
+  }
+}
+
+(* should work, or at least not crash *)
+[@@expect_failure]
+fn test2 (x : t2)
+  requires foo x
+  ensures  foo x
+{
+  match x {
+    C y z -> {
+      ();
+    }
+  }
+}
+
+fn test3 (x : t2)
+  requires foo x
+  ensures  foo x
+{
+  norewrite let C y z = x;
+  ();
+}
+
+(* should work, or at least not crash *)
+[@@expect_failure]
+fn test4 (x : t2)
+  requires foo x
+  ensures  foo x
+{
+  let C y z = x;
+  ();
+}

--- a/test/nolib/NoRewrite.fst
+++ b/test/nolib/NoRewrite.fst
@@ -1,0 +1,49 @@
+module NoRewrite
+
+#lang-pulse
+open Pulse.Nolib
+
+assume val foo : [@@@equate_strict]_:int -> slprop
+
+fn test1 (x : int)
+  requires foo x
+  ensures  foo x
+{
+  match x {
+    norewrite y -> {
+      assert foo x;
+      ();
+    }
+  }
+}
+
+fn test2 (x : int)
+  requires foo x
+  ensures  foo x
+{
+  match x {
+    y -> {
+      assert foo y;
+      rewrite each y as x; (* restore *)
+    }
+  }
+}
+
+assume val bar : [@@@equate_strict]_:option int -> slprop
+
+fn test3 (x : option int{Some? x})
+  requires bar x
+  ensures  bar x
+{
+  let Some xx = x;
+  assert (bar (Some xx));
+  rewrite each Some xx as x; (* restore *)
+}
+
+fn test4 (x : option int{Some? x})
+  requires bar x
+  ensures  bar x
+{
+  norewrite let Some xx = x;
+  assert (bar x);
+}


### PR DESCRIPTION
- allowing to avoid autorewrite in matches
- Make autorewrite work for let <pattern> = foo