### PR TITLE
Allow to set PULSE_NO_DOMAINSLIB=1 to skip a test

### DIFF
--- a/test/pool/Makefile
+++ b/test/pool/Makefile
@@ -1,6 +1,8 @@
 PULSE_ROOT ?= ../..
 
 SUBDIRS += pulse_task
+ifeq ($(PULSE_NO_DOMAINSLIB),)
 SUBDIRS += domainslib
+endif
 
 include $(PULSE_ROOT)/mk/test.mk


### PR DESCRIPTION
There is no need to test this from, e.g., the everest build.