### PR TITLE
rewrite each: apply rewrites_to substitution to each side

### DIFF
--- a/src/checker/Pulse.Checker.AssertWithBinders.fst
+++ b/src/checker/Pulse.Checker.AssertWithBinders.fst
@@ -263,12 +263,22 @@ let rec as_subst (p : list (term & term))
 
 
 
-let rewrite_all (is_source:bool) (g:env) (p: list (term & term)) (t:term) : T.Tac (term & term) =
+let rewrite_all (is_source:bool) (g:env) (p: list (term & term)) (t:term) tac_opt : T.Tac (term & term) =
+  (* We only use the rewrites_to substitution if there is no tactic attached to the
+  rewrite. Otherwise, tactics may become brittle as the goal is changed unexpectedly
+  by other things in the context. See tests/Match.fst. *)
+  let use_rwr = None? tac_opt in
+  let norm (t:term) : T.Tac term = dfst <| Pulse.Checker.Prover.normalize_slprop g t use_rwr in
+  let t =
+    let t, _ = Pulse.Checker.Pure.instantiate_term_implicits g t None true in
+    let t = dfst <| Pulse.Checker.Prover.normalize_slprop g t use_rwr in
+    t
+  in
   let elab_pair (lhs rhs : R.term) : T.Tac (R.term & R.term) =
     let lhs, lhs_typ = Pulse.Checker.Pure.instantiate_term_implicits g lhs None true in
     let rhs, rhs_typ = Pulse.Checker.Pure.instantiate_term_implicits g rhs (Some lhs_typ) true in
-    let lhs = dfst <| Pulse.Checker.Prover.normalize_slprop g lhs in
-    let rhs = dfst <| Pulse.Checker.Prover.normalize_slprop g rhs in
+    let lhs = norm lhs in
+    let rhs = norm rhs in
     lhs, rhs
   in
   let p : list (R.term & R.term) = T.map (fun (e1, e2) -> elab_pair e1 e2) p in
@@ -313,7 +323,7 @@ let check_renaming
 
   | [], None ->
     // if there is no goal, take the goal to be the full current pre
-    let lhs, rhs = rewrite_all (T.unseal st.source) g pairs pre in
+    let lhs, rhs = rewrite_all (T.unseal st.source) g pairs pre tac_opt in
     let t = { st with term = Tm_Rewrite { t1 = lhs; t2 = rhs; tac_opt};
                       source = Sealed.seal false; } in
     { st with
@@ -323,7 +333,7 @@ let check_renaming
 
   | [], Some goal -> (
       let goal, _ = PC.instantiate_term_implicits g goal None false in
-      let lhs, rhs = rewrite_all (T.unseal st.source) g pairs goal in
+      let lhs, rhs = rewrite_all (T.unseal st.source) g pairs goal tac_opt in
       let t = { st with term = Tm_Rewrite { t1 = lhs; t2 = rhs; tac_opt };
                         source = Sealed.seal false; } in
       { st with term = Tm_Bind { binder = as_binder tm_unit; head = t; body };

--- a/src/checker/Pulse.Checker.Prover.fsti
+++ b/src/checker/Pulse.Checker.Prover.fsti
@@ -30,6 +30,7 @@ include Pulse.Checker.Prover.Util
 val normalize_slprop
   (g:env)
   (v:slprop)
+  (use_rewrites_to : bool)
   : T.Tac (v':slprop & slprop_equiv g v v')
 
 val normalize_slprop_welltyped

--- a/test/Match.fst
+++ b/test/Match.fst
@@ -1,0 +1,22 @@
+module Match
+
+#lang-pulse
+open Pulse
+
+type abc = | A
+
+fn foo (r : ref abc) (#zzz : erased abc)
+  preserves r |-> zzz
+{
+  let z = !r;
+  match z {
+    A -> {
+     (* There is an implicit `rewrite each z as A` here, using the match_rewrite_tac.
+     The tactic relies on a particular shape of the goal and environment,
+     so we must *not* apply the rewrites_to substitution to the sides of the
+     rewrite. The implementation of rewrite_each will not apply the substitution
+     if a tactic is provided. *)
+     ()
+   }
+  };
+}

--- a/test/RewriteEachUnfold.fst
+++ b/test/RewriteEachUnfold.fst
@@ -14,3 +14,20 @@ fn test (_ : squash (foo == baz))
   rewrite each bar as baz;
   ()
 }
+
+
+(* These work since we apply the rewrites_to substitution
+   on each side before rewriting. *)
+fn test1 (x: ref int)
+  preserves exists* (yy: int). (x |-> yy) ** pure (yy == 42)
+{
+  let y = !x;
+  rewrite each y as 42;
+}
+
+fn test2 (x: ref (ref int))
+  preserves exists* (yy: ref int) zz. (x |-> yy) ** (yy |-> zz) ** pure (zz == 42)
+{
+  let z = ! !x;
+  rewrite each z as 42;
+}


### PR DESCRIPTION
As discussed in #417. The substitution is not done when there is a tactic attached to the rewrite, as it may obfuscate the goal. Not considering this does break several matches in the library.