### PR TITLE
More duplicable instances.

### DIFF
--- a/lib/pulse/lib/Pulse.Lib.Pervasives.fst
+++ b/lib/pulse/lib/Pulse.Lib.Pervasives.fst
@@ -214,3 +214,10 @@ fn dup_star (p q:slprop) {| duplicable p |} {| duplicable q |} : duplicable_f (p
 instance duplicable_star (p q : slprop)  {| duplicable p |}  {| duplicable q|} : duplicable (p ** q) = {
   dup_f = (fun _ -> dup_star p q)
 }
+
+instance duplicable_slprop_ref_pts_to x y : duplicable (slprop_ref_pts_to x y) = {
+  dup_f = (fun _ -> slprop_ref_share x #y)
+}
+
+ghost fn dup_emp () : duplicable_f emp = { }
+instance duplicable_emp : duplicable emp = { dup_f = dup_emp }

--- a/lib/pulse/lib/Pulse.Lib.Task.fst
+++ b/lib/pulse/lib/Pulse.Lib.Task.fst
@@ -409,10 +409,6 @@ fn elim_state_pred
   hide v_state
 }
 
-instance duplicable_slprop_ref_pts_to x y : duplicable (slprop_ref_pts_to x y) = {
-  dup_f = (fun _ -> slprop_ref_share x #y)
-}
-
 ghost fn shift_up (x: slprop_ref) (y: slprop)
   requires slprop_ref_pts_to x y
   ensures shift (up x ** later_credit 1) y


### PR DESCRIPTION
The duplicable instance for emp is particularly useful for introducing shifts.