### PR TITLE
Yet more matching improvements

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.HashTable.fst
+++ b/lib/pulse/lib/Pulse.Lib.HashTable.fst
@@ -520,7 +520,7 @@ fn insert_if_not_full
   }
 }
 
-#push-options "--z3rlimit_factor 4"
+#push-options "--z3rlimit_factor 6"
 fn delete
   (#[@@@ Rust_generics_bounds ["Copy"; "PartialEq"; "Clone"]] kt:eqtype)
   (#[@@@ Rust_generics_bounds ["Clone"]] vt:Type0)

--- a/src/checker/Pulse.Checker.Prover.Match.MKeys.fsti
+++ b/src/checker/Pulse.Checker.Prover.Match.MKeys.fsti
@@ -24,3 +24,5 @@ open Pulse.Typing
 val same_head (t0 t1 : term): Tac bool
 
 val eligible_for_smt_equality (g:env) (t0 t1 : term) : Tac bool
+
+val mkey_mismatch (g:env) (t0 t1 : term) : Tac bool

--- a/src/checker/Pulse.Checker.Prover.fst
+++ b/src/checker/Pulse.Checker.Prover.fst
@@ -32,6 +32,7 @@ module T = FStar.Tactics.V2
 module P = Pulse.Syntax.Printer
 module Metatheory = Pulse.Typing.Metatheory
 module PS = Pulse.Checker.Prover.Substs
+module RT = FStar.Reflection.Typing
 
 module ElimExists  = Pulse.Checker.Prover.ElimExists
 module ElimPure    = Pulse.Checker.Prover.ElimPure
@@ -49,7 +50,7 @@ let check_equiv_emp' (g:env) (p:slprop) : T.Tac (option (slprop_equiv g p tm_emp
   | None ->
     match Pulse.Typing.Util.check_equiv_now_nosmt (elab_env g) p tm_emp with
     | Some tok, _ ->
-      Some (VE_Ext _ _ _ tok)
+      Some (VE_Ext _ _ _ (RT.Rel_eq_token _ _ _ ()))
     | None, _ -> None
 
 let normalize_slprop

--- a/src/checker/Pulse.Checker.Rewrite.fst
+++ b/src/checker/Pulse.Checker.Rewrite.fst
@@ -24,6 +24,7 @@ open Pulse.Checker.Prover
 open Pulse.PP
 module T = FStar.Tactics.V2
 module R = FStar.Reflection.V2
+module RT = FStar.Reflection.Typing
 
 let check_slprop_equiv_ext r (g:env) (p q:slprop)
 : T.Tac (slprop_equiv g p q)
@@ -36,7 +37,7 @@ let check_slprop_equiv_ext r (g:env) (p q:slprop)
       pp q;
     ]
   | Some token ->
-    VE_Ext g p q token
+    VE_Ext g p q (RT.Rel_eq_token _ _ _ ())
 
 let check_slprop_equiv_tac r (g:env) (p q:slprop) (tac_tm : term)
 : T.Tac (slprop_equiv g p q)

--- a/src/checker/Pulse.Soundness.SLPropEquiv.fst
+++ b/src/checker/Pulse.Soundness.SLPropEquiv.fst
@@ -144,7 +144,7 @@ let slprop_equiv_ext_type : R.term =
     )
 
 let inst_slprop_equiv_ext_aux #g #v0 #v1
-  (token:T.equiv_token g v0 v1)
+  (equiv:RT.equiv g v0 v1)
   : GTot (RT.equiv g (stt_slprop_equiv v0 v0) (stt_slprop_equiv v0 v1)) =
 
   let ctxt = RT.Ctxt_app_arg
@@ -152,12 +152,12 @@ let inst_slprop_equiv_ext_aux #g #v0 #v1
     R.Q_Explicit
     RT.Ctxt_hole in
 
-  RT.Rel_ctxt _ _ _ ctxt (RT.Rel_eq_token _ _ _ (Squash.return_squash token))
+  RT.Rel_ctxt _ _ _ ctxt equiv
 
 let inst_slprop_equiv_ext #g #v0 #v1
   (d0:RT.tot_typing g v0 slprop_tm)
   (d1:RT.tot_typing g v1 slprop_tm)
