### PR TITLE
rewrite each: make sure to normalize/unfold each side

### DIFF
--- a/src/checker/Pulse.Checker.AssertWithBinders.fst
+++ b/src/checker/Pulse.Checker.AssertWithBinders.fst
@@ -269,6 +269,13 @@ let rewrite_all (is_source:bool) (g:env) (p: list (term & term)) (t:term) : T.Ta
           (fst (Pulse.Checker.Pure.instantiate_term_implicits g e2 None false)))
         p
     in
+    let p : list (R.term & R.term) =
+      T.map
+        (fun (e1, e2) ->
+          dfst <| Pulse.Checker.Prover.normalize_slprop g e1,
+          dfst <| Pulse.Checker.Prover.normalize_slprop g e2)
+        p
+    in
     let lhs, rhs = visit_and_rewrite_conjuncts_all is_source g p t in
     debug_log g (fun _ -> Printf.sprintf "Rewrote %s to %s" (P.term_to_string lhs) (P.term_to_string rhs));
     lhs, rhs

--- a/test/nolib/RewriteEachUnfold.fst
+++ b/test/nolib/RewriteEachUnfold.fst
@@ -1,0 +1,16 @@
+module RewriteEachUnfold
+
+#lang-pulse
+open Pulse.Nolib
+
+assume val foo : slprop
+assume val baz : slprop
+unfold let bar = foo
+
+fn test (_ : squash (foo == baz))
+  requires bar
+  ensures  baz
+{
+  rewrite each bar as baz;
+  ()
+}


### PR DESCRIPTION
This fixes the attached test case, where we try to rewrite every `bar` in the context into `baz`, but since `bar` is unfold, it will never appear as such, making the rewrite do nothing.

This happens pretty often for operators like `SizeT.(+)`, which is just defined as `SizeT.add`, with an unfold qualifier. Without this patch, one cannot use these operators in the LHS of a rewrite and must use the underlying names.