### PR TITLE
Some optimization in Pulse.Simplify: do not repeatedly call T.hua

### DIFF
--- a/src/checker/Pulse.Simplify.fsti
+++ b/src/checker/Pulse.Simplify.fsti
@@ -5,17 +5,4 @@ module Pulse.Simplify
 open FStar.Reflection.V2
 module T       = FStar.Tactics.V2
 
-val is_tuple2__1 (t:term) : T.Tac (option term)
-
-val is_tuple2__2 (t:term) : T.Tac (option term)
-
-val is_tuple2 (t:term) : T.Tac (option (term & term))
-
-(* This is a huge hack to work around the lack of reduction of projectors in F*.
-Note that we cannot simply unfold the projects willy-nilly, we only want to do so
-when they are applied to a constructed value. *)
-val _simpl_proj (t:term) : T.Tac (option term)
-
-val simpl_proj (t:term) : T.Tac term
-
 val simplify (t:term) : T.Tac term


### PR DESCRIPTION
I measure that repeatedly calling T.hua on a term to try to simplify it has a small but noticeable overhead: E.g., in Test.Basic1.fst we spend about 150ms in the prover, and about 50ms of that is eliminated by this optimization.

Going further, I wonder how useful it is to apply these simplifications to an slprop at all. This is only trying to simplify things like reveal/hide, projections etc. at the head of a term.