### PR TITLE
Pulse.Typing.Env: making elab_env O(1)

### DIFF
--- a/src/checker/Pulse.Checker.While.fst
+++ b/src/checker/Pulse.Checker.While.fst
@@ -82,7 +82,7 @@ let check
     let r = check
       (push_context "check_while_condition" cond.range g)
       (comp_pre (comp_while_cond nm inv))
-      cond_pre_typing
+      (coerce_eq () cond_pre_typing) // why is coerce_eq needed !?
       (PostHint while_cond_hint)
       ppname
       cond in
@@ -106,7 +106,7 @@ let check
       let r = check
         (push_context "check_while_body" body.range g)
         (comp_pre (comp_while_body nm inv))
-        body_pre_typing
+        (coerce_eq () body_pre_typing) // why is coerce_eq needed !?
         (PostHint while_post_hint)
         ppname
         body in

--- a/src/checker/Pulse.Typing.Env.fsti
+++ b/src/checker/Pulse.Typing.Env.fsti
@@ -30,17 +30,35 @@ module Pprint = FStar.Pprint
 type binding = var & typ
 type env_bindings = list binding
 
+let extend_env_l (f:R.env) (g:env_bindings) : Tot R.env =
+  L.fold_right
+    (fun (x, b) g ->
+      RT.extend_env g x b)
+     g
+     f
+
 val env : Type0
 
 val fstar_env (g:env) : RT.fstar_top_env
-
-val fresh_anf (g:env) : T.Tac (env & nat)
 
 //
 // most recent binding at the head of the list
 //
 val bindings (g:env) : env_bindings
 val bindings_with_ppname (g:env) : T.Tac (list (ppname & var & typ))
+
+(* Returns an F* reflection environment.
+The result is the same as taking the initial F*
+environment (fstar_env g) and extending it with
+all the bindings, but this is O(1). *)
+val elab_env  (g:env) : R.env
+
+val elab_env_lemma (g:env)
+  : Lemma (elab_env g == extend_env_l (fstar_env g) (bindings g))
+          [SMTPat (elab_env g)]
+
+val fresh_anf (g:env) : T.Tac (env & nat)
+
 
 val as_map (g:env) : Map.t var typ
 

--- a/src/checker/Pulse.Typing.fst
+++ b/src/checker/Pulse.Typing.fst
@@ -118,15 +118,6 @@ let comp_return (c:ctag) (use_eq:bool) (u:universe) (t:term) (e:term) (post:term
       { u; res = t; pre = open_term' post e 0; post = post_maybe_eq }
 
 
-module L = FStar.List.Tot
-let extend_env_l (f:R.env) (g:env_bindings) : R.env = 
-  L.fold_right 
-    (fun (x, b) g ->  
-      RT.extend_env g x b)
-     g
-     f
-let elab_env (e:env) : R.env = extend_env_l (fstar_env e) (bindings e)
-
 
 (*
  * If I call this fresh, I get:


### PR DESCRIPTION
This does not seem to have a big impact on synthetic tests, but seems strictly better than recomputing this every time.