### PR TITLE
Support type annotations on local functions.

### DIFF
--- a/test/LocalFnAnnot.fst
+++ b/test/LocalFnAnnot.fst
@@ -1,0 +1,13 @@
+module LocalFnAnnot
+open Pulse.Nolib
+#lang-pulse
+
+let t (p: slprop) = unit -> stt unit (requires p) (ensures fun _ -> emp)
+
+fn f (p: slprop) requires p {
+  fn g (q: slprop) (x: nat) : t (p ** q) = a {
+    drop_ p;
+    drop_ q;
+  };
+  g emp 42 ()
+}


### PR DESCRIPTION
```fstar
let t (p: slprop) = unit -> stt unit (requires p) (ensures fun _ -> emp)

fn f (p: slprop) requires p {
  fn g p : t p = a { drop_ p; };
  g p ()
}
```