### PR TITLE
parser: allow nested quantifiers at the top level

### DIFF
--- a/src/ml/FStarC_Parser_Parse.mly
+++ b/src/ml/FStarC_Parser_Parse.mly
@@ -419,8 +419,8 @@ rawDecl:
       {
         let r = rr $loc in
         let lbs = focusLetBindings lbs r in
-        if q <> Rec && List.length lbs <> 1
-        then raise_error_text r Fatal_MultipleLetBinding "Unexpected multiple let-binding (Did you forget some rec qualifier ?)";
+        if q <> Rec && FStarC_List.length lbs > Prims.parse_int "1"
+        then raise_error_text (fst (nth lbs (Prims.parse_int "1"))).prange Fatal_MultipleLetBinding "Unexpected multiple let-binding (Did you forget some rec qualifier ?)";
         TopLevelLet(q, lbs)
       }
   | VAL c=constant

--- a/src/ml/pulseparser.mly
+++ b/src/ml/pulseparser.mly
@@ -359,10 +359,10 @@ mutOrRefQualifier:
   | MUT { MUT }
   | REF { REF }
 
-typX(X,Y):
-  | t=Y { t }
+typX(X):
+  | t=X { t }
 
-  | q=quantifier bs=binders DOT trigger=trigger e=X
+  | q=quantifier bs=binders DOT trigger=trigger e=typX(X)
       {
         match bs with
         | [] ->
@@ -373,5 +373,5 @@ typX(X,Y):
       }
 
 pulseSLProp:
-  | p=typX(tmEqWith(appTermNoRecordExp), tmEqWith(appTermNoRecordExp))
+  | p=typX(tmEqWith(appTermNoRecordExp))
     { p }

--- a/test/nolib/QuantifierOps.fst
+++ b/test/nolib/QuantifierOps.fst
@@ -1,0 +1,26 @@
+module QuantifierOps
+
+#lang-pulse
+open Pulse.Nolib
+
+let ( exists* ) : #a:Type -> (a -> slprop) -> slprop = admit()
+let ( forall+ ) : #a:Type -> (a -> slprop) -> slprop = admit()
+
+let test =
+  forall+ (x : int).
+    exists* (y : int).
+      emp
+
+let test2 =
+  exists* (y : int).
+    forall+ (x : int).
+      emp
+
+fn def ()
+  preserves
+    forall+ (x : int).
+      exists* (y : int).
+        emp
+{
+  ()
+}


### PR DESCRIPTION
Note: the parser is spitting out a lot of conflicts.

	Warning: 28 states have shift/reduce conflicts.
	Warning: one state has reduce/reduce conflicts.
	Warning: 338 shift/reduce conflicts were arbitrarily resolved.
	Warning: one reduce/reduce conflict was arbitrarily resolved.
	Warning: 232 end-of-stream conflicts were arbitrarily resolved.

These are not introduced (nor fixed) by this patch.