### PR TITLE
Speed up quicksort tests.

### DIFF
--- a/test/pool/domainslib/driver.ml
+++ b/test/pool/domainslib/driver.ml
@@ -2,7 +2,7 @@ let dbg s = print_string (s ^ "\n"); flush stdout
 
 let main =
   let nproc = 32 in
-  let len = 100000 in
+  let len = 10000 in
   let a = Array.make len 0 in
   for i = 0 to len - 1 do
     a.(i) <- Random.int (10 * len)

--- a/test/pool/pulse_task/driver.ml
+++ b/test/pool/pulse_task/driver.ml
@@ -2,7 +2,7 @@ let dbg s = print_string (s ^ "\n"); flush stdout
 
 let main =
   let nproc = 32 in
-  let len = 100000 in
+  let len = 10000 in
   let a = Array.make len 0 in
   for i = 0 to len - 1 do
     a.(i) <- Random.int (10 * len)


### PR DESCRIPTION
With 1e5 elements these tests take 5s on my machine.  This makes it really slow to run make in the test directory.  Reducing the element count brings the make runtime to half a second.