### PR TITLE
Do not discard names in elab_env.

### DIFF
--- a/src/checker/Pulse.Checker.Bind.fst
+++ b/src/checker/Pulse.Checker.Bind.fst
@@ -143,6 +143,12 @@ let check_bind'
   )
   else (
     let dflt () =
+      let binder =
+        // do not generate null binders, those are ignored by SMT...
+        if T.unseal binder.binder_ppname.name = "_" then
+          { binder with binder_ppname = ppname_default }
+        else
+          binder in
       let r0 = check g ctxt ctxt_typing NoHint binder.binder_ppname e1 in
       check_if_seq_lhs g ctxt _ r0 e1;
       check_binder_typ g ctxt _ r0 binder e1;

--- a/src/checker/Pulse.Checker.Match.fst
+++ b/src/checker/Pulse.Checker.Match.fst
@@ -351,6 +351,7 @@ let ctag_of_br  (#g #pre #post_hint #sc_u #sc_ty #sc:_)
 : ctag
 = let (|_, c, _|) = l in ctag_of_comp_st c
 
+#push-options "--admit_smt_queries true" // Z3 crash
 let weaken_branch_observability
       (obs:observability)
       (#g #pre:_) (#post_hint:post_hint_for_env g) 
@@ -377,6 +378,7 @@ let weaken_branch_observability
       in
       (| br, d |)
     )
+#pop-options
 
 let rec max_obs 
     (checked_brs : list comp_st)

--- a/src/checker/Pulse.Checker.fst
+++ b/src/checker/Pulse.Checker.fst
@@ -244,11 +244,12 @@ let rec check
   else (
     maybe_trace t g0 pre0 t.range;  
     if RU.debug_at_level (fstar_env g0) "pulse.checker" then (
-      T.print (Printf.sprintf "At %s{\nerr context:\n>%s\n\n{\n\tenv=%s\ncontext:\n%s,\n\nst_term: %s\nis_source: %s}}\n"
+      T.print (Printf.sprintf "At %s{\nerr context:\n>%s\n\n{\n\tenv=%s\ncontext:\n%s,\n\nres_ppname: %s\nst_term: %s\nis_source: %s}}\n"
                 (show t.range)
                 (RU.print_context (get_context g0))
                 (show g0)
                 (show pre0)
+                (show (T.unseal res_ppname.name))
                 (show t)
                 (show (T.unseal t.source)))
     );

--- a/src/checker/Pulse.Extract.Main.fst
+++ b/src/checker/Pulse.Extract.Main.fst
@@ -111,7 +111,7 @@ let is_internal_binder (b:binder) : T.Tac bool =
   s = "_tbind_c" ||
   s = "_if_br" ||
   s = "_br" ||
-  s = "_"
+  s = "__"
 
 let is_return (e:st_term) : option term =
   match e.term with
@@ -347,7 +347,12 @@ let extract_dv_binder (b:Pulse.Syntax.Base.binder) (q:option Pulse.Syntax.Base.q
   : T.Tac R.binder =
   R.pack_binder {
     sort = b.binder_ty;
-    ppname = b.binder_ppname.name;
+    ppname =
+      // "__" binders become `int __1 = f();` in karamel
+      if T.unseal b.binder_ppname.name = "__" then
+        T.seal "_"
+      else
+        b.binder_ppname.name;
     attrs = T.unseal b.binder_attrs;
     qual = (match q with
       | Some Implicit -> R.Q_Implicit

--- a/src/checker/Pulse.Syntax.Base.fsti
+++ b/src/checker/Pulse.Syntax.Base.fsti
@@ -43,7 +43,8 @@ type ppname = {
 }
 
 let ppname_default =  {
-    name = FStar.Sealed.seal "_";
+    // This used to be "_", but that is a *null binder* and behaves very magically
+    name = FStar.Sealed.seal "__";
     range = FStar.Range.range_0
 }
 

--- a/src/checker/Pulse.Typing.Env.fsti
+++ b/src/checker/Pulse.Typing.Env.fsti
@@ -30,7 +30,8 @@ module Pprint = FStar.Pprint
 type binding = var & typ
 type env_bindings = list binding
 
-let extend_env_l (f:R.env) (g:env_bindings) : Tot R.env =
+// This function is marked ghost because it should not be used as it renames all variables to "x"
+let extend_env_l (f:R.env) (g:env_bindings) : GTot R.env =
   L.fold_right
     (fun (x, b) g ->
       RT.extend_env g x b)
@@ -45,7 +46,7 @@ val fstar_env (g:env) : RT.fstar_top_env
 // most recent binding at the head of the list
 //
 val bindings (g:env) : env_bindings
-val bindings_with_ppname (g:env) : T.Tac (list (ppname & var & typ))
+val bindings_with_ppname (g:env) : list (ppname & var & typ)
 
 (* Returns an F* reflection environment.
 The result is the same as taking the initial F*

--- a/test/bug-reports/Bug.SpinLock.fst.output.expected
+++ b/test/bug-reports/Bug.SpinLock.fst.output.expected
@@ -1,7 +1,7 @@
 * Info at Bug.SpinLock.fst(45,2-45,4):
   - Expected failure:
   - Cannot prove:
-      Pulse.Lib.Reference.pts_to _ ?uu___
+      Pulse.Lib.Reference.pts_to __ ?__
   - In the context:
       Pulse.Lib.SpinLock.lock_alive my_lock
         (exists* (v: Prims.int). Pulse.Lib.Reference.pts_to r v)

--- a/test/bug-reports/Bug266.fst.output.expected
+++ b/test/bug-reports/Bug266.fst.output.expected
@@ -11,8 +11,8 @@
   - Current context:
       emp
   - In typing environment:
-      _#60 : Prims.squash (_ == Bug266.my_intro Prims.l_False),
-      _#59 :
+      __#60 : Prims.squash (__ == Bug266.my_intro Prims.l_False),
+      __#59 :
         Pulse.Lib.Core.stt_ghost Prims.unit
           Pulse.Lib.Core.emp_inames
           (Pulse.Lib.Core.pure Prims.l_False)

--- a/test/bug-reports/ExistsErasedAndPureEqualities.fst.output.expected
+++ b/test/bug-reports/ExistsErasedAndPureEqualities.fst.output.expected
@@ -13,9 +13,9 @@
   - Current context:
       ExistsErasedAndPureEqualities.some_pred x v
   - In typing environment:
-      _#586 : Prims.squash (v_ == v),
+      __#586 : Prims.squash (v_ == v),
       v_#585 : FStar.Ghost.erased Prims.int,
-      _#451 : Prims.squash (v == v),
+      __#451 : Prims.squash (v == v),
       v#267 : FStar.Ghost.erased Prims.int,
       x#262 : Pulse.Lib.Reference.ref Prims.int
 

--- a/test/bug-reports/IntroGhost.fst.output.expected
+++ b/test/bug-reports/IntroGhost.fst.output.expected
@@ -1,7 +1,7 @@
 * Info at IntroGhost.fst(44,18-44,20):
   - Expected failure:
   - Cannot prove:
-      Pulse.Lib.Reference.pts_to r _
+      Pulse.Lib.Reference.pts_to r __
   - In the context:
       IntroGhost.my_inv b r
 


### PR DESCRIPTION
I'm tired of looking at log files without variable names because we replace them with `x` before passing them to F*.

Before:
`try_teq of FStar.Pervasives.Native.tuple2 and FStar.Pervasives.Native.tuple2 in [Binding_var x, Binding_var x, Binding_var x, Binding_var x, Binding_var x, Binding_var x] {`
After:
`try_teq of FStar.Pervasives.Native.tuple2 and FStar.Pervasives.Native.tuple2 in [Binding_var __, Binding_var v, Binding_var i, Binding_var p, Binding_var s, Binding_var t] {`

The only awkward part is that we used to use the binder name `_` a *lot*.  However this name is treated specially in F*, in particular assumptions with this name seem to be dropped in the SMT encoding.  Therefore this PR changes the name to `__` instead.  Right before extraction we change it back to `_`, because obviously the underscore is magic in extraction as well.