### PR TITLE
Use a custom tactic for finding non_informative proofs

### DIFF
--- a/lib/common/Pulse.Lib.Core.fsti
+++ b/lib/common/Pulse.Lib.Core.fsti
@@ -577,6 +577,12 @@ val invariant_name_identifies_invariant
 
 (***** end computation types and combinators *****)
 
+(* This tactic is called to find non_informative witnesses.
+It must run fast in the simple cases like unit and squash, but
+also default to tcresolve before failing. *)
+let non_info_tac () : T.Tac unit =
+  Pulse.Lib.Tactics.non_info_tac ()
+
 //////////////////////////////////////////////////////////////////////////
 // Some basic actions and ghost operations
 //////////////////////////////////////////////////////////////////////////
@@ -591,6 +597,8 @@ than SMT. This tactic is also used by the checker when elaborating fold/unfold. 
 let slprop_equiv_norm (_:unit) : T.Tac unit =
     T.mapply (`slprop_equiv_refl)
 
+(* TODO: Can these be made plugins? They would have to go into another module
+   probably. *)
 
 let slprop_equiv_unfold (head_sym:string) (_:unit) : T.Tac unit =
     T.mapply (`slprop_equiv_trans);

--- a/lib/common/Pulse.Lib.Tactics.fst
+++ b/lib/common/Pulse.Lib.Tactics.fst
@@ -1,0 +1,31 @@
+module Pulse.Lib.Tactics
+
+open FStar.Tactics.V2
+open Pulse.Lib.NonInformative
+
+let non_info_tac () : Tac unit =
+  match hua (cur_goal ()) with
+  | Some (fv, _, [a, _]) -> (
+    let nm = implode_qn (inspect_fv fv) in
+    if nm = `%non_informative then
+    match hua a with
+    | Some (fv, _, _) ->
+      let nm = implode_qn (inspect_fv fv) in
+      if false then
+        ()
+      else if nm = `%squash then
+        apply (`non_informative_squash)
+      else if nm = `%unit then
+        apply (`non_informative_unit)
+      else if nm = `%Ghost.erased then
+        apply (`non_informative_erased)
+      else if nm = `%prop then
+        apply (`non_informative_prop)
+      else (
+        Tactics.Typeclasses.tcresolve ()
+      )
+    | _ ->
+      fail "non_info_tac: bad call"
+  )
+  | _ ->
+    fail "non_info_tac: bad call"

--- a/lib/common/Pulse.Lib.Tactics.fsti
+++ b/lib/common/Pulse.Lib.Tactics.fsti
@@ -1,0 +1,6 @@
+module Pulse.Lib.Tactics
+
+open FStar.Tactics.Effect
+
+[@@plugin]
+val non_info_tac () : Tac unit

--- a/mk/checker.mk
+++ b/mk/checker.mk
@@ -4,7 +4,11 @@ CACHE_DIR := build/$(TAG).checked
 OUTPUT_DIR := build/$(TAG).ml
 CODEGEN := Plugin
 ROOTS := $(shell find $(SRC) -name '*.fst' -o -name '*.fsti')
+ROOTS += lib/common/Pulse.Lib.Tactics.fsti
+# ^ List files with plugins here
+
 FSTAR_OPTIONS += --already_cached 'Prims,FStar'
+FSTAR_OPTIONS += --include lib/common
 EXTRACT += --extract '-*,+Pulse,+PulseSyntaxExtension'
 DEPFLAGS += --already_cached 'Prims,FStar,FStarC'
 

--- a/src/checker/Pulse.Checker.Pure.fst
+++ b/src/checker/Pulse.Checker.Pure.fst
@@ -388,6 +388,9 @@ let non_informative_class_typing
   : my_erased (typing_token (elab_env g) (non_informative_class u ty) (E_Total, R.pack_ln (R.Tv_Type u)))
   = E (magic())
 
+let non_info_tac_tm : term =
+  pack_ln (Tv_FVar (pack_fv (explode_qn "Pulse.Lib.Core.non_info_tac")))
+
 (* This function attempts to construct a dictionary for `NonInformative.non_informative ty`.
 To do so, we simply create that constraint (and prove it's well-typed), and then
 call the tcresolve typeclass resolution tactic on it to obtain a dictionary and
@@ -400,7 +403,7 @@ let try_get_non_informative_witness_aux (g:env) (u:universe) (ty:term) (ty_typin
     let goal_typing_tok : squash (typing_token r_env goal (E_Total, R.pack_ln (R.Tv_Type u))) =
       match constraint_typing with | E tok -> Squash.return_squash tok
     in
-    let r = T.call_subtac r_env FStar.Tactics.Typeclasses.tcresolve u goal in
+    let r = T.call_subtac_tm r_env non_info_tac_tm u goal in
     match r with
     | None, issues ->
       None, issues


### PR DESCRIPTION
Calling tcresolve works, and allows us to use the typeclass system to extend the set of non-informative types, but comes at a cost. For once, tcresolve will try to apply local instances from the enviroment beofre attempting to apply global ones, which means traversing the entire environment and, for each binder, normalizing it and attempting to unify it with the goal.

tcresolve should probably have smarter defaults, but, we also don't need to call it directly. This PR adds a custom tactic that has a fastpath for the common cases and only calls tcresolve if it could not solve the goal.

See the perf improvement in just building lib-pulse. Left is before, right is after:

<img width="1067" height="246" alt="image" src="https://github.com/user-attachments/assets/0547177e-40ef-4af7-9af5-ad31335ee88c" />
