### PR TITLE
Bump CI to OCaml 5.3

### DIFF
--- a/.devcontainer/fromscratch/minimal.Dockerfile
+++ b/.devcontainer/fromscratch/minimal.Dockerfile
@@ -40,7 +40,7 @@ RUN mkdir -p $HOME/bin
 RUN echo 'export PATH=$HOME/bin:$PATH' | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile
 
 # Install OCaml
-ARG OCAML_VERSION=4.14.0
+ARG OCAML_VERSION=5.3.0
 RUN opam init --compiler=$OCAML_VERSION --disable-sandboxing
 RUN opam option depext-run-installs=true
 ENV OPAMYES=1

--- a/.github/setup-macos.sh
+++ b/.github/setup-macos.sh
@@ -4,7 +4,7 @@
 # coreutils: for the `install` command used in install-ulib.sh
 export OPAMYES=1
 brew install opam bash gnu-getopt coreutils gnu-sed make
-opam init --compiler=4.14.0
+opam init --compiler=5.3.0
 eval $(opam env)
 
 # Install Z3 and the opam package dependencies

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 4.14.2
+          ocaml-compiler: 5.3.0
 
       - name: Prepare
         run: |
@@ -45,7 +45,7 @@ jobs:
 
       - uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 4.14.2
+          ocaml-compiler: 5.3.0
 
       - name: Prepare
         run: |

--- a/pulse2rust/src/ocaml/Cargo.toml
+++ b/pulse2rust/src/ocaml/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["staticlib"]
 path = "rust/src/lib.rs"
 
 [dependencies]
-ocaml-interop = "0.9.2"
+ocaml-interop = "0.12.0"
 syn = { version="2.0.29", features=["full", "derive"] }
 proc-macro2 = "1.0.66"
 quote = "1.0.33"

--- a/pulse2rust/src/ocaml/rust/src/lib.rs
+++ b/pulse2rust/src/ocaml/rust/src/lib.rs
@@ -1,6 +1,5 @@
 use ocaml_interop::{
-    impl_from_ocaml_record, impl_from_ocaml_variant, ocaml_export, OCaml, OCamlList, OCamlRef,
-    ToOCaml,
+    impl_from_ocaml_record, impl_from_ocaml_variant, OCaml, OCamlList, OCamlRuntime, ToOCaml
 };
 use proc_macro2::Span;
 use quote::ToTokens;
@@ -2408,55 +2407,26 @@ impl fmt::Display for File {
     }
 }
 
-ocaml_export! {
-  fn rust_fn_to_string(cr, e:OCamlRef<Fn>) -> OCaml<String> {
-    let e = cr.get(e);
-    let e: Fn = e.to_rust ();
-    fn_to_string(&e).to_owned ().to_ocaml(cr)
-  }
-
-  fn rust_expr_to_string(cr, e:OCamlRef<Expr>) -> OCaml<String> {
-    let e = cr.get(e);
-    let e: Expr = e.to_rust ();
-    e.to_string().to_owned().to_ocaml(cr)
-  }
-
-  fn rust_typ_to_string(cr, e:OCamlRef<Typ>) -> OCaml<String> {
-    let e = cr.get(e);
-    let e: Typ = e.to_rust ();
-    e.to_string().to_owned().to_ocaml(cr)
-  }
-
-  fn rust_file_to_syn_string(cr, e:OCamlRef<File>) -> OCaml<String> {
-    let e = cr.get(e);
-    let e: File = e.to_rust ();
-    file_to_syn_string(&e).to_owned ().to_ocaml(cr)
-  }
-
-  // fn rust_add_2(cr, x:OCamlRef<OCamlInt64>) -> OCaml<String> {
-  //   let x: OCaml<OCamlInt64> = cr.get(x);
-  //   let x: i64 = FromOCaml::from_ocaml(x);
-  //   let z = x + 2;
-  //   z.to_string().to_owned().to_ocaml(cr)
-  // }
-
-  // fn rust_dflt(cr, x:OCamlRef<Option<OCamlInt64>>) -> OCaml<String> {
-  //   let x: OCaml<Option<OCamlInt64>> = cr.get(x);
-  //   let x: Option<i64> = FromOCaml::from_ocaml(x);
-  //   let z = match x {
-  //     Some(x) => x,
-  //     None => 0,
-  //   };
-  //   z.to_string().to_owned().to_ocaml(cr)
-  // }
+#[ocaml_interop::export]
+fn rust_fn_to_string(cr: &mut OCamlRuntime, e: OCaml<Fn>) -> OCaml<String> {
+    let e: Fn = e.to_rust();
+    fn_to_string(&e).to_owned().to_ocaml(cr)
 }
 
-// use std::sync::Mutex;
+#[ocaml_interop::export]
+fn rust_expr_to_string(cr: &mut OCamlRuntime, e: OCaml<Expr>) -> OCaml<String> {
+    let e: Expr = e.to_rust();
+    e.to_string().to_owned().to_ocaml(cr)
+}
 
-// fn test(m: Mutex<i32>) -> Mutex<i32 {
-//     let mut data = m.lock().unwrap();
-//     *data = 5;
-//     let x = std::mem::replace::<i32>(&mut data, 6);
-//     let y = *data;
-//     drop(data);
-// }
+#[ocaml_interop::export]
+fn rust_typ_to_string(cr: &mut OCamlRuntime, e: OCaml<Typ>) -> OCaml<String> {
+    let e: Typ = e.to_rust();
+    e.to_string().to_owned().to_ocaml(cr)
+}
+
+#[ocaml_interop::export]
+fn rust_file_to_syn_string(cr: &mut OCamlRuntime, e: OCaml<File>) -> OCaml<String> {
+    let e: File = e.to_rust();
+    file_to_syn_string(&e).to_owned().to_ocaml(cr)
+}


### PR DESCRIPTION
pulse2rust no longer builds with OCaml 5.3.0 (and make test fails for me locally).  However the new ocaml-interop crate version supports *only* OCaml 5.x.  So we need to bump both the OCaml version and the ocaml-interop dependency to support OCaml 5, which is now recommended for dev setups.

This also requires an update to the dev container image.