### PR TITLE
A missing include in PulseChecker.fst.config.json: to blame for slow …

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.DequeRef.fsti
+++ b/lib/pulse/lib/Pulse.Lib.DequeRef.fsti
@@ -1,6 +1,7 @@
 module Pulse.Lib.DequeRef
 #lang-pulse
 open Pulse.Lib.Pervasives
+open FStar.List.Tot
 
 val dq (t:Type0) : Type0
 

--- a/src/checker/PulseChecker.fst.config.json
+++ b/src/checker/PulseChecker.fst.config.json
@@ -8,5 +8,6 @@
     "4.13.3"
   ],
   "include_dirs": [
+    "--include", "../../build/checker.checked"
   ]
 }


### PR DESCRIPTION
…load times, plus address a deprecation warning