### PR TITLE
Syntax: allow multiple (new-style) invariants in While loops

### DIFF
--- a/src/ml/pulseparser.mly
+++ b/src/ml/pulseparser.mly
@@ -225,6 +225,15 @@ optional_norewrite:
   | NOREWRITE { true }
   | { false }
 
+while_invariant1:
+  | INVARIANT i=lident DOT v=pulseSLProp
+    { PulseSyntaxExtension_Sugar.Old (i, v) }
+  | INVARIANT v=pulseSLProp
+    { PulseSyntaxExtension_Sugar.New v }
+
+while_invariant:
+  | is=list(while_invariant1) { is }
+
 pulseStmtNoSeq:
   | OPEN i=quident
     { PulseSyntaxExtension_Sugar.mk_open i }
@@ -246,8 +255,8 @@ pulseStmtNoSeq:
     { PulseSyntaxExtension_Sugar.mk_let_binding norw q p typOpt (Some init) }
   | s=pulseBindableTerm
     { s }
-  | WHILE LPAREN tm=pulseStmt RPAREN INVARIANT iopt=option (i=lident DOT{ i }) v=pulseSLProp LBRACE body=pulseStmt RBRACE
-    { PulseSyntaxExtension_Sugar.mk_while tm iopt v body }
+  | WHILE LPAREN tm=pulseStmt RPAREN inv=while_invariant LBRACE body=pulseStmt RBRACE
+    { PulseSyntaxExtension_Sugar.mk_while tm inv body }
   | INTRO p=pulseSLProp WITH ws=nonempty_list(indexingTerm)
     { PulseSyntaxExtension_Sugar.mk_intro p ws }
   | PARALLEL REQUIRES p1=pulseSLProp AND p2=pulseSLProp

--- a/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
+++ b/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
@@ -568,21 +568,29 @@ let rec desugar_stmt' (env:env_t) (s:Sugar.stmt)
       let! branches = branches |> mapM (desugar_branch env) in
       return (SW.tm_match head returns_annot branches s.range)
 
-    | While { guard; id=Some id; invariant; body } ->
+    | While { guard; invariant=[Old (id, inv)]; body } ->
       let! guard = desugar_stmt env guard in
-      let! invariant = 
+      let! inv =
         let env, bv = push_bv env id in
-        let! inv = desugar_slprop env invariant in
+        let! inv = desugar_slprop env inv in
         return (SW.close_term inv bv.index)
       in
       let! body = desugar_stmt env body in
-      return (SW.tm_while guard (id, invariant) body s.range)
+      return (SW.tm_while guard (id, inv) body s.range)
 
-    | While { guard; id=None; invariant; body } ->
+    | While { guard; invariant=invs; body } ->
+      (* If there are multiple invariants, they must all be in
+      the New style. *)
+      let! invs = invs |> mapM (function
+                        | New i -> return i
+                        | Old (_, p) -> fail "When using multiple invariants, they must all be in the \
+                        \"new\" style without a binder." (pos p))
+      in
+      let inv = sugar_star_of_list s.range invs in
       let! guard = desugar_stmt env guard in
-      let! invariant = desugar_slprop env invariant in
+      let! inv = desugar_slprop env inv in
       let! body = desugar_stmt env body in
-      return (SW.tm_nuwhile guard invariant body s.range)
+      return (SW.tm_nuwhile guard inv body s.range)
 
     | Introduce { slprop; witnesses } -> (
       let! vp = desugar_slprop env slprop in

--- a/test/LoopInvariants.fst
+++ b/test/LoopInvariants.fst
@@ -1,0 +1,89 @@
+module LoopInvariants
+
+#lang-pulse
+open Pulse
+
+fn test0 ()
+{
+  while (true)
+    invariant (emp)
+  { (); }
+}
+
+fn test1 ()
+{
+  (* This failed to parse, confusing the opening brace
+  for the start of a refinement. `invariant (emp)` worked*)
+  while (true)
+    invariant emp
+  { (); }
+}
+
+(* Multiple invariant annotations in a loop are just
+starred together. *)
+fn test2 (r s : ref int)
+  preserves r |-> 1
+  preserves s |-> 2
+{
+  while (true)
+    invariant r |-> 1
+    invariant emp
+    invariant s |-> 2
+  { (); }
+}
+
+(* You can have no invariants, that's the same as annotating
+emp. *)
+fn test3 (r s : ref int)
+  preserves r |-> 1
+  preserves s |-> 2
+{
+  while (true)
+  {
+    r := !s - 1;
+    s := !r + 1;
+  }
+}
+
+fn test4 ()
+{
+  while (true)
+    invariant emp
+    invariant emp
+  { (); }
+}
+
+(* One cannot mix old-style and new-style invariants. *)
+[@@expect_failure]
+fn test5 (r s : ref int)
+  preserves r |-> 1
+  preserves s |-> 2
+{
+  while (true)
+    invariant r |-> 1
+    invariant b. emp
+  { (); }
+}
+
+[@@expect_failure]
+fn test6 (r s : ref int)
+  preserves r |-> 1
+  preserves s |-> 2
+{
+  while (true)
+    invariant r |-> 1
+    invariant emp
+    invariant s |-> 2
+  { s := 3; }
+}
+
+[@@expect_failure]
+fn test7 (r s : ref int)
+  preserves r |-> 1
+  preserves s |-> 2
+{
+  (* We infer the same invariant as above. *)
+  while (true)
+    invariant r |-> 1
+  { s := 3; }
+}

--- a/test/LoopInvariants.fst.output.expected
+++ b/test/LoopInvariants.fst.output.expected
@@ -1,0 +1,24 @@
+* Info at LoopInvariants.fst(64,17-64,20):
+  - Expected failure:
+  - When using multiple invariants, they must all be in the "new" style without a binder.
+
+* Info at LoopInvariants.fst(77,9-77,10):
+  - Expected failure:
+  - Failed to discharge match guard for goal:
+      Pulse.Lib.Reference.pts_to s 2
+    with resource from context:
+      Pulse.Lib.Reference.pts_to s 3
+  - Assertion failed
+  - The SMT solver could not prove the query. Use --query_stats for more
+    details.
+
+* Info at LoopInvariants.fst(88,9-88,10):
+  - Expected failure:
+  - Failed to discharge match guard for goal:
+      Pulse.Lib.Reference.pts_to s 2
+    with resource from context:
+      Pulse.Lib.Reference.pts_to s 3
+  - Assertion failed
+  - The SMT solver could not prove the query. Use --query_stats for more
+    details.
+


### PR DESCRIPTION
From the test file:
```fstar
fn test1 ()
{
  (* This failed to parse, confusing the opening brace
  for the start of a refinement. `invariant (emp)` worked*)
  while (true)
    invariant emp
  { (); }
}

(* Multiple invariant annotations in a loop are just
starred together. *)
fn test2 (r s : ref int)
  preserves r |-> 1
  preserves s |-> 2
{
  while (true)
    invariant r |-> 1
    invariant emp
    invariant s |-> 2
  { (); }
}

(* You can have no invariants, that's the same as annotating
emp. *)
fn test3 (r s : ref int)
  preserves r |-> 1
  preserves s |-> 2
{
  while (true)
  {
    r := !s - 1;
    s := !r + 1;
  }
}

(* One cannot mix old-style and new-style invariants. *)
[@@expect_failure]
fn test5 (r s : ref int)
  preserves r |-> 1
  preserves s |-> 2
{
  while (true)
    invariant r |-> 1
    invariant b. emp
  { (); }
}
```