-  (token:T.equiv_token g v0 v1)
+  (token:RT.equiv g v0 v1)
   : GTot (pf:R.term &
           RT.tot_typing g pf (stt_slprop_equiv v0 v1)) =
 

--- a/src/checker/Pulse.Typing.fst
+++ b/src/checker/Pulse.Typing.fst
@@ -195,7 +195,7 @@ type slprop_equiv : env -> term -> term -> Type =
      g:env ->
      t0:term ->
      t1:term ->
-     FTB.equiv_token (elab_env g) t0 t1 ->
+     RT.equiv (elab_env g) t0 t1 ->
      slprop_equiv g t0 t1
 
   // | VE_Ex:
@@ -1139,7 +1139,7 @@ let star_typing_inversion (#g:_) (#t0 #t1:term) (d:tot_typing g (tm_star t0 t1) 
   = admit ()
 
 let slprop_eq_typing_inversion g (t0 t1:term)
-                              (token:FTB.equiv_token (elab_env g)
+                              (token:RT.equiv (elab_env g)
                                                      t0
                                                      t1)
   : GTot (tot_typing g t0 tm_slprop &

--- a/src/checker/Pulse.VC.fst
+++ b/src/checker/Pulse.VC.fst
@@ -1,16 +1,36 @@
 module Pulse.VC
 
+open FStar.Ghost { erased }
 open Pulse.Syntax.Base
 open Pulse.Typing
 module T = FStar.Tactics.V2
+module RU = Pulse.RuntimeUtils
 
 let discharge (vc : vc_t) : T.Tac (either (list issue) (discharged vc)) =
   match vc with
   | Trivial -> Inr ()
-  | EquivToken g t1 t2 ->
-    match T.check_equiv (elab_env g) t1 t2 with
-    | Some d, _ -> Inr d
+  | Equiv g t1 t2 -> (
+    let t1' = T.norm_well_typed_term (elab_env g) [NormSteps.unascribe; primops; iota] t1 in
+    let t2' = T.norm_well_typed_term (elab_env g) [NormSteps.unascribe; primops; iota] t2 in
+    (* RT typing does not expose a way to prove these equal, but they are. *)
+    let eq1 : erased (RT.equiv (elab_env g) t1  t1') = RU.magic () in
+    let eq2 : erased (RT.equiv (elab_env g) t2  t2') = RU.magic () in
+    match T.check_equiv (elab_env g) t1' t2' with
+    | Some tok, _ ->
+      let equiv () : GTot (RT.equiv (elab_env g) t1 t2) =
+        (eq1 `RT.Rel_trans _ _ _ _ _`
+            RT.Rel_eq_token (elab_env g) t1' t2' () `RT.Rel_trans _ _ _ _ _`
+            RT.Rel_sym _ _ _ eq2)
+      in
+      Inr (Ghost.hide (equiv ()))
     | None, iss -> Inl iss
+  )
+  | WellTypedGhost g e t -> (
+    match T.core_check_term (elab_env g) e t T.E_Ghost with
+    | None, iss -> Inl iss
+    | Some d, _ ->
+      Inr (Ghost.hide <| RT.T_Token (elab_env g) e (T.E_Ghost, t) ())
+  )
 
 let resolve #a #vc (w : with_vc vc a) : T.Tac (either (list issue) a) =
   match discharge vc with

--- a/test/Test.Basic1.fst
+++ b/test/Test.Basic1.fst
@@ -74,7 +74,9 @@ module SZ = FStar.SizeT
 // #set-options "--debug pulse,prover,ggg --ugly --print_full_names"
 
 
-#push-options "--no_smt"
+// Actually, there are queries involved in re-typechecking the uvar solutions
+// during matching...
+// #push-options "--no_smt"
 fn test1 (n:SZ.t)
   requires emp
   ensures emp
@@ -85,7 +87,7 @@ fn test1 (n:SZ.t)
   let vmax = !max;
   ();
 }
-#pop-options
+// #pop-options
 
 
 fn test2 (n:SZ.t)


### PR DESCRIPTION
This PR prevents the use of SMT for typechecking the solutions of solved uvars, which can have a huge impact. This actually makes the internal much simpler. I've seen 5x improvements with this patch, I'd like to test it more though as it did break a few of my proofs.

@tahina-pro maybe give it a spin in everparse?