### PR TITLE
Recognizing meta qualifiers more, allowing to instantiate a final argument

### DIFF
--- a/src/checker/Pulse.Checker.STApp.fst
+++ b/src/checker/Pulse.Checker.STApp.fst
@@ -216,8 +216,12 @@ let apply_impure_function
           let c = (canon_comp (open_comp_with comp_typ arg)) in
           (| t, c, d |)
         | _ ->
-          fail g (Some range)
-            "Expected an effectful application; got a pure term (could it be partially applied by mistake?)"
+          let open Pulse.PP in
+          fail_doc g (Some range) [
+            text "Expected an effectful application, got a pure term.";
+            pp comp_typ;
+            text "Could it be partially applied by mistake?"
+          ]
       in
       let (| st', c', st_typing' |) = match_comp_res_with_post_hint d post_hint in
       debug_log g (fun _ -> T.print (Printf.sprintf "st_app: c' = %s\n\tallow_ambiguous = %s\n"

--- a/src/checker/Pulse.Checker.STApp.fst
+++ b/src/checker/Pulse.Checker.STApp.fst
@@ -120,8 +120,8 @@ let compatible_qual (actual expected : option qualifier) : bool =
   match actual, expected with
   | None, None -> true
   | Some Implicit, Some Implicit
-  | Some TcArg, Some Implicit
-  | Some (Meta _), Some Implicit -> true
+  | Some Implicit, Some TcArg
+  | Some Implicit, Some (Meta _) -> true
   | _ -> false
 
 #push-options "--z3rlimit_factor 4 --fuel 1 --ifuel 1"

--- a/src/checker/Pulse.Show.fst
+++ b/src/checker/Pulse.Show.fst
@@ -16,7 +16,7 @@
 
 module Pulse.Show
 
-open FStar.Tactics
+open FStar.Tactics.V2
 open FStar.Tactics.Typeclasses
 open Pulse.Typing
 open Pulse.Syntax.Base
@@ -54,6 +54,13 @@ instance tac_showable_ctag : tac_showable ctag = {
 instance tac_showable_term : tac_showable term = {
   show = term_to_string;
 }
+instance tac_showable_aqualv : tac_showable aqualv = {
+  show = function
+         | Q_Explicit -> "Q_Explicit"
+         | Q_Implicit -> "Q_Implicit"
+         | Q_Meta t -> "Q_Meta " ^ show t
+         | Q_Equality -> "Q_Equality"
+}
 instance tac_showable_st_term : tac_showable st_term = {
   show = st_term_to_string;
 }
@@ -83,12 +90,8 @@ instance tac_showable_post_hint_t : tac_showable post_hint_t = {
       "post = " ^ show h.post ^ "; " ^
     "}")
 }
-instance tac_showable_namedv : tac_showable namedv = {
+instance tac_showable_namedv : tac_showable Reflection.namedv = {
   show = (fun b -> namedv_to_string b);
-}
-
-instance tac_showable_r_term : tac_showable Reflection.term = {
-  show = Tactics.term_to_string;
 }
 
 instance tac_showable_range : tac_showable Range.range = {
@@ -117,4 +120,15 @@ instance tac_showable_tuple6 (a b c d e f : Type) (_ : tac_showable a) (_ : tac_
 
 instance tac_showable_tuple7 (a b c d e f g : Type) (_ : tac_showable a) (_ : tac_showable b) (_ : tac_showable c) (_ : tac_showable d) (_ : tac_showable e) (_ : tac_showable f) (_ : tac_showable g) : tac_showable (a & b & c & d & e & f & g) = {
   show = (fun (x, y, z, w, v, u, t) -> "(" ^ show x ^ ", " ^ show y ^ ", " ^ show z ^ ", " ^ show w ^ ", " ^ show v ^ ", " ^ show u ^ ", " ^ show t ^ ")");
+}
+
+instance tac_showable_tot_or_ghost : tac_showable tot_or_ghost = {
+  show = (fun e -> tot_or_ghost_to_string e);
+}
+
+instance tac_showable_qualifier : tac_showable qualifier = {
+  show = function
+         | Implicit -> "Implicit"
+         | TcArg -> "TcArg"
+         | Meta t -> "Meta " ^ show t
 }

--- a/src/checker/Pulse.Show.fsti
+++ b/src/checker/Pulse.Show.fsti
@@ -16,7 +16,8 @@
 
 module Pulse.Show
 
-open FStar.Tactics
+open FStar.Tactics.V2
+open FStar.Tactics.NamedView
 open Pulse.Typing
 open Pulse.Syntax.Base
 
@@ -36,6 +37,7 @@ instance val tac_showable_list (a:Type) (_ : tac_showable a)
   
 instance val tac_showable_ctag : tac_showable ctag
 instance val tac_showable_term : tac_showable term
+instance val tac_showable_aqualv : tac_showable aqualv
 instance val tac_showable_st_term : tac_showable st_term
 instance val tac_showable_universe : tac_showable universe
 instance val tac_showable_comp : tac_showable comp
@@ -43,9 +45,8 @@ instance val tac_showable_env : tac_showable env
 instance val tac_showable_observability : tac_showable observability
 instance val tac_showable_effect_annot : tac_showable effect_annot
 instance val tac_showable_post_hint_t : tac_showable post_hint_t
-instance val tac_showable_namedv : tac_showable namedv
+instance val tac_showable_namedv : tac_showable Reflection.namedv
 
-instance val tac_showable_r_term : tac_showable Reflection.term
 instance val tac_showable_range  : tac_showable Range.range
 
 instance val tac_showable_tuple2 (a b : Type) (_:tac_showable a) (_:tac_showable b) : tac_showable (a & b)
@@ -54,3 +55,6 @@ instance val tac_showable_tuple4 (a b c d : Type) (_:tac_showable a) (_:tac_show
 instance val tac_showable_tuple5 (a b c d e : Type) (_:tac_showable a) (_:tac_showable b) (_:tac_showable c) (_:tac_showable d) (_:tac_showable e) : tac_showable (a & b & c & d & e)
 instance val tac_showable_tuple6 (a b c d e f : Type) (_:tac_showable a) (_:tac_showable b) (_:tac_showable c) (_:tac_showable d) (_:tac_showable e) (_:tac_showable f) : tac_showable (a & b & c & d & e & f)
 instance val tac_showable_tuple7 (a b c d e f g : Type) (_:tac_showable a) (_:tac_showable b) (_:tac_showable c) (_:tac_showable d) (_:tac_showable e) (_:tac_showable f) (_:tac_showable g) : tac_showable (a & b & c & d & e & f & g)
+
+instance val tac_showable_tot_or_ghost : tac_showable tot_or_ghost
+instance val tac_showable_qualifier    : tac_showable qualifier

--- a/src/checker/Pulse.Syntax.Pure.fst
+++ b/src/checker/Pulse.Syntax.Pure.fst
@@ -144,6 +144,7 @@ let is_fvar (t:term) : option (R.name & list universe) =
 
 let readback_qual = function
   | R.Q_Implicit -> Some Implicit
+  | R.Q_Meta t -> Some (Meta t)
   | _ -> None
 
 let is_pure_app (t:term) : option (term & option qualifier & term) =
@@ -176,7 +177,6 @@ let is_arrow (t:term) : option (binder & option qualifier & comp) =
   | R.Tv_Arrow b c ->
     let {ppname;qual;sort} = R.inspect_binder b in
     begin match qual with
-          | R.Q_Meta _ -> None
           | _ ->
             let q = readback_qual qual in
             let c_view = R.inspect_comp c in

--- a/test/nolib/Implicits.fst
+++ b/test/nolib/Implicits.fst
@@ -1,0 +1,41 @@
+module Implicits
+
+#lang-pulse
+open Pulse.Nolib
+
+class deq (a:Type) = {
+  (=?) : a -> a -> bool;
+}
+
+instance deq_int : deq int = {
+  (=?) = (fun x y -> x = y);
+}
+
+fn foo1 (a:Type0) {| deq a |}
+{ () }
+
+fn foo2 (#a:Type0) {| deq a |}
+{ () }
+
+fn foo3 (#a:Type0) {| deq a |} (x:a)
+{ () }
+
+fn foo4 (#a:Type0) (x:a) {| deq a |}
+{ () }
+
+fn foo5 (x:int) (#_:unit)
+{ () }
+
+(* Would be nice if everything here worked. *)
+fn test () {
+  // foo5 1; (* can't resolve the unit *)
+  // foo1 int; (* pulse claims partially applied *)
+  foo1 int #deq_int;
+  foo1 int #_;
+  // foo2 #int; (* pulse claims partially applied *)
+  foo2 #int #_;
+  foo3 123;
+  // foo4 123; (* pulse claims partially applied *)
+  foo4 123 #_;
+  ();
+}


### PR DESCRIPTION
We're still not automatically instantiating meta args (including typeclass) at the end of an STApp. See the added test for some calls that fail, but would be nice to have.