### PR TITLE
[RFC] Impure specifications

### DIFF
--- a/src/checker/Pulse.Checker.AssertWithBinders.fst
+++ b/src/checker/Pulse.Checker.AssertWithBinders.fst
@@ -457,7 +457,7 @@ let check
     let bs = infer_binder_types g bs v in
     let (| uvs, v_opened, body_opened |) = open_binders g bs (mk_env (fstar_env g)) v body in
     let v, body = v_opened, body_opened in
-    let (| v, d |) = PC.check_slprop (push_env g uvs) v in
+    let (| v, d |) = ImpureSpec.purify_spec (push_env g uvs) pre v in
     let (| g1, nts, _, pre', k_frame |) = Prover.prove false pre_typing uvs d in
     //
     // No need to check effect labels for the uvs solution here,

--- a/src/checker/Pulse.Checker.ImpureSpec.fst
+++ b/src/checker/Pulse.Checker.ImpureSpec.fst
@@ -1,0 +1,148 @@
+(*
+   Copyright 2025 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+module Pulse.Checker.ImpureSpec
+module R = FStar.Reflection.V2
+module T = FStar.Tactics.V2
+module RU = Pulse.RuntimeUtils
+module PS = Pulse.Checker.Prover.Substs
+open Pulse.Syntax.Base
+open Pulse.Syntax.Pure
+open Pulse.Checker.Prover.RewritesTo
+open Pulse.Checker.Pure
+open Pulse.Typing.Env
+open Pulse.Checker.Base
+open Pulse.Readback
+open Pulse.Syntax.Naming
+open Pulse.Reflection.Util
+
+let rec get_rewrites_to_from_post (g: env) xres (post: slprop) : T.Tac (option R.term) =
+  match inspect_term post with
+  | Tm_Star p q ->
+    (match get_rewrites_to_from_post g xres p with
+    | None -> get_rewrites_to_from_post g xres q
+    | Some res -> Some res)
+  | Tm_Pure p ->
+    ((if RU.debug_at_level (fstar_env g) "hhh" then let open Pulse.PP in info_doc g None [ text "IMPURE_SPEC"; pp post; ]);
+    match is_rewrites_to_p p with
+    | None -> None
+    | Some (lhs, rhs) ->
+      match R.inspect_ln lhs with
+      | R.Tv_Var x ->
+        let x = R.inspect_namedv x in
+        if x.uniq = xres then
+          ((if RU.debug_at_level (fstar_env g) "hhh" then let open Pulse.PP in info_doc g None [ text "IMPURE_SPEC found"; pp rhs; ]);
+          // TODO: check that rhs does not contain xres
+          Some rhs)
+        else
+          None
+      | _ -> None)
+  | _ -> None
+
+let rec maybe_hoist (g:env) (ctxt: slprop) (t:R.term) : T.Tac (bool & R.term) = 
+  let head, args = T.collect_app_ln t in
+  match args with
+  | [] -> false, t //no args to hoist
+  | _ ->
+  match is_stateful_application g t with
+  | None -> (
+    let g, binders, args = maybe_hoist_args g ctxt args in
+    match binders with
+    | false -> false, t // no elab
+    | _ -> 
+      let t = RU.mk_app_flat head args (T.range_of_term t) in
+      binders, t
+  )
+  | Some _ -> (
+    let g, binders, args = maybe_hoist_args g ctxt args in
+    let t = RU.mk_app_flat head args (T.range_of_term t) in
+    let (| uvs, t, ty |) = instantiate_term_implicits_uvs g t true in
+    (if RU.debug_at_level (fstar_env g) "hhh" then
+    let open Pulse.PP in
+    info_doc g None [
+      text "IMPURE_SPEC inferred type";
+      pp t;
+      pp ty;
+    ]);
+    match readback_comp ty with
+    | None | Some (C_Tot ..) -> T.fail "impossible: not a stateful application type"
+    | Some c -> match c with
+    | C_STAtomic _ _ { pre; post } | C_STGhost _ { pre; post } | C_ST { pre; post } ->
+      let x = fresh g in
+      let x_ppn = mk_ppname_no_range "result" in
+      let g' = push_binding g x (mk_ppname_no_range "result") ty in
+      assume disjoint g' uvs;
+      let post = open_term_nv post (x_ppn, x) in
+      let (| post, _ |) = Pulse.Checker.Prover.normalize_slprop (push_env g' uvs) post true in 
+      (if RU.debug_at_level (fstar_env g) "hhh" then let open Pulse.PP in info_doc g None [ text "IMPURE_SPEC post"; pp post; ]);
+      match get_rewrites_to_from_post g x post with
+      | None -> T.fail "cannot find rewrites_to"
+      | Some rwr ->
+        let allow_amb = true in
+        let (| g', ss, _, _, _ |) = Pulse.Checker.Prover.prove allow_amb #g #ctxt (RU.magic ()) uvs #pre (RU.magic ()) in
+        let rwr = PS.nt_subst_term rwr ss in
+        // TODO: make sure that the prover doesn't extend the environment
+        true, rwr
+  )
+
+and maybe_hoist_args (g:env) (ctxt: slprop) (args:list T.argv)
+: T.Tac (env & bool & list T.argv)
+= T.fold_right
+    (fun (arg, q) (g, binders, args) ->
+      let binders', arg = maybe_hoist g ctxt arg in
+      let binders = binders' || binders in
+      g, binders, (arg, q)::args)
+    args
+    (g, false, [])
+
+(* Adds add to the ctxt in a way that the prover will prefer it when ambiguous. *)
+let push_ctxt ctxt add = tm_star add ctxt
+
+let inspect_ast_term (t: term) : term_view =
+  let default_view = Tm_FStar t in
+  let head, args = T.collect_app_ln t in
+  match R.inspect_ln head, args with
+  | R.Tv_FVar fv, [a1, R.Q_Explicit; a2, R.Q_Explicit] ->
+    if R.inspect_fv fv = star_lid then
+      Tm_Star a1 a2
+    else
+      default_view
+  | R.Tv_FVar fv, [a1, R.Q_Explicit] ->
+    if R.inspect_fv fv = exists_lid || R.inspect_fv fv = forall_lid then
+      match R.inspect_ln a1 with
+      | R.Tv_Abs b body ->
+        let bview = R.inspect_binder b in
+        let b = mk_binder_ppname a1 (mk_ppname bview.ppname (RU.binder_range b)) in
+        if R.inspect_fv fv = exists_lid
+        then Tm_ExistsSL u_unknown b body
+        else Tm_ForallSL u_unknown b body
+      | _ -> default_view
+    else
+      default_view
+  | _ ->
+    default_view
+
+
+let rec purify_spec (g: env) (ctxt: slprop) (t: slprop) : T.Tac (t: slprop & tot_typing g t tm_slprop) =
+  match inspect_ast_term t with
+  | Tm_Star t s ->
+    let (| t, _ |) = purify_spec g ctxt t in
+    let (| s, _ |) = purify_spec g (push_ctxt ctxt t) s in
+    (| tm_star t s, E (RU.magic ()) |)
+  // TODO: exists
+  | _ ->
+    let _, t = maybe_hoist g ctxt t in
+    check_slprop g t

--- a/src/checker/Pulse.Checker.ImpureSpec.fsti
+++ b/src/checker/Pulse.Checker.ImpureSpec.fsti
@@ -14,15 +14,11 @@
    limitations under the License.
 *)
 
-module Pulse.Checker.Prover.RewritesTo
-open Pulse.Syntax
-open Pulse.Typing.Env
-module PS = Pulse.Checker.Prover.Substs
+module Pulse.Checker.ImpureSpec
+module T = FStar.Tactics.V2
+open Pulse.Syntax.Base
+open Pulse.Syntax.Pure
+open Pulse.Typing
 
-val is_rewrites_to_p (t: typ) : option (term & term)
-
-val extract_rewrites_to_p (t: typ) : option (var & term)
-
-val get_subst_from_env (g: env) : PS.ss_t
-
-val get_new_substs_from_env (g: env) (g': env { env_extends g' g }) (ss: PS.ss_t) : PS.ss_t
+val purify_spec (g: env) (ctxt: slprop) (t: slprop) :
+  T.Tac (t:slprop & tot_typing g t tm_slprop)

--- a/src/checker/Pulse.Checker.Pure.fst
+++ b/src/checker/Pulse.Checker.Pure.fst
@@ -208,11 +208,11 @@ let instantiate_term_implicits
     | [] ->
       t, ty
 
-let instantiate_term_implicits_uvs (g:env) (t0:term) =
+let instantiate_term_implicits_uvs (g:env) (t0:term) (inst_extra:bool) =
   let f = elab_env g in
   let rng = RU.range_of_term t0 in
   let f = RU.env_set_range f (Pulse.Typing.Env.get_range g (Some rng)) in
-  let topt, issues = catch_all (fun _ -> rtb_instantiate_implicits g f t0 None false) in (* false? *)
+  let topt, issues = catch_all (fun _ -> rtb_instantiate_implicits g f t0 None inst_extra) in (* false? *)
   match topt with
   | None -> (
     let open Pulse.PP in

--- a/src/checker/Pulse.Checker.Pure.fsti
+++ b/src/checker/Pulse.Checker.Pure.fsti
@@ -31,6 +31,7 @@ val instantiate_term_implicits
   : T.Tac (term & term)
 
 val instantiate_term_implicits_uvs (g:env) (t:term)
+  (inst_extra : bool) (* Should this instantiate implicits at the end of t? *)
   : T.Tac (uvs:env { disjoint g uvs } & term & term)  // uvs
 
 val check_universe (g:env) (t:term)

--- a/src/checker/Pulse.Checker.Rewrite.fst
+++ b/src/checker/Pulse.Checker.Rewrite.fst
@@ -118,8 +118,8 @@ let check
 
   let g = push_context "check_rewrite" t.range g in
   let Tm_Rewrite {t1=p; t2=q; tac_opt} = t.term in
-  let (| p, p_typing |) = check_slprop g p in
-  let (| q, q_typing |) = check_slprop g q in
+  let (| p, p_typing |) = ImpureSpec.purify_spec g pre p in
+  let (| q, q_typing |) = ImpureSpec.purify_spec g pre q in
 
   let equiv_p_q =
     (* If we don't have a tactic, we just call the check_slprop_equiv

--- a/src/checker/Pulse.Checker.STApp.fst
+++ b/src/checker/Pulse.Checker.STApp.fst
@@ -96,7 +96,7 @@ let instantiate_implicits (g:env) (t:st_term { Tm_STApp? t.term })
   let range = t.range in
   let Tm_STApp { head; arg_qual=qual; arg } = t.term in
   let pure_app = tm_pureapp head qual arg in
-  let (| uvs, t, ty |) = instantiate_term_implicits_uvs g pure_app in
+  let (| uvs, t, ty |) = instantiate_term_implicits_uvs g pure_app false in
   match is_arrow ty with
   | Some (_, Some Implicit, _) ->
     //Some implicits to follow

--- a/test/ImpureSpec.fst
+++ b/test/ImpureSpec.fst
@@ -1,0 +1,9 @@
+module ImpureSpec
+open Pulse
+#lang-pulse
+
+fn test1 () {
+  let mut x = 2;
+  let mut y = x;
+  assert pure (!(!y) == 2);
+}


### PR DESCRIPTION
This PR adds a mechanism to write specifications (assertions/preconditions/etc.) without explicitly referring to the erased values of variables/arrays/etc., instead supporting the same syntax as executable code.

```fstar
// x |-> vx
if (2 * !x > !x + 3) {
  assert pure (2 * !x > !x + 3);
}

// is the same as:
// x |-> vx
let anf1 = !x;
let anf2 = !x;
if (2 * anf1 > anf2 + 3) {
  assert pure (2 * vx > vx + 3);
}
```

## Abstract procedure

The general idea is to run a preprocessing pass on slprops used in asserts/preconditions/etc.  The preprocessing step depends on the current context (list of slprops), and replaces stateful applications by their `rewrites_to` result.

```
purify(ctxt, a ** b) = purify(ctxt, a) ** purify(a ** ctxt, b)
purify(ctxt, exists* x. a) = exists x. purify (ctxt, a)
purify(ctxt, p) = purify_term(ctxt, p)

purify_term(ctxt, t) = s
  where
    t : stt(_ghost/_atomic/) _ pre fun result -> ... ** rewrites_to result s ** ...
    pre  follows from  ctxt

purify_term(ctxt, f(x1, ..., xn)) = f(purify_term(ctxt, x1), ..., purify_term(ctxt, xn))
```

The pass does not create any extra bind statements and does not modify the structure of the slprop.  It also works for any function that has a `rewrites_to` in the postcondition.


## Simplest example

```fstar
#lang-pulse

fn foo () {
  let mut x = 42;
  // x |-> 42
  assert pure (!x == 42);
  // elaborates to: pure (42 == 42)
}
```

## Nested references

```fstar
#lang-pulse

fn foo () {
  let mut x = 42;
  let mut y = x;
  // (x |-> 42) ** (y |-> x)
  assert pure (!(!y) == 42);
  // also elaborates to: pure (42 == 42)
}
```

## Array accesses (WIP)

```fstar
#lang-pulse

fn foo (x: array int) (#vx: erased _)
  preserves x |-> vx
  requires pure (forall i. SizeT.v i < Seq.length vx ==> x.(i) > 10)
  // elaborates to: pure (forall i. SizeT.v i < Seq.length vx ==> Seq.index x (SizeT.v i) > 10)
{
  ()
}
```

TODO:
 - traverse binders in purify_term
 - disable checking pure preconditions in purify_term

## Preconditions (WIP)

```fstar
#lang-pulse

fn foo (x: ref int) (#vx: erased _)
  preserves x |-> vx
  requires pure (!x == 42)
// precondition
//  first desugars to: (x |-> vx) ** pure (!x == 42)
//  then elaborates to: (x |-> vx) ** pure (vx == 42)
{
  assert pure (!x > 0);
  // elaborates to: pure (vx > 0)
}
```

TODO:
 - hook into the abs checker

## Invariants (WIP)

```fstar
#lang-pulse

fn foo () {
  let mut x = 10;
  let mut y = 20;
  while (!y > !x)
    invariant exists* vy. (y |-> vy) ** pure (!y >= !x)
    // elaborates to:            ... ** pure (vy >= 10)
  {
    y := !y - 1;
  }
}
```

TODO:
  - implement exists-case in purify