### PR TITLE
Removing uses of internal ref/array allocs, use box/vec instead

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.Box.fst
+++ b/lib/pulse/lib/Pulse.Lib.Box.fst
@@ -29,6 +29,10 @@ let pts_to b #p v = R.pts_to b.r #p v
 
 let pts_to_timeless _ _ _ = ()
 
+(* This function is extracted primitively. The implementation
+below is only a model, and uses the internal Ref.alloc. Hence
+we disable the warning about using Ref.alloc. *)
+#push-options "--warn_error -288"
 fn alloc (#a:Type0) (x:a)
   requires emp
   returns  b : box a
@@ -38,6 +42,7 @@ fn alloc (#a:Type0) (x:a)
   rewrite R.pts_to r x as pts_to (B r) x;
   (B r);
 }
+#pop-options
 
 fn op_Bang (#a:Type0) (b:box a) (#v:erased a) (#p:perm)
   requires pts_to b #p v
@@ -61,7 +66,10 @@ fn op_Colon_Equals (#a:Type0) (b:box a) (x:a) (#v:erased a)
 
 #lang-fstar // 'rewrite' below is not the keyword!
 
+(* Same comment as for alloc. *)
+#push-options "--warn_error -288"
 let free b #v = R.free b.r #v
+#pop-options
 
 let share b = R.share b.r
 let gather b = R.gather b.r

--- a/lib/pulse/lib/Pulse.Lib.Vec.fst
+++ b/lib/pulse/lib/Pulse.Lib.Vec.fst
@@ -21,7 +21,7 @@ open Pulse.Lib.Core
 open Pulse.Lib.Pervasives
 
 module R = Pulse.Lib.Reference
-module A = Pulse.Lib.Array.Core
+module A = Pulse.Lib.Array
 
 type vec a = A.array a
 let length v = A.length v
@@ -123,3 +123,26 @@ fn replace_i_ref (#a:Type0) (r:R.ref (vec a)) (i:SZ.t) (x:a)
   y
 }
 
+
+fn compare
+        (#t:eqtype)
+        (l:SZ.t)
+        (a1 a2:lvec t (SZ.v l))
+        (#p1 #p2:perm)
+        (#s1 #s2:Ghost.erased (Seq.seq t))
+  requires
+     pts_to a1 #p1 s1 **
+     pts_to a2 #p2 s2
+  returns res : bool
+  ensures
+     pts_to a1 #p1 s1 **
+     pts_to a2 #p2 s2 **
+     pure (res <==> Seq.equal s1 s2)
+{
+  unfold (pts_to a1 #p1 s1);
+  unfold (pts_to a2 #p2 s2);
+  let r = A.compare l a1 a2;
+  fold (pts_to a1 #p1 s1);
+  fold (pts_to a2 #p2 s2);
+  r
+}

--- a/lib/pulse/lib/Pulse.Lib.Vec.fst
+++ b/lib/pulse/lib/Pulse.Lib.Vec.fst
@@ -29,10 +29,19 @@ let is_full_vec v = A.is_full_array v
 let pts_to v #p s = A.pts_to v #p s
 let pts_to_timeless _ _ _ = ()
 let pts_to_len v = A.pts_to_len v
+
+(* This function is extracted primitively. The implementation
+below is only a model, and uses the internal Ref.alloc. Hence
+we disable the warning about using Array.alloc. *)
+#push-options "--warn_error -288"
 let alloc x n = A.alloc x n
+#pop-options
 let op_Array_Access v i #p #s = A.op_Array_Access v i #p #s
 let op_Array_Assignment v i x #s = A.op_Array_Assignment v i x #s
+(* Same comment as above *)
+#push-options "--warn_error -288"
 let free v #s = A.free v #s
+#pop-options
 let share v = A.share v
 let gather v = A.gather v
 

--- a/lib/pulse/lib/Pulse.Lib.Vec.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Vec.fsti
@@ -154,3 +154,18 @@ fn replace_i_ref (#a:Type0) (r:R.ref (vec a)) (i:SZ.t) (x:a)
   requires R.pts_to r v ** pts_to v s
   returns  res : a
   ensures R.pts_to r v ** pts_to v (Seq.upd s (SZ.v i) x) ** pure (res == Seq.index s (SZ.v i))
+
+fn compare
+        (#t:eqtype)
+        (l:SZ.t)
+        (a1 a2:lvec t (SZ.v l))
+        (#p1 #p2:perm)
+        (#s1 #s2:Ghost.erased (Seq.seq t))
+  requires
+     pts_to a1 #p1 s1 **
+     pts_to a2 #p2 s2
+  returns res : bool
+  ensures
+     pts_to a1 #p1 s1 **
+     pts_to a2 #p2 s2 **
+     pure (res <==> Seq.equal s1 s2)

--- a/share/pulse/examples/GhostStateMachine.fst
+++ b/share/pulse/examples/GhostStateMachine.fst
@@ -16,9 +16,11 @@
 
 module GhostStateMachine
 #lang-pulse
-open Pulse.Lib.Pervasives
-open Pulse.Lib.Reference
+open Pulse
+open Pulse.Lib
+
 open Pulse.Lib.SpinLock
+open Pulse.Lib.Box { box, (:=), (!) }
 
 module R = Pulse.Lib.Reference
 
@@ -56,9 +58,9 @@ type st_t =
   | CNext : payload_t -> st_t
   | CFinal : payload_t -> st_t
 
-type pure_handle_t = ref pure_st_t
+type pure_handle_t = box pure_st_t
 
-type handle_t = ref st_t
+type handle_t = box st_t
 
 let pure_handle_has_state (h:pure_handle_t) (s:pure_st_t) : slprop = pts_to h #0.5R s
 
@@ -100,10 +102,10 @@ fn init ()
   returns st:locked_state_t
   ensures pure_handle_has_state st.ph Init ** lock_alive st.lk #1.0R (lock_inv st.h st.ph)
 {
-  let ph = alloc Init;
-  let h = alloc CInit;
+  let ph = Box.alloc Init;
+  let h = Box.alloc CInit;
 
-  R.share #pure_st_t ph #Init;
+  Box.share #pure_st_t ph #Init;
   fold pure_handle_has_state ph Init;
   fold pure_handle_has_state ph Init;
   fold handle_has_state h CInit;
@@ -143,16 +145,16 @@ fn next ()
   unfold pure_handle_has_state global_locked_state.ph Init;
   unfold pure_handle_has_state global_locked_state.ph ps;
 
-  pts_to_injective_eq #pure_st_t #0.5R #0.5R #Init #ps global_locked_state.ph;
+  Box.pts_to_injective_eq #pure_st_t #0.5R #0.5R #Init #ps global_locked_state.ph;
   rewrite (pts_to global_locked_state.ph #0.5R ps)
        as (pts_to global_locked_state.ph #0.5R Init);
-  Pulse.Lib.Reference.gather #pure_st_t global_locked_state.ph #Init;
+  Box.gather #pure_st_t global_locked_state.ph #Init;
 
   let st = CNext some_payload;
   global_locked_state.h := st;
   global_locked_state.ph := Next;
 
-  R.share #pure_st_t global_locked_state.ph #Next;
+  Box.share #pure_st_t global_locked_state.ph #Next;
   fold pure_handle_has_state global_locked_state.ph Next;
   fold pure_handle_has_state global_locked_state.ph Next;
   fold handle_has_state global_locked_state.h st;
@@ -181,16 +183,16 @@ fn close ()
   unfold pure_handle_has_state global_locked_state.ph Next;
   unfold pure_handle_has_state global_locked_state.ph ps;
 
-  pts_to_injective_eq #pure_st_t #0.5R #0.5R #Next #ps global_locked_state.ph;
+  Box.pts_to_injective_eq #pure_st_t #0.5R #0.5R #Next #ps global_locked_state.ph;
   rewrite (pts_to global_locked_state.ph #0.5R ps)
        as (pts_to global_locked_state.ph #0.5R Next);
-  Pulse.Lib.Reference.gather #pure_st_t global_locked_state.ph #Next;
+  Box.gather #pure_st_t global_locked_state.ph #Next;
 
   let st = CFinal some_payload;
   global_locked_state.h := st;
   global_locked_state.ph := Final;
 
-  R.share #pure_st_t global_locked_state.ph #Final;
+  Box.share #pure_st_t global_locked_state.ph #Final;
   fold pure_handle_has_state global_locked_state.ph Final;
   fold pure_handle_has_state global_locked_state.ph Final;
   fold handle_has_state global_locked_state.h st;

--- a/share/pulse/examples/Invariant.fst
+++ b/share/pulse/examples/Invariant.fst
@@ -18,6 +18,8 @@ module Invariant
 
 #lang-pulse
 open Pulse
+open Pulse.Lib
+open Pulse.Lib.Box { box, (:=), (!) }
 
 assume val p : slprop
 assume val q : slprop
@@ -83,12 +85,12 @@ let test (i:iname) = assert (
 )
 
 assume
-val atomic_write_int (r : ref int) (v : int) :
+val atomic_write_int (r : box int) (v : int) :
   stt_atomic unit emp_inames (exists* v0. pts_to r v0) (fun _ -> pts_to r v)
 
 
 atomic
-fn test_atomic (r : ref int)
+fn test_atomic (r : box int)
   requires pts_to r 'v
   ensures pts_to r 0
 {
@@ -112,8 +114,8 @@ fn test2 ()
   requires emp
   ensures emp
 {
-  let r = alloc #int 0;
-  let i = new_invariant (exists* v. pts_to r v);
+  let r = Box.alloc #int 0;
+  let i = new_invariant (exists* v. Box.pts_to r v);
   with_invariants i
     returns _:unit
     ensures later (exists* v. pts_to r v)

--- a/share/pulse/examples/ZetaHashAccumulator.fst
+++ b/share/pulse/examples/ZetaHashAccumulator.fst
@@ -43,11 +43,15 @@ open Pulse.Lib.Pervasives
 module U32 = FStar.UInt32
 module U8 = FStar.UInt8
 module SZ = FStar.SizeT
-module A = Pulse.Lib.Array
+module V = Pulse.Lib.Vec
 module U64 = FStar.UInt64
 module Cast = FStar.Int.Cast
 open Pulse.Lib.BoundedIntegers
-#push-options "--fuel 0 --ifuel 0"
+module B = Pulse.Lib.Box
+open Pulse.Lib.Box { box, (:=), (!) }
+open Pulse.Lib.Vec { op_Array_Access, op_Array_Assignment }
+
+#push-options "--fuel 0 --ifuel 0 --warn_error @288"
 
 (**********************************************************)
 (* Pure specification *) 
@@ -131,11 +135,11 @@ let aggregate_hashes (h0 h1: hash_value_t)
 assume
 val blake2b:
      nn:SZ.t{1 ≤ SZ.v nn ∧ SZ.v nn ≤ 64}
-  -> output: A.array U8.t { A.length output == SZ.v nn}
+  -> output: V.vec U8.t { V.length output == SZ.v nn}
   -> ll: SZ.t { SZ.v ll <= blake2_max_input_length}
-  -> d:A.array U8.t { SZ.v ll ≤ A.length d}
+  -> d:V.vec U8.t { SZ.v ll ≤ V.length d}
   -> kk: SZ.t { kk == 0sz }                        //We do not use blake2 in keyed mode
-  -> _dummy: A.array U8.t // this really should be a NULL, but krml doesn't extract Steel's null pointers yet
+  -> _dummy: V.vec U8.t // this really should be a NULL, but krml doesn't extract Steel's null pointers yet
   -> #sout:Ghost.erased (Seq.seq U8.t)
   -> #p:perm
   -> #sd:Ghost.erased (Seq.seq U8.t) { Seq.length sd == SZ.v ll}
@@ -149,10 +153,10 @@ val blake2b:
 (* Pulse *)
 
 // A buffer with the input to be hashed
-let hashable_buffer = b:A.array U8.t { A.length b ≤ blake2_max_input_length }
+let hashable_buffer = b:V.vec U8.t { V.length b ≤ blake2_max_input_length }
 
 // A buffer holding the raw hash value
-let hash_value_buf  = x:A.array U8.t { A.length x == 32 ∧ A.is_full_array x }
+let hash_value_buf  = x:V.vec U8.t { V.length x == 32 ∧ V.is_full_vec x }
 
 // The main data structure: ha_core
 // This contains a buffer with the raw hash value
@@ -160,7 +164,7 @@ let hash_value_buf  = x:A.array U8.t { A.length x == 32 ∧ A.is_full_array x }
 noeq
 type ha_core = {
   acc: hash_value_buf;
-  ctr: ref U32.t;
+  ctr: box U32.t;
 }
 
 // The representation predicate for ha_core ties it to a hash_value_t
@@ -171,7 +175,7 @@ type ha_core = {
 // the counter hasn't overflowed yet.
 let ha_val_core ([@@@mkey] core:ha_core) (h:hash_value_t) 
   : slprop
-  = A.pts_to core.acc (fst h) **
+  = V.pts_to core.acc (fst h) **
     (exists* (n:U32.t).
       pure (U32.v n == snd h) **
       pts_to core.ctr n)
@@ -183,7 +187,7 @@ let ha_val_core ([@@@mkey] core:ha_core) (h:hash_value_t)
 ghost
 fn fold_ha_val_core (#acc:Seq.lseq U8.t 32) (h:ha_core)
   requires
-   A.pts_to h.acc acc **
+   V.pts_to h.acc acc **
    pts_to h.ctr 'n
   ensures
    ha_val_core h (acc, U32.v 'n)
@@ -195,8 +199,8 @@ fn fold_ha_val_core (#acc:Seq.lseq U8.t 32) (h:ha_core)
 // This too is a bit of boilerplate. It use fold_ha_val_core, but also 
 // creates and returns a new ha_core value
 
-fn package_core (#vacc:erased (Seq.lseq U8.t 32)) (acc:hash_value_buf) (ctr:ref U32.t)
-  requires A.pts_to acc vacc **
+fn package_core (#vacc:erased (Seq.lseq U8.t 32)) (acc:hash_value_buf) (ctr:box U32.t)
+  requires V.pts_to acc vacc **
            pts_to ctr 'vctr 
   returns h:ha_core
   ensures ha_val_core h (reveal vacc, U32.v 'vctr) **
@@ -211,7 +215,7 @@ fn package_core (#vacc:erased (Seq.lseq U8.t 32)) (acc:hash_value_buf) (ctr:ref 
 
 // A quirk of the Blake spec is that we need a dummy buffer to pass to it
 // which could contain a key, but we're not using it in keyed mode
-let dummy_buf = x:A.larray U8.t 1 { A.is_full_array x }
+let dummy_buf = x:V.lvec U8.t 1 { V.is_full_vec x }
 
 // The full structure holds a core hash value, but also a temporary buffer
 // into which to hash new values, and the dummy buffer
@@ -227,8 +231,8 @@ type ha = {
 // A representation predicate for ha, encapsulating an ha_val_core
 let ha_val ([@@@mkey] h : ha) (s:hash_value_t) =
   ha_val_core h.core s **
-  (exists* (s:Seq.seq U8.t). A.pts_to h.tmp s ** pure (Seq.length s == 32)) **
-  A.pts_to h.dummy (Seq.create 1 0uy)
+  (exists* (s:Seq.seq U8.t). V.pts_to h.tmp s ** pure (Seq.length s == 32)) **
+  V.pts_to h.dummy (Seq.create 1 0uy)
 
 // A ghost function to package up a ha_val predicate
 // If we were generating this automatically and inserting folds also in the prover,
@@ -238,10 +242,10 @@ let ha_val ([@@@mkey] h : ha) (s:hash_value_t) =
 ghost
 fn fold_ha_val (#acc #s:Seq.lseq U8.t 32) (h:ha)
   requires
-   A.pts_to h.core.acc acc **
+   V.pts_to h.core.acc acc **
    pts_to h.core.ctr 'n **
-   A.pts_to h.tmp s **
-   A.pts_to h.dummy (Seq.create 1 0uy)
+   V.pts_to h.tmp s **
+   V.pts_to h.dummy (Seq.create 1 0uy)
   ensures
    ha_val h (acc, U32.v 'n)
 {
@@ -257,11 +261,11 @@ fn fold_ha_val (#acc #s:Seq.lseq U8.t 32) (h:ha)
 fn package
   (#vacc:erased (Seq.lseq U8.t 32))
   (#vtmp:erased (Seq.lseq U8.t 32))
-  (acc:hash_value_buf) (ctr:ref U32.t) (tmp:hash_value_buf) (dummy:dummy_buf)
-  requires A.pts_to acc vacc **
+  (acc:hash_value_buf) (ctr:box U32.t) (tmp:hash_value_buf) (dummy:dummy_buf)
+  requires V.pts_to acc vacc **
            pts_to ctr 'vctr **
-           A.pts_to tmp vtmp **
-           A.pts_to dummy (Seq.create 1 0uy)
+           V.pts_to tmp vtmp **
+           V.pts_to dummy (Seq.create 1 0uy)
   returns h:ha
   ensures ha_val h (reveal vacc, U32.v 'vctr) **
           pure (h == { core={acc;ctr}; tmp; dummy })
@@ -284,10 +288,10 @@ fn create ()
     returns h:ha
     ensures ha_val h initial_hash
 {  
-    let acc = A.alloc 0uy 32sz;
-    let ctr = alloc 0ul;
-    let tmp = A.alloc 0uy 32sz;
-    let dummy = A.alloc 0uy 1sz;
+    let acc = V.alloc 0uy 32sz;
+    let ctr = B.alloc 0ul;
+    let tmp = V.alloc 0uy 32sz;
+    let dummy = V.alloc 0uy 1sz;
     package acc ctr tmp dummy
 }
 
@@ -301,14 +305,11 @@ fn reclaim (#h:hash_value_t) (s:ha)
 {
     unfold ha_val;
     unfold ha_val_core;
-    free s.core.ctr;
-    A.free s.core.acc;
-    A.free s.tmp;
-    A.free s.dummy
+    B.free s.core.ctr;
+    V.free s.core.acc;
+    V.free s.tmp;
+    V.free s.dummy
 }
-
-
-
 
 // Aggregating two raw hashes XOR's them byte-by-byte
 // Compared to the version in Zeta.Steel, this is significantly cleaner
@@ -327,11 +328,11 @@ fn reclaim (#h:hash_value_t) (s:ha)
 fn aggregate_raw_hashes (#s1 #s2:e_raw_hash_value_t)
                         (b1 b2: hash_value_buf)
   requires 
-    A.pts_to b1 s1 **
-    A.pts_to b2 s2
+    V.pts_to b1 s1 **
+    V.pts_to b2 s2
   ensures
-    A.pts_to b1 (xor_bytes s1 s2) **
-    A.pts_to b2 s2
+    V.pts_to b1 (xor_bytes s1 s2) **
+    V.pts_to b2 s2
 {
     let mut i = 0sz;
     assert (pure (s1 `Seq.equal` xor_bytes_pfx s1 s2 0));
@@ -339,14 +340,15 @@ fn aggregate_raw_hashes (#s1 #s2:e_raw_hash_value_t)
     invariant b.
         exists* wi.
             pts_to i wi **
-            A.pts_to b1 (xor_bytes_pfx s1 s2 (v wi)) **
-            A.pts_to b2 s2 **
+            V.pts_to b1 (xor_bytes_pfx s1 s2 (v wi)) **
+            V.pts_to b2 s2 **
             pure (b == (wi < 32sz))
     {
       let x1 = b1.(i);
       let x2 = b2.(i);
       b1.(i) <- U8.logxor x1 x2;
       extend_hash_value s1 s2 (v i);
+      open Pulse.Lib.Reference;
       i := i + 1sz;
     };
     assert (pure (xor_bytes_pfx s1 s2 32 `Seq.equal` xor_bytes s1 s2))
@@ -413,7 +415,7 @@ fn compare (b1 b2:ha)
   }
   else
   {
-    let res = A.compare 32sz b1.core.acc b2.core.acc;
+    let res = V.compare 32sz b1.core.acc b2.core.acc;
     fold_ha_val b1;
     fold_ha_val b2;
     res
@@ -434,15 +436,15 @@ fn add (ha:ha) (input:hashable_buffer) (l:(l:SZ.t {SZ.v l <= blake2_max_input_le
        (#p:perm)
   requires
     ha_val ha 'h **
-    A.pts_to input #p s
+    V.pts_to input #p s
   returns ok:bool
   ensures
     ha_val ha (if ok then aggregate_hashes 'h (hash_one_value (Seq.slice s 0 (SZ.v l))) else 'h) **
-    A.pts_to input #p s
+    V.pts_to input #p s
 { 
-   let mut ctr = 1ul;
+   let ctr = B.alloc 1ul;
    unfold ha_val;
-   A.pts_to_len input;
+   V.pts_to_len input;
    blake2b 32sz ha.tmp l input 0sz ha.dummy;
    let ha' = package_core ha.tmp ctr;
    let v = aggregate ha.core ha';
@@ -451,6 +453,7 @@ fn add (ha:ha) (input:hashable_buffer) (l:(l:SZ.t {SZ.v l <= blake2_max_input_le
    with w. unfold (ha_val_core ha.core w);
    fold_ha_val ha;
    rewrite each ha'.ctr as ctr;
+   B.free ctr;
    v
 }
 

--- a/test/Test.ReflikeClass.fst
+++ b/test/Test.ReflikeClass.fst
@@ -13,12 +13,15 @@ class reflike (vt:Type) (rt:Type) = {
   (:=) : r:rt -> v:vt -> #v0:erased vt -> stt unit (r |-> v0) (fun _ -> r |-> v);
 }
 
+(* Prevent warning about using alloc... this is just a test. *)
+#push-options "--warn_error -288"
 instance reflike_ref (a:Type) : reflike a (ref a) = {
   ( |-> ) = (fun r v -> Pulse.Lib.Reference.pts_to r v);
   alloc   = Pulse.Lib.Reference.alloc;
   ( ! )   = (fun r #v0 -> Pulse.Lib.Reference.op_Bang r #v0 #1.0R);
   ( := )  = (fun r v #v0 -> Pulse.Lib.Reference.op_Colon_Equals r v #v0);
 }
+#pop-options
 
 instance reflike_box (a:Type) : reflike a (Box.box a) = {
   ( |-> ) = (fun r v -> Pulse.Lib.Box.pts_to r v);

--- a/test/bug-reports/Records.fst
+++ b/test/bug-reports/Records.fst
@@ -17,15 +17,16 @@
 module Records
 #lang-pulse
 open Pulse.Lib.Pervasives
-module R = Pulse.Lib.Reference
 module U8 = FStar.UInt8
+module Box = Pulse.Lib.Box
+open Pulse.Lib.Box { box, (:=), (!) }
 
 (* test record mutation and permissions for records of byte refs *)
 
 noeq
 type rec2 = {
-  r1: R.ref U8.t;
-  r2: R.ref U8.t;
+  r1: box U8.t;
+  r2: box U8.t;
 }
 
 type rec_repr = {
@@ -35,8 +36,8 @@ type rec_repr = {
 
 let rec_perm (r:rec2) (v:rec_repr)
   : slprop
-  = R.pts_to r.r1 v.v1 **
-    R.pts_to r.r2 v.v2
+  = Box.pts_to r.r1 v.v1 **
+    Box.pts_to r.r2 v.v2
 
 
 // When defining a predicate like rec_perm relating 
@@ -49,8 +50,8 @@ let rec_perm (r:rec2) (v:rec_repr)
 ghost
 fn fold_rec_perm (r:rec2) (#v1 #v2:erased U8.t)
   requires
-    R.pts_to r.r1 v1 **
-    R.pts_to r.r2 v2
+    Box.pts_to r.r1 v1 **
+    Box.pts_to r.r2 v2
   ensures
     (rec_perm r {v1; v2})
 {
@@ -78,15 +79,15 @@ fn alloc_rec (v1 v2:U8.t)
   returns r:rec2
   ensures (rec_perm r {v1; v2})
 {
-  let r1 = alloc #U8.t v1;
-  let r2 = alloc #U8.t v2; 
+  let r1 = Box.alloc #U8.t v1;
+  let r2 = Box.alloc #U8.t v2; 
   let r = { r1; r2 };
   (* Unfortunately, these two rewrites are still needed
      to "rename" r1 and r2 as r.r1 and r.r2 *)
-  rewrite (R.pts_to r1 v1)
-      as  (R.pts_to r.r1 v1);
-  rewrite (R.pts_to r2 v2)
-      as  (R.pts_to r.r2 v2);
+  rewrite (Box.pts_to r1 v1)
+      as  (Box.pts_to r.r1 v1);
+  rewrite (Box.pts_to r2 v2)
+      as  (Box.pts_to r.r2 v2);
   fold_rec_perm r;
   r
 }
@@ -99,8 +100,8 @@ fn alloc_rec_alt (v1 v2:U8.t)
   returns r:rec2
   ensures (rec_perm r {v1; v2})
 {
-  let r1 = alloc v1;
-  let r2 = alloc v2; 
+  let r1 = Box.alloc v1;
+  let r2 = Box.alloc v2; 
   let r = { r1; r2 };
   rewrite each r1 as r.r1, r2 as r.r2;
   fold_rec_perm r;
@@ -115,12 +116,12 @@ fn alloc_rec_alt_alt (v1 v2:U8.t)
   returns r:rec2
   ensures (rec_perm r {v1; v2})
 {
-  let r1 = alloc v1;
-  let r2 = alloc v2; 
+  let r1 = Box.alloc v1;
+  let r2 = Box.alloc v2; 
   let r = { r1; r2 };
   with w1 w2.
     rewrite each r1 as r.r1, r2 as r.r2 in 
-      (R.pts_to r1 w1 ** R.pts_to r2 w2);
+      (Box.pts_to r1 w1 ** Box.pts_to r2 w2);
   fold_rec_perm r;
   r
 }
@@ -130,10 +131,10 @@ fn alloc_rec_alt_alt (v1 v2:U8.t)
 // helpers 
 
 
-fn get_witness (x:R.ref U8.t) (#y:Ghost.erased U8.t)
-requires R.pts_to x y
+fn get_witness (x:box U8.t) (#y:Ghost.erased U8.t)
+requires Box.pts_to x y
 returns z:Ghost.erased U8.t
-ensures R.pts_to x y ** pure (y==z)
+ensures Box.pts_to x y ** pure (y==z)
 {   
     y
 }
@@ -145,11 +146,11 @@ fn unfold_and_fold_manually (r:rec2) (#v:Ghost.erased rec_repr)
   ensures exists* (v_:rec_repr) . rec_perm r v_
 {
   rewrite (rec_perm r v)
-    as (R.pts_to r.r1 v.v1 **
-        R.pts_to r.r2 v.v2);
+    as (Box.pts_to r.r1 v.v1 **
+        Box.pts_to r.r2 v.v2);
 
-  rewrite (R.pts_to r.r1 v.v1 **
-           R.pts_to r.r2 v.v2)
+  rewrite (Box.pts_to r.r1 v.v1 **
+           Box.pts_to r.r2 v.v2)
     as (rec_perm r v);
   
   ()
@@ -162,14 +163,14 @@ fn explicit_unfold_witness_taking_and_fold (r:rec2) (#v:Ghost.erased rec_repr)
   ensures exists* (v_:rec_repr) . rec_perm r v_
 {
   rewrite (rec_perm r v)
-    as (R.pts_to r.r1 v.v1 **
-        R.pts_to r.r2 v.v2);
+    as (Box.pts_to r.r1 v.v1 **
+        Box.pts_to r.r2 v.v2);
 
   r.r2 := 0uy;
   let v2 = get_witness(r.r2);
 
-  rewrite (R.pts_to r.r1 v.v1 **
-           R.pts_to r.r2 v2)
+  rewrite (Box.pts_to r.r1 v.v1 **
+           Box.pts_to r.r2 v2)
     as    (rec_perm r {v with v2});
   ()
 }
@@ -181,13 +182,13 @@ fn explicit_unfold_slightly_better_witness_taking_and_fold (r:rec2) (#v:Ghost.er
   ensures exists* (v_:rec_repr) . rec_perm r v_
 {
   rewrite (rec_perm r v)
-    as (R.pts_to r.r1 v.v1 **
-        R.pts_to r.r2 v.v2);
+    as (Box.pts_to r.r1 v.v1 **
+        Box.pts_to r.r2 v.v2);
 
   r.r2 := 0uy;
   with v2. 
-   rewrite (R.pts_to r.r1 v.v1 **
-            R.pts_to r.r2 v2)
+   rewrite (Box.pts_to r.r1 v.v1 **
+            Box.pts_to r.r2 v2)
     as    (rec_perm r {v with v2});
 
   ()


### PR DESCRIPTION
This removes tons of warnings about Reference.alloc (and others) being deprecated. It mostly uniformly moves everything to boxes and vectors.