### PR TITLE
PtsTo: add an instance for lseq on the RHS

### DIFF
--- a/lib/pulse/lib/class/Pulse.Class.PtsTo.fst
+++ b/lib/pulse/lib/class/Pulse.Class.PtsTo.fst
@@ -38,3 +38,9 @@ type frac a =
 instance pts_to_frac (p a : Type) (d : has_pts_to p a) : has_pts_to p (frac a) = {
   pts_to = (fun p #f' (Frac f v) -> d.pts_to p #(f' *. f) v);
 }
+
+(* Handle lseq by ignoring the refinement. *)
+[@@pulse_unfold]
+instance pts_to_lseq (p a : Type) (n : nat) (d : has_pts_to p (Seq.seq a)) : has_pts_to p (Seq.lseq a n) = {
+  pts_to = d.pts_to;
+}


### PR DESCRIPTION
By ignoring the refinement. It's very common to have lseq arounds and this allows to use the |-> syntax.