### PR TITLE
Add `rewrites_to` for `(!(!x))`

### DIFF
--- a/lib/common/Pulse.Lib.Core.fsti
+++ b/lib/common/Pulse.Lib.Core.fsti
@@ -1026,6 +1026,22 @@ let (@@) : inames -> inames -> inames = join_inames
 (* Attribute to eagerly unfold slprops in the context and goal. *)
 val pulse_unfold : unit
 
+let rewrites_to_p #t (x y: t) = (x == y)
+
+(*
+`rewrites_to x t` instructs the Pulse matcher to globally replace `x` by `t` before matching.
+(The first argument needs to be a variable.)
+
+This is used in read functions to rewrite the return value
+to the erased value, which makes nested dereferencing (!(!x)) work.
+
+fn ( ! ) #t (x: ref t) (y: erased t)
+  preserves x |-> y
+  returns result: t
+  ensures rewrites_to result y
+*)
+[@@pulse_unfold] let rewrites_to #t (x y: t) = pure (rewrites_to_p x y)
+
 [@@coercion; pulse_unfold; strict_on_arguments [0]; unfold_check_opens]
 let rec iname_list (xs : list iname) : inames =
   match xs with

--- a/lib/pulse/lib/Pulse.Lib.AVLTree.fst
+++ b/lib/pulse/lib/Pulse.Lib.AVLTree.fst
@@ -183,9 +183,7 @@ fn rec height (#t:Type0) (x:tree_t t)
     }
     Some vl -> {
       is_tree_case_some (Some vl) vl;
-      with gnode. assert vl |-> gnode;
       let node = !vl;
-      rewrite each gnode as node; (* unfortunate *)
       let l_height = height node.left;
       let r_height = height node.right;
       intro_is_tree_node x vl;
@@ -299,8 +297,6 @@ fn rec append_left (#t:Type0) (x:tree_t t) (v:t) (#ft:G.erased (T.tree t))
 
       let node = !vl;
 
-      rewrite each _node as node;
-
       let left_new = append_left node.left v;
 
       vl := {node with left = left_new};
@@ -351,8 +347,6 @@ fn rec append_right (#t:Type0) (x:tree_t t) (v:t) (#ft:G.erased (T.tree t))
       with _node _ltree _rtree._;
       
       let node = !np;
-      
-      rewrite each _node as node;
 
       let right_new = append_right node.right v;
       
@@ -381,11 +375,7 @@ fn node_data (#t:Type) (x:tree_t t) (#ft:G.erased (T.tree t))
       
   is_tree_case_some x np;
       
-  with _node _ltree _rtree._;
-      
   let node = !np;
-      
-  rewrite each _node as node;
 
   let v = node.data;
   
@@ -408,9 +398,7 @@ fn rec mem (#t:eqtype) (x:tree_t t) (v: t) (#ft:G.erased (T.tree t))
        }
        Some vl -> {
            is_tree_case_some (Some vl) vl;
-           with _node _ltree _rtree. _;
            let n = !vl;
-           rewrite each _node as n;
 
            let dat = n.data;
 
@@ -482,9 +470,7 @@ fn read_node
   rewrite each tree as (Some p);
   with node. assert p |-> node;
   let n = !p;
-  rewrite each node as n;
   rewrite p |-> n as Some?.v tree |-> n;
-  // rewrite each ltree as tree.left;
   (n.left, n.data, n.right, ())
 }
 
@@ -577,9 +563,7 @@ fn rec is_balanced (#t:Type0) (tree:tree_t t)
     }
     Some vl -> {
       is_tree_case_some (Some vl) vl;
-      with node. assert vl |-> node;
       let n = !vl;
-      rewrite each node as n;
 
       let height_l = height n.left;
       let height_r = height n.right;
@@ -625,9 +609,7 @@ fn rec  rebalance_avl (#t:Type0) (tree:tree_t t) (#l:G.erased(T.tree t))
       }
       else
       {
-        with node. assert vl |-> node;
         let n = !vl;
-        rewrite each node as n;
         let height_l = height n.left;
         let height_r = height n.right;
         
@@ -639,10 +621,7 @@ fn rec  rebalance_avl (#t:Type0) (tree:tree_t t) (#l:G.erased(T.tree t))
           intro_is_tree_node n.left vll;
           is_tree_case_some n.left vll;
          
-
-          with nodel. assert vll |-> nodel;
           let nl = !vll;
-          rewrite each nodel as nl;
 
           let height_ll = height nl.left;
           let height_lr = height nl.right;
@@ -678,9 +657,7 @@ fn rec  rebalance_avl (#t:Type0) (tree:tree_t t) (#l:G.erased(T.tree t))
           intro_is_tree_node n.right vlr;
           is_tree_case_some n.right vlr;
 
-          with noder. assert vlr |-> noder;
           let nr = !vlr;
-          rewrite each noder as nr;
 
           let height_rl = height nr.left;
           let height_rr = height nr.right;
@@ -748,7 +725,6 @@ fn rec insert_avl (#t:Type0) (cmp: T.cmp t) (tree:tree_t t) (key: t)
       is_tree_case_some (Some vl) vl;
       with node. assert vl |-> node;
       let n = !vl;
-      rewrite each node as n;
       let delta = cmp n.data key;
       if (delta >= 0)
       {
@@ -756,7 +732,7 @@ fn rec insert_avl (#t:Type0) (cmp: T.cmp t) (tree:tree_t t) (key: t)
         let vl' = {data = n.data; left = new_left; right = n.right};
         vl := vl';
         rewrite each new_left as vl'.left;
-        rewrite each n.right as vl'.right;
+        rewrite each node.right as vl'.right;
         intro_is_tree_node (Some vl) vl #vl';
         let new_tree = rebalance_avl (Some vl);
         new_tree
@@ -767,7 +743,7 @@ fn rec insert_avl (#t:Type0) (cmp: T.cmp t) (tree:tree_t t) (key: t)
         let vl' = {data = n.data; left = n.left; right = new_right };
         vl := vl';
         rewrite each new_right as vl'.right;
-        rewrite each n.left as vl'.left;
+        rewrite each node.left as vl'.left;
         intro_is_tree_node (Some vl) vl #vl';
         let new_tree = rebalance_avl (Some vl);
         new_tree
@@ -801,26 +777,17 @@ fn rec tree_max_c (#t:Type0) (tree:tree_t t) (#l:G.erased(T.tree t){T.Node? l})
     }
     Some vl -> {
       is_tree_case_some (Some vl) vl;
-      with node. assert vl |-> node;
       let n = !vl;
-      rewrite each node as n;
-      let right = n.right;
-      rewrite each n.right as right;
-      with rtree. assert (is_tree right rtree);
-      match right {
+      match n.right {
         None -> {
           let d = n.data;
-          assert (is_tree #t None rtree);
-          is_tree_case_none None;
-          rewrite is_tree None rtree as is_tree right rtree;
-          rewrite each right as n.right;
+          is_tree_case_none n.right;
           intro_is_tree_node tree vl;
           d
         }
         Some vlr -> {
-          is_tree_case_some1 (Some vlr) vlr;
-          let max = tree_max_c (Some vlr);
-          rewrite each Some vlr as n.right;
+          is_tree_case_some1 n.right vlr;
+          let max = tree_max_c n.right;
           intro_is_tree_node tree vl;
           max
         }
@@ -845,13 +812,12 @@ fn rec delete_avl (#t:Type0) (cmp: T.cmp t) (tree:tree_t t) (key: t)
       is_tree_case_some (Some vl) vl;
       with node. assert vl |-> node;
       let n = !vl;
-      rewrite each node as n;
       let delta = cmp n.data key;
       if (delta = 0) {
         let left = n.left;
         let right = n.right;
-        rewrite each n.left as left;
-        rewrite each n.right as right;
+        rewrite each node.left as left;
+        rewrite each node.right as right;
         //explicit ltree and rtree is needed, to find a proof for the existence of func ltree and rtree
         with ltree. assert is_tree left ltree;
         with rtree. assert is_tree right rtree;
@@ -871,9 +837,7 @@ fn rec delete_avl (#t:Type0) (cmp: T.cmp t) (tree:tree_t t) (key: t)
               }
               Some vlr -> {(*Leaf,Node_*)
                 is_tree_case_some (Some vlr) vlr;
-                with rnode'. assert vlr |-> rnode';
                 let rnode = !vlr;
-                rewrite each rnode' as rnode;
                 let vl' = {data = rnode.data; left = rnode.left; right = rnode.right};
                 vl := vl';
                 with ltree.
@@ -895,9 +859,7 @@ fn rec delete_avl (#t:Type0) (cmp: T.cmp t) (tree:tree_t t) (key: t)
               None -> {(*Node_,Leaf*)
                 is_tree_case_some (Some vll) vll;
                 is_tree_case_none None;
-                with node. assert vll |-> node;
                 let lnode = !vll;
-                rewrite each node as lnode;
                 let vl' = {data = lnode.data; left = lnode.left; right = lnode.right};
                 vl := vl';
                 with ltree.

--- a/lib/pulse/lib/Pulse.Lib.Array.Core.fst
+++ b/lib/pulse/lib/Pulse.Lib.Array.Core.fst
@@ -93,12 +93,9 @@ fn op_Array_Access
     (i: SZ.t)
     (#p: perm)
     (#s: Ghost.erased (Seq.seq t){SZ.v i < Seq.length s})
-requires
-  pts_to a #p s
-  returns res:t
-ensures 
-  pts_to a #p s **
-  pure (res == Seq.index s (SZ.v i))
+preserves pts_to a #p s
+returns res:t
+ensures rewrites_to res (Seq.index s (SZ.v i))
 {
   unfold (pts_to a #p s);
   let res = H.(a.(i));

--- a/lib/pulse/lib/Pulse.Lib.Array.Core.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Array.Core.fsti
@@ -67,9 +67,9 @@ fn alloc (#elt: Type) (x: elt) (n: SZ.t)
 fn op_Array_Access
   (#t: Type) (a: array t) (i: SZ.t)
   (#p: perm) (#s: erased (Seq.seq t){SZ.v i < Seq.length s})
-  requires pts_to a #p s
+  preserves pts_to a #p s
   returns  res : t
-  ensures  pts_to a #p s ** pure (res == Seq.index s (SZ.v i))
+  ensures  rewrites_to res (Seq.index s (SZ.v i))
 
 (* Written a.(i) <- v *)
 fn op_Array_Assignment

--- a/lib/pulse/lib/Pulse.Lib.BigGhostReference.fst
+++ b/lib/pulse/lib/Pulse.Lib.BigGhostReference.fst
@@ -63,9 +63,9 @@ let read_compat (#a:Type u#2) (x:fractional a)
 
 ghost
 fn read (#a:Type u#2) (r:ref a) (#n:erased a) (#p:perm)
-  requires pts_to r #p n
+  preserves pts_to r #p n
   returns x:erased a
-  ensures pts_to r #p n ** pure (n == x)
+  ensures rewrites_to x n
 {
   unfold pts_to r #p n;
   with w. assert (big_ghost_pcm_pts_to r w);

--- a/lib/pulse/lib/Pulse.Lib.BigGhostReference.fsti
+++ b/lib/pulse/lib/Pulse.Lib.BigGhostReference.fsti
@@ -41,16 +41,16 @@ fn alloc (#a:Type) (x:a)
   
 ghost
 fn read (#a:Type) (r:ref a) (#n:erased a) (#p:perm)
-  requires pts_to r #p n
+  preserves pts_to r #p n
   returns  x : erased a
-  ensures  pts_to r #p n ** pure (n == x)
+  ensures  rewrites_to x n
 
 (* = read *)
 ghost
 fn ( ! ) (#a:Type) (r:ref a) (#n:erased a) (#p:perm)
-  requires pts_to r #p n
+  preserves pts_to r #p n
   returns  x : erased a
-  ensures  pts_to r #p n ** pure (n == x)
+  ensures rewrites_to x n
 
 ghost
 fn write (#a:Type) (r:ref a) (x:erased a) (#n:erased a)

--- a/lib/pulse/lib/Pulse.Lib.BigReference.fst
+++ b/lib/pulse/lib/Pulse.Lib.BigReference.fst
@@ -47,9 +47,9 @@ let read_compat (#a:Type u#1) (x:fractional a)
 
 
 fn op_Bang (#a:Type u#2) (r:ref a) (#n:erased a) (#p:perm)
-  requires pts_to r #p n
+  preserves pts_to r #p n
   returns x:a
-  ensures pts_to r #p n ** pure (reveal n == x)
+  ensures rewrites_to x n
 {
   unfold pts_to r #p n;
   with w. assert (big_pcm_pts_to r w);

--- a/lib/pulse/lib/Pulse.Lib.BigReference.fsti
+++ b/lib/pulse/lib/Pulse.Lib.BigReference.fsti
@@ -38,9 +38,9 @@ fn alloc (#a:Type) (x:a)
   ensures  pts_to r x
 
 fn ( ! ) (#a:Type) (r:ref a) (#n:erased a) (#p:perm)
-  requires pts_to r #p n
+  preserves pts_to r #p n
   returns  x : a
-  ensures  pts_to r #p n ** pure (reveal n == x)
+  ensures rewrites_to x n
 
 fn ( := ) (#a:Type) (r:ref a) (x:a) (#n:erased a)
   requires pts_to r n

--- a/lib/pulse/lib/Pulse.Lib.Box.fst
+++ b/lib/pulse/lib/Pulse.Lib.Box.fst
@@ -51,9 +51,9 @@ fn alloc (#a:Type0) (x:a)
 #pop-options
 
 fn op_Bang (#a:Type0) (b:box a) (#v:erased a) (#p:perm)
-  requires pts_to b #p v
+  preserves pts_to b #p v
   returns  x : a
-  ensures  pts_to b #p v ** pure (reveal v == x)
+  ensures rewrites_to x v
 {
   unfold (pts_to b #p v);
   let x = R.(!b.r);

--- a/lib/pulse/lib/Pulse.Lib.Box.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Box.fsti
@@ -54,7 +54,7 @@ fn alloc (#a:Type0) (x:a)
 fn ( ! ) (#a:Type0) (b:box a) (#v:erased a) (#p:perm)
   preserves b |-> Frac p v
   returns  x : a
-  ensures  pure (eq2 #a (reveal v) x)
+  ensures  rewrites_to x (reveal v)
 
 fn ( := ) (#a:Type0) (b:box a) (x:a) (#v:erased a)
   requires b |-> v

--- a/lib/pulse/lib/Pulse.Lib.Deque.fst
+++ b/lib/pulse/lib/Pulse.Lib.Deque.fst
@@ -610,10 +610,9 @@ fn is_singleton
 
   with v. assert (pts_to headp v);
   let vv = Box.( !headp );
-  rewrite each v as vv;
 
   let nextp = vv.dnext;
-  rewrite each vv.dnext as nextp;
+  rewrite each v.dnext as nextp;
 
   match nextp {
   None -> {

--- a/lib/pulse/lib/Pulse.Lib.GhostReference.fst
+++ b/lib/pulse/lib/Pulse.Lib.GhostReference.fst
@@ -51,9 +51,9 @@ fn alloc (#a:Type u#0) (v:a)
 
 ghost
 fn read (#a:Type) (r:ref a) (#n:erased a) (#p:perm)
-  requires pts_to r #p n
+  preserves pts_to r #p n
   returns x:erased a
-  ensures pts_to r #p n ** pure (n == x)
+  ensures rewrites_to x n
 {
   unfold (pts_to r #p n);
   let k = H.( !r );

--- a/lib/pulse/lib/Pulse.Lib.GhostReference.fsti
+++ b/lib/pulse/lib/Pulse.Lib.GhostReference.fsti
@@ -53,14 +53,14 @@ ghost
 fn read (#a:Type) (r:ref a) (#n:erased a) (#p:perm)
   preserves r |-> Frac p n
   returns  x : erased a
-  ensures  pure (n == x)
+  ensures  rewrites_to x n
 
 (* alias for  read *)
 ghost
 fn ( ! ) (#a:Type) (r:ref a) (#n:erased a) (#p:perm)
   preserves r |-> Frac p n
   returns  x : erased a
-  ensures  pure (n == x)
+  ensures  rewrites_to x n
 
 ghost
 fn write (#a:Type) (r:ref a) (x:erased a) (#n:erased a)

--- a/lib/pulse/lib/Pulse.Lib.HigherGhostReference.fst
+++ b/lib/pulse/lib/Pulse.Lib.HigherGhostReference.fst
@@ -65,9 +65,9 @@ let read_compat (#a:Type u#1) (x:fractional a)
 
 ghost
 fn read (#a:Type u#1) (r:ref a) (#n:erased a) (#p:perm)
-  requires pts_to r #p n
+  preserves pts_to r #p n
   returns x:erased a
-  ensures pts_to r #p n ** pure (n == x)
+  ensures rewrites_to x n
 {
   unfold pts_to r #p n;
   with w. assert (ghost_pcm_pts_to r w);

--- a/lib/pulse/lib/Pulse.Lib.HigherGhostReference.fsti
+++ b/lib/pulse/lib/Pulse.Lib.HigherGhostReference.fsti
@@ -53,14 +53,14 @@ ghost
 fn read (#a:Type) (r:ref a) (#n:erased a) (#p:perm)
   preserves r |-> Frac p n
   returns  x : erased a
-  ensures  pure (n == x)
+  ensures  rewrites_to x n
 
 (* alias for read *)
 ghost
 fn ( ! ) (#a:Type) (r:ref a) (#n:erased a) (#p:perm)
   preserves pts_to r #p n
   returns  x : erased a
-  ensures  pure (n == x)
+  ensures  rewrites_to x n
 
 ghost
 fn write (#a:Type) (r:ref a) (x:erased a) (#n:erased a)

--- a/lib/pulse/lib/Pulse.Lib.HigherReference.fst
+++ b/lib/pulse/lib/Pulse.Lib.HigherReference.fst
@@ -56,7 +56,7 @@ let read_compat (#a:Type u#1) (x:fractional a)
 fn read (#a:Type u#1) (r:ref a) (#n:erased a) (#p:perm)
   preserves r |-> Frac p n
   returns  x : a
-  ensures  pure (n == x)
+  ensures  rewrites_to x n
 {
   unfold pts_to r #p n;
   with w. assert (pcm_pts_to r w);

--- a/lib/pulse/lib/Pulse.Lib.HigherReference.fsti
+++ b/lib/pulse/lib/Pulse.Lib.HigherReference.fsti
@@ -46,13 +46,13 @@ fn alloc (#a:Type) (x:a)
 fn read (#a:Type) (r:ref a) (#n:erased a) (#p:perm)
   preserves r |-> Frac p n
   returns  x : a
-  ensures  pure (n == x)
+  ensures  rewrites_to x n
 
 (* alias for read *)
 fn ( ! ) (#a:Type) (r:ref a) (#n:erased a) (#p:perm)
   preserves r |-> Frac p n
   returns  x : a
-  ensures  pure (n == x)
+  ensures  rewrites_to x n
 
 fn write (#a:Type) (r:ref a) (x:a) (#n:erased a)
   requires r |-> n

--- a/lib/pulse/lib/Pulse.Lib.InsertionSort.fst
+++ b/lib/pulse/lib/Pulse.Lib.InsertionSort.fst
@@ -193,7 +193,7 @@ ensures exists* s'. (a |-> s') **
       with s1. assert (a |-> s1);
       step_inner_invariant ss s0 s1 key vi vj;
       if (vi = 0sz) { done := true }
-      else { i := SZ.(vi -^ 1sz); }
+      else { assert pure (SZ.v vi > 0); i := SZ.(vi -^ 1sz); }
     };
     with s0. assert (a |-> s0);
     let vi = !i;

--- a/lib/pulse/lib/Pulse.Lib.LinkedList.fst
+++ b/lib/pulse/lib/Pulse.Lib.LinkedList.fst
@@ -239,8 +239,9 @@ fn rec append (#t:Type0) (x y:llist t)
   is_list_cases_some x np;
   with _node _tl. _;
   let node = !np;
-  rewrite each _node as node;
-  match node.tail {
+  let nt = node.tail;
+  with tl. rewrite is_list node.tail tl as is_list nt tl;
+  match nt {
     None -> {
       is_list_cases_none None;
       unfold (is_list #t None []);
@@ -361,13 +362,13 @@ fn is_last_cell (#t:Type) (x:llist t)
   some_iff_cons x;
   let np = Some?.v x;
   is_list_cases_some x np;
-  with _node _tl. _;
   let node = !np;
-  rewrite each _node as node;
-  match node.tail {
+  let nt = node.tail;
+  with tl. rewrite is_list node.tail tl as is_list nt tl;
+  match nt {
     None -> {
       is_list_cases_none None;
-      rewrite is_list #t None _tl as is_list node.tail _tl;
+      with tl. rewrite is_list #t None tl as is_list node.tail tl;
       intro_is_list_cons x np;
       true
     }
@@ -392,10 +393,10 @@ ensures
   some_iff_cons x;
   let np = Some?.v x;
   is_list_cases_some x np;
-  with _node _tl. _;
   let node = !np;
-  rewrite each _node as node;
-  match node.tail {
+  let nt = node.tail;
+  with tl. rewrite is_list node.tail tl as is_list nt tl;
+  match nt {
     None -> {
       is_list_cases_none None;
       unfold (is_list #t None []);

--- a/lib/pulse/lib/Pulse.Lib.Mutex.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Mutex.fsti
@@ -44,7 +44,7 @@ val pts_to (#a:Type0) (mg:mutex_guard a) (#[T.exact (`1.0R)] p:perm) (x:a) : slp
 val ( ! ) (#a:Type0) (mg:mutex_guard a) (#x:erased a) (#p:perm)
   : stt a
       (requires pts_to mg #p x)
-      (ensures fun y -> pts_to mg #p x ** pure (reveal x == y))
+      (ensures fun y -> pts_to mg #p x ** rewrites_to y (reveal x))
 
 val ( := ) (#a:Type0) (mg:mutex_guard a) (y:a) (#x:erased a)
   : stt unit
@@ -54,7 +54,7 @@ val ( := ) (#a:Type0) (mg:mutex_guard a) (y:a) (#x:erased a)
 val replace (#a:Type0) (mg:mutex_guard a) (y:a) (#x:erased a)
   : stt a
       (requires mg `pts_to` x)
-      (ensures fun r -> mg `pts_to` y ** pure (r == reveal x))
+      (ensures fun r -> mg `pts_to` y ** rewrites_to r (reveal x))
 
 val new_mutex (#a:Type0) (v:a -> slprop) (x:a)
   : stt (mutex a)

--- a/lib/pulse/lib/Pulse.Lib.Primitives.fst
+++ b/lib/pulse/lib/Pulse.Lib.Primitives.fst
@@ -21,9 +21,6 @@ module Pulse.Lib.Primitives
 friend Pulse.Lib.Box
 
 let read_atomic (r:ref U32.t) (#n:erased U32.t) (#p:perm)
-: stt_atomic U32.t emp_inames
-    (pts_to r #p n)
-    (fun x -> pts_to r #p n ** pure (reveal n == x))
 = Pulse.Lib.Core.as_atomic _ _ ((let open Pulse.Lib.Reference in ( ! )) r #n #p)
 
 let write_atomic (r:ref U32.t) (x:U32.t) (#n:erased U32.t)

--- a/lib/pulse/lib/Pulse.Lib.Primitives.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Primitives.fsti
@@ -35,7 +35,7 @@ module B = Pulse.Lib.Box
 val read_atomic (r:ref U32.t) (#n:erased U32.t) (#p:perm)
   : stt_atomic U32.t #Observable emp_inames
     (pts_to r #p n)
-    (fun x -> pts_to r #p n ** pure (reveal n == x))
+    (fun x -> pts_to r #p n ** pure (x == reveal n))
 
 val write_atomic (r:ref U32.t) (x:U32.t) (#n:erased U32.t)
   : stt_atomic unit #Observable emp_inames
@@ -54,7 +54,7 @@ val cas (r:ref U32.t) (u v:U32.t) (#i:erased U32.t)
 val read_atomic_box (r:B.box U32.t) (#n:erased U32.t) (#p:perm)
   : stt_atomic U32.t emp_inames
     (pts_to r #p n)
-    (fun x -> pts_to r #p n ** pure (reveal n == x))
+    (fun x -> pts_to r #p n ** pure (x == reveal n))
 
 val write_atomic_box (r:B.box U32.t) (x:U32.t) (#n:erased U32.t)
   : stt_atomic unit emp_inames

--- a/lib/pulse/lib/Pulse.Lib.Reference.fst
+++ b/lib/pulse/lib/Pulse.Lib.Reference.fst
@@ -55,9 +55,9 @@ fn read
   (r:ref a)
   (#n:erased a)
   (#p:perm)
-  requires pts_to r #p n
+  preserves pts_to r #p n
   returns x:a
-  ensures pts_to r #p n ** pure (eq2 #a (reveal n) x)
+  ensures rewrites_to x n
 {
   unfold (pts_to r #p n);
   let k = H.( !r );

--- a/lib/pulse/lib/Pulse.Lib.Reference.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Reference.fsti
@@ -60,7 +60,7 @@ fn read
   (#p:perm)
   preserves r |-> Frac p n
   returns  x : a
-  ensures  pure (reveal n == x)
+  ensures rewrites_to x n
 
 (* alias for read *)
 fn ( ! )
@@ -70,7 +70,7 @@ fn ( ! )
   (#p:perm)
   preserves r |-> Frac p n
   returns  x : a
-  ensures  pure (reveal n == x)
+  ensures rewrites_to x n
 
 (* := *)
 fn write
@@ -177,5 +177,6 @@ fn replace
   (#v:erased a)
   requires r |-> v
   returns  res : a
-  ensures  (r |-> x) ** pure (res == reveal v)
+  ensures  r |-> x
+  ensures  rewrites_to res v
 

--- a/lib/pulse/lib/Pulse.Lib.Slice.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Slice.fsti
@@ -103,7 +103,7 @@ val op_Array_Access
             pts_to a #p s)
         (ensures fun res ->
             pts_to a #p s **
-            pure (res == Seq.index s (SZ.v i)))
+            rewrites_to res (Seq.index s (SZ.v i)))
 
 
 (* Written a.(i) <- v *)

--- a/lib/pulse/lib/Pulse.Lib.Vec.fsti
+++ b/lib/pulse/lib/Pulse.Lib.Vec.fsti
@@ -77,7 +77,7 @@ fn op_Array_Access
   requires pts_to v #p s
   returns  res : a
   ensures  pts_to v #p s **
-           pure (res == Seq.index s (SZ.v i))
+           rewrites_to res (Seq.index s (SZ.v i))
 
 (* Written x.(i) <- v *)
 fn op_Array_Assignment

--- a/src/checker/Pulse.Checker.Prover.ElimPure.fst
+++ b/src/checker/Pulse.Checker.Prover.ElimPure.fst
@@ -29,6 +29,8 @@ open Pulse.Typing.Combinators
 module Metatheory = Pulse.Typing.Metatheory
 open Pulse.Reflection.Util
 open Pulse.Checker.Prover.Base
+open Pulse.Checker.Prover.Util
+module PS = Pulse.Checker.Prover.Substs
 module RU = Pulse.RuntimeUtils
 
 let elim_pure_head =
@@ -97,6 +99,7 @@ let mk (#g:env) (#v:slprop) (v_typing:tot_typing g v tm_slprop)
   | Tm_Pure pp ->
     let p_typing =
       Metatheory.pure_typing_inversion #g #(wr pp) v_typing in
+    debug_prover g (fun _ -> Printf.sprintf "elim_pure: %s\n" (T.term_to_string pp));
     Some (| ppname_default,
             mk_elim_pure (wr pp),
             elim_pure_comp pp,
@@ -138,23 +141,27 @@ let elim_pure_pst (#preamble:_) (pst:prover_state preamble)
       (RU.magic ())
       pst.uvs in
 
+  let ss : PS.ss_t = // extends pst.ss with new rewrites_to_p substitutions
+    RewritesTo.get_new_substs_from_env pst.pg g' pst.ss in
+
   let k
     : continuation_elaborator
-        pst.pg (list_as_slprop pst.remaining_ctxt * (preamble.frame * pst.ss.(pst.solved)))
-        g' (remaining_ctxt' * (preamble.frame * pst.ss.(pst.solved))) = k in
-  
+        pst.pg (list_as_slprop pst.remaining_ctxt * (preamble.frame * ss.(pst.solved)))
+        g' (remaining_ctxt' * (preamble.frame * ss.(pst.solved))) =
+    admit (); k in
+
   // some *s
   let k
     : continuation_elaborator
-        pst.pg ((list_as_slprop pst.remaining_ctxt * preamble.frame) * pst.ss.(pst.solved))
-        g' ((remaining_ctxt' * preamble.frame) * pst.ss.(pst.solved)) =
+        pst.pg ((list_as_slprop pst.remaining_ctxt * preamble.frame) * ss.(pst.solved))
+        g' ((remaining_ctxt' * preamble.frame) * ss.(pst.solved)) =
     
     k_elab_equiv k (RU.magic ()) (RU.magic ()) in
 
   let k_new
     : continuation_elaborator
         preamble.g0 (preamble.ctxt * preamble.frame)
-        g' ((remaining_ctxt' * preamble.frame) * pst.ss.(pst.solved)) =
+        g' ((remaining_ctxt' * preamble.frame) * ss.(pst.solved)) =
     k_elab_trans pst.k k in
   
   assume (list_as_slprop (slprop_as_list remaining_ctxt') == remaining_ctxt');
@@ -163,6 +170,7 @@ let elim_pure_pst (#preamble:_) (pst:prover_state preamble)
     pg = g';
     remaining_ctxt = slprop_as_list remaining_ctxt';
     remaining_ctxt_frame_typing = RU.magic ();
+    ss;
     nts = None;
     k = k_new;
     goals_inv = RU.magic ();  // weakening of pst.goals_inv

--- a/src/checker/Pulse.Checker.Prover.RewritesTo.fst
+++ b/src/checker/Pulse.Checker.Prover.RewritesTo.fst
@@ -1,0 +1,62 @@
+(*
+   Copyright 2025 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+module Pulse.Checker.Prover.RewritesTo
+open Pulse.Syntax
+open Pulse.Typing.Env
+module PS = Pulse.Checker.Prover.Substs
+module R = FStar.Reflection.V2
+
+let rewrites_to_p_lid = Pulse.Reflection.Util.mk_pulse_lib_core_lid "rewrites_to_p"
+
+let extract_rewrites_to_p (t: typ) =
+  let hd, args = R.collect_app_ln t in
+  match R.inspect_ln hd, args with
+  | R.Tv_UInst hd _, [t, _] ->
+    if R.inspect_fv hd <> R.squash_qn then None else
+    let hd, args = R.collect_app_ln t in
+    (match R.inspect_ln hd, args with
+    | R.Tv_UInst hd _, [_; lhs, _; rhs, _] ->
+      if R.inspect_fv hd <> rewrites_to_p_lid then None else
+      (match R.inspect_ln lhs with
+      | R.Tv_Var x ->
+        let x = R.inspect_namedv x in
+        Some (x.uniq, rhs)
+      | _ -> None)
+    | _ -> None)
+  | _ -> None
+
+let maybe_add_binding_to_subst (ss: PS.ss_t) (t: typ) =
+  match extract_rewrites_to_p t with
+  | Some (x, t) -> if PS.contains ss x then ss else PS.push ss x t
+  | None -> ss
+
+let get_subst_from_env g =
+  let rec go (ss: PS.ss_t) (bs: env_bindings) : Tot PS.ss_t (decreases bs) =
+    match bs with
+    | (x, t) :: bs -> go (maybe_add_binding_to_subst ss t) bs
+    | [] -> ss in
+  go PS.empty (bindings g)
+
+let get_new_substs_from_env g g' ss =
+  let rec go (ss: PS.ss_t) (bs: env_bindings) : Tot PS.ss_t (decreases bs) =
+    match bs with
+    | (x, t) :: bs ->
+      let ss = if contains g x then ss else 
+        maybe_add_binding_to_subst ss t in
+      go ss bs
+    | [] -> ss in
+  go ss (bindings g')

--- a/src/checker/Pulse.Checker.Prover.RewritesTo.fsti
+++ b/src/checker/Pulse.Checker.Prover.RewritesTo.fsti
@@ -1,5 +1,5 @@
 (*
-   Copyright 2023 Microsoft Research
+   Copyright 2025 Microsoft Research
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,26 +14,13 @@
    limitations under the License.
 *)
 
-module Pulse.Lib.GlobalVar
-#lang-pulse
+module Pulse.Checker.Prover.RewritesTo
+open Pulse.Syntax
+open Pulse.Typing.Env
+module PS = Pulse.Checker.Prover.Substs
 
-open Pulse.Lib.Pervasives
-open Pulse.Class.Duplicable
-open FStar.ExtractAs
-open Pulse.Lib.Trade
+val extract_rewrites_to_p (t: typ) : option (var & term)
 
-val gvar (#a:Type0) (p:a -> slprop) : Type0
+val get_subst_from_env (g: env) : PS.ss_t
 
-val mk_gvar
-      (#a:Type0)
-      (#p:a -> slprop) 
-      {| (x:a -> duplicable (p x)) |}
-      (init:unit -> stt a emp (fun x -> p x))
-: gvar p
-
-val read_gvar_ghost (#a:Type0) (#p:a -> slprop) (x:gvar p) : GTot a
-
-fn read_gvar (#a:Type0) (#p:a -> slprop) (x:gvar p)
-  returns  r : a
-  ensures  p r
-  ensures  rewrites_to r (read_gvar_ghost x)
+val get_new_substs_from_env (g: env) (g': env { env_extends g' g }) (ss: PS.ss_t) : PS.ss_t

--- a/src/checker/Pulse.Checker.Prover.Substs.fst
+++ b/src/checker/Pulse.Checker.Prover.Substs.fst
@@ -323,10 +323,8 @@ let rec ss_to_nt_substs (g:env) (uvs:env) (ss:ss_t)
   let g = Env.push_context g "ss_to_nt_substs" (range_of_env g) in
   match bindings uvs with
   | [] ->
-    (match ss.l with
-     | [] -> Inl (| [], [] |)
-     | x::_ ->
-       Inr (Printf.sprintf "Extra uvars in the substitutions collected by the prover, e.g._#%d" x))
+    // The substitution can have a larger domain than just the uvars when using rewrites_to
+    Inl (| [], [] |)
   | _ ->
     let x, ty, rest_uvs = remove_binding uvs in
     if Map.contains ss.m x

--- a/src/checker/Pulse.Checker.Prover.fsti
+++ b/src/checker/Pulse.Checker.Prover.fsti
@@ -38,13 +38,6 @@ val normalize_slprop_welltyped
   (v_typing:tot_typing g v tm_slprop)
   : T.Tac (v':slprop & slprop_equiv g v v' & tot_typing g v' tm_slprop)
 
-val elim_exists_and_pure (#g:env) (#ctxt:slprop)
-  (ctxt_typing:tot_typing g ctxt tm_slprop)
-  : T.Tac (g':env { env_extends g' g } &
-           ctxt':term &
-           tot_typing g' ctxt' tm_slprop &
-           continuation_elaborator g ctxt g' ctxt')
-
 val prove
   (allow_ambiguous : bool)
   (#g:env) (#ctxt:slprop) (ctxt_typing:tot_typing g ctxt tm_slprop)
@@ -80,3 +73,10 @@ val prove_post_hint (#g:env) (#ctxt:slprop)
   (rng:range)
   
   : T.Tac (checker_result_t g ctxt post_hint)
+
+val elim_exists_and_pure (#g:env) (#ctxt:slprop)
+  (ctxt_typing:tot_typing g ctxt tm_slprop)
+  : T.Tac (g':env { env_extends g' g } &
+           ctxt':term &
+           tot_typing g' ctxt' tm_slprop &
+           continuation_elaborator g ctxt g' ctxt')

--- a/test/BangBang.c.expected
+++ b/test/BangBang.c.expected
@@ -1,0 +1,23 @@
+/* krml header omitted for test repeatability */
+
+
+#include "BangBang.h"
+
+int32_t BangBang_modify_nested_ptr(int32_t **x)
+{
+  int32_t *__anf = *x;
+  int32_t *__anf1 = *x;
+  int32_t __anf2 = *__anf1;
+  *__anf = __anf2 + (int32_t)2;
+  int32_t *__anf3 = *x;
+  int32_t __anf4 = *__anf3;
+  return __anf4 + (int32_t)1;
+}
+
+void BangBang_decr_uint(void)
+{
+  uint32_t x = 1U;
+  uint32_t __anf = x;
+  x = __anf - 1U;
+}
+

--- a/test/BangBang.fst
+++ b/test/BangBang.fst
@@ -1,0 +1,19 @@
+module BangBang
+open Pulse
+#lang-pulse
+
+fn modify_nested_ptr (x: ref (ref Int32.t)) (#y: erased (ref Int32.t)) (#z: erased Int32.t { Int32.v z < Int.max_int Int32.n - 3 })
+  preserves x |-> y
+  requires reveal y |-> z
+  returns z': Int32.t
+  ensures reveal y |-> Int32.add z 2l
+  ensures rewrites_to z' (Int32.add z 3l)
+{
+  (!x) := (!(!x)) `Int32.add` 2l;
+  ((!(!x)) `Int32.add` 1l)
+}
+
+fn decr_uint () {
+  let mut x: UInt32.t = 1ul;
+  x := !x `UInt32.sub` 1ul;
+}

--- a/test/Null.fst
+++ b/test/Null.fst
@@ -43,10 +43,9 @@ fn test (x : ref int)
   returns int
 {
   if (Ref.is_null x) {
+    rewrite emp as null_or_live x;
     0
   } else {
-    unfold null_or_live x;
-    rewrite each Ref.is_null #int x as false;
     let res = Ref.(!x);
     rewrite live x as null_or_live x;
     res

--- a/test/Test.ReflikeClass.fst
+++ b/test/Test.ReflikeClass.fst
@@ -9,7 +9,7 @@ module Box = Pulse.Lib.Box
 class reflike (vt:Type) (rt:Type) = {
   ( |-> ) : rt -> vt -> slprop;
   alloc   : v:vt -> stt rt emp (fun r -> r |-> v);
-  (!) : r:rt -> #v0:erased vt -> stt vt (r |-> v0) (fun v -> (r |-> v0) ** pure (Ghost.reveal v0 == v));
+  (!) : r:rt -> #v0:erased vt -> stt vt (r |-> v0) (fun v -> (r |-> v0) ** rewrites_to v (reveal v0));
   (:=) : r:rt -> v:vt -> #v0:erased vt -> stt unit (r |-> v0) (fun _ -> r |-> v);
 }
 

--- a/test/nolib/AdmitDoesNotSimpl.fst.output.expected
+++ b/test/nolib/AdmitDoesNotSimpl.fst.output.expected
@@ -24,7 +24,7 @@
 * Info at AdmitDoesNotSimpl.fst(35,2-35,9):
   - Admitting continuation.
   - Current context:
-      AdmitDoesNotSimpl.foo (1 + 1)
+      AdmitDoesNotSimpl.foo 2
   - In typing environment:
       uu___0#116 : Prims.unit
 


### PR DESCRIPTION
When dereferencing nested references (like `(! (! x))` in the context `x |-> y ** y |-> z`), we currently have the problem that the first read returns `__anf` and the second read then unsuccessfully looks for `__anf |-> ?_`.  This PR adds a `rewrites_to x t` resource that instructs the matcher to replace `x` by `t` before matching (in this case replacing `__anf` by `reveal y`).

Together with the ANF transformation this PR allows us to write cute code with nested references like:
```fstar
  (!x) := (!(!x)) `Int32.add` 2l;
  ((!(!x)) `Int32.add` 1l)
```

Overall, this seems to work really nicely (I didn't try building other projects yet).  I could remove a lot of rewrites in the AVL tree module.

Implementation-wise, I ended up computing the substitution from the F* environment (i.e., by just looking at which hypotheses have a `squash (rewrites_to_p x t)` type and collecting those).  At first I tried to add them to the Pulse environment as new field but that's a huge headache since it's used in proofs and we assume extensionality (i.e., that an environment is merely a list of bindings).