### PR TITLE
Fix tm_pureapp for meta/tc implicit args

### DIFF
--- a/src/checker/Pulse.Elaborate.Pure.fst
+++ b/src/checker/Pulse.Elaborate.Pure.fst
@@ -34,6 +34,16 @@ let elab_qual = function
   | Some TcArg -> R.Q_Meta (`FStar.Tactics.Typeclasses.tcresolve)
   | Some (Meta t) -> R.Q_Meta t
 
+(* When we want to apply a function, where the binder has
+qualifier q, this is the qualifier to set in the application.
+Basically, meta and typeclass parameters are applied with the
+same hash as normal implicits. *)
+let elab_qual_for_application = function
+  | None -> R.Q_Explicit
+  | Some Implicit
+  | Some TcArg
+  | Some (Meta _) -> R.Q_Implicit
+
 let elab_observability =
   let open R in
   function

--- a/src/checker/Pulse.Syntax.Pure.fst
+++ b/src/checker/Pulse.Syntax.Pure.fst
@@ -174,37 +174,33 @@ let is_fvar_app (t:term) : option (R.name &
 
 let is_arrow (t:term) : option (binder & option qualifier & comp) =
   match R.inspect_ln_unascribe t with
-  | R.Tv_Arrow b c ->
+  | R.Tv_Arrow b c -> (
     let {ppname;qual;sort} = R.inspect_binder b in
-    begin match qual with
-          | _ ->
-            let q = readback_qual qual in
-            let c_view = R.inspect_comp c in
-            let ret (c_t:R.typ) =
-              let binder_ty = sort in
-              let? c =
-                match readback_comp c_t with
-                | Some c -> Some c <: option Pulse.Syntax.Base.comp
-                | None -> None in
-              Some (mk_binder_ppname
-                      binder_ty
-                      (mk_ppname ppname (T.range_of_term t)),
-                      q,
-                      c) in
-                      
-            begin match c_view with
-            | R.C_Total c_t -> ret c_t
-            | R.C_Eff _ eff_name c_t _ _ ->
-              //
-              // Consider Tot effect with decreases also
-              //
-              if eff_name = tot_lid
-              then ret c_t
-              else None
-            | _ -> None
-            end
-    end
-          
+    let q = readback_qual qual in
+    let c_view = R.inspect_comp c in
+    let ret (c_t:R.typ) =
+      let binder_ty = sort in
+      let? c =
+        match readback_comp c_t with
+        | Some c -> Some c <: option Pulse.Syntax.Base.comp
+        | None -> None in
+      Some (mk_binder_ppname
+              binder_ty
+              (mk_ppname ppname (T.range_of_term t)),
+              q,
+              c)
+    in
+    match c_view with
+    | R.C_Total c_t -> ret c_t
+    | R.C_Eff _ eff_name c_t _ _ ->
+      //
+      // Consider Tot effect with decreases also
+      //
+      if eff_name = tot_lid
+      then ret c_t
+      else None
+    | _ -> None
+  )
   | _ -> None
 
 // TODO: write it better, with pattern matching on reflection syntax

--- a/src/checker/Pulse.Syntax.Pure.fst
+++ b/src/checker/Pulse.Syntax.Pure.fst
@@ -79,7 +79,7 @@ let tm_let (t e1 e2:term) rng : term =
            rng
 
 let tm_pureapp (head:term) (q:option qualifier) (arg:term) : term =
-  set_range (R.mk_app head [(arg, elab_qual q)])
+  set_range (R.mk_app head [(arg, elab_qual_for_application q)])
             (union_ranges (range_of_term head) (range_of_term arg))
 
 let tm_pureabs (ppname:R.ppname_t) (ty : term) (q : option qualifier) (body:term) rng : term =

--- a/test/UnfoldMetaArg.fst
+++ b/test/UnfoldMetaArg.fst
@@ -1,0 +1,24 @@
+module UnfoldMetaArg
+
+#lang-pulse
+open Pulse
+open FStar.Tactics.V2
+
+let my_pts_to (r : ref int) (#[exact (`1.0R)] f:perm) (v:int) : slprop =
+  Pulse.Lib.Reference.pts_to r #f v
+
+fn add1 (r : ref int)
+  preserves my_pts_to r 1
+{
+  unfold my_pts_to;
+  (* ^ Used to fail with
+  * Error 228:
+  - 'norm_term' failed
+  - Cannot type Pulse.Lib.Reference.pts_to ?r ?p ?n in context [x; x; x; x; x]
+  - Expected a function.
+  - Got an expression of type: Pulse.Lib.Core.slprop
+  - See also Pulse.Checker.AssertWithBinders.fst:152.15-152.73
+  *)
+  fold   my_pts_to;
+  ();
+}


### PR DESCRIPTION
This failed:
```fstar
let my_pts_to (r : ref int) (#[exact (`1.0R)] f:perm) (v:int) : slprop =
  Pulse.Lib.Reference.pts_to r #f v

fn add1 (r : ref int)
  preserves my_pts_to r 1
{
  unfold my_pts_to;
  (* ^ Used to fail with
  * Error 228:
  - 'norm_term' failed
  - Cannot type Pulse.Lib.Reference.pts_to ?r ?p ?n in context [x; x; x; x; x]
  - Expected a function.
  - Got an expression of type: Pulse.Lib.Core.slprop
  - See also Pulse.Checker.AssertWithBinders.fst:152.15-152.73
  *)
  fold   my_pts_to;
  ();
}
```