### PR TITLE
Replace uses of unsafe lookup_* functions.

### DIFF
--- a/src/checker/Pulse.Lib.Core.Typing.fsti
+++ b/src/checker/Pulse.Lib.Core.Typing.fsti
@@ -22,14 +22,14 @@ open Pulse.Syntax.Pure
 
 module RT = FStar.Reflection.Typing
 
-let return_post_with_eq (u:universe) (a:term) (e:term) (p:term) (x:var) : term =
+let return_post_with_eq (u:universe) (a:term) (e:term) (p:term) (x:var) : GTot term =
   let x_tm = RT.var_as_term x in
   let eq2_tm = mk_eq2 u a x_tm e in
   let p_app_x = pack_ln (Tv_App p (x_tm, Q_Explicit)) in  
   let star_tm = mk_star p_app_x (mk_pure eq2_tm) in
   mk_abs a Q_Explicit (RT.subst_term star_tm [ RT.ND x 0 ])
 
-let return_stt_comp (u:universe) (a:term) (e:term) (p:term) (x:var) : term =
+let return_stt_comp (u:universe) (a:term) (e:term) (p:term) (x:var) : GTot term =
   mk_stt_comp u a
     (pack_ln (Tv_App p (e, Q_Explicit)))
     (return_post_with_eq u a e p x)
@@ -67,7 +67,7 @@ val return_stt_noeq_typing
             (return_stt_noeq_comp u a x p))
 
 let neutral_fv = pack_ln (Tv_FVar (pack_fv neutral_lid))
-let return_stt_atomic_comp (u:universe) (a:term) (e:term) (p:term) (x:var) : term =
+let return_stt_atomic_comp (u:universe) (a:term) (e:term) (p:term) (x:var) : GTot term =
   mk_stt_atomic_comp neutral_fv u a tm_emp_inames
     (pack_ln (Tv_App p (e, Q_Explicit)))
     (return_post_with_eq u a e p x)
@@ -104,7 +104,7 @@ val return_stt_atomic_noeq_typing
             (mk_stt_atomic_return_noeq u a x p)
             (return_stt_atomic_noeq_comp u a x p))
 
-let return_stt_ghost_comp (u:universe) (a:term) (e:term) (p:term) (x:var) : term =
+let return_stt_ghost_comp (u:universe) (a:term) (e:term) (p:term) (x:var) : GTot term =
   mk_stt_ghost_comp u a tm_emp_inames
     (pack_ln (Tv_App p (e, Q_Explicit)))
     (return_post_with_eq u a e p x)
@@ -173,7 +173,7 @@ val while_typing
       (mk_stt_comp uzero unit_tm (mk_exists uzero bool_tm inv)
          (mk_abs unit_tm Q_Explicit (pack_ln (Tv_App inv (false_tm, Q_Explicit)))))
 
-let par_post (u:universe) (aL aR:term) (postL postR:term) (x:var) : term =
+let par_post (u:universe) (aL aR:term) (postL postR:term) (x:var) : GTot term =
   let x_tm = RT.var_as_term x in
   let postL = pack_ln (Tv_App postL (mk_fst u u aL aR x_tm, Q_Explicit)) in
   let postR = pack_ln (Tv_App postR (mk_snd u u aL aR x_tm, Q_Explicit)) in

--- a/src/checker/Pulse.Soundness.Return.fst
+++ b/src/checker/Pulse.Soundness.Return.fst
@@ -83,7 +83,7 @@ let return_soundness
     | STT_Ghost -> elab_stghost_equiv _ c _ _ pre_eq (RT.Rel_refl _ _ _)  in
 
   let comp_equiv_eq (_:unit{use_eq == true})
-    : (match ctag with
+    : GTot (match ctag with
        | STT -> RT.equiv (elab_env g)
                          (WT.return_stt_comp u t e rpost_abs x)
                          (elab_comp c)

--- a/src/checker/Pulse.Syntax.Naming.fsti
+++ b/src/checker/Pulse.Syntax.Naming.fsti
@@ -475,10 +475,10 @@ let rec subst_pat (p:pattern) (ss:subst)
     | Pat_Dot_Term None ->
       p
     | Pat_Var n t -> 
-      let t = RU.map_seal t (fun t -> RT.subst_term t ss) in
+      let t = RU.map_seal t (fun t -> subst_host_term t ss) in
       Pat_Var n t
     | Pat_Dot_Term (Some e) ->
-      Pat_Dot_Term (Some (subst_term e ss))
+      Pat_Dot_Term (Some (subst_host_term e ss))
     | Pat_Cons d args ->
       let args = subst_pat_args args ss in
       Pat_Cons d args

--- a/src/checker/Pulse.Typing.FV.fst
+++ b/src/checker/Pulse.Typing.FV.fst
@@ -24,7 +24,7 @@ open Pulse.Typing
 open Pulse.Elaborate
 open Pulse.Soundness.Common
 
-let vars_of_rt_env (g:R.env) = Set.intension (fun x -> Some? (RT.lookup_bvar g x))
+// let vars_of_rt_env (g:R.env) = Set.intension (fun x -> Some? (RT.lookup_bvar g x))
 
 let freevars_close_term_host_term (t:term) (x:var) (i:index)
   : Lemma
@@ -249,7 +249,8 @@ let freevars_open_term_both (x:var) (t:term)
 let freevars_close_st_term e x i = freevars_close_st_term' e x i
 
 let contains_r (g:R.env) (x:var) = Some? (RT.lookup_bvar g x)
-let vars_of_env_r (g:R.env) = Set.intension (contains_r g)
+assume val vars_of_env_r (g:R.env) :
+  s:Set.set var { forall x. Set.mem x s <==> contains_r g x } // = Set.intension (contains_r g)
 
 assume
 val refl_typing_freevars (#g:R.env) (#e:R.term) (#t:R.term) (#eff:_) 


### PR DESCRIPTION
The typing module in reflection has lots of functions that are implemented using magic.  This PR replaces all transitive uses of these function.  The main function that needs replacing is substitution.