### PR TITLE
Disable cronjobs on forks.

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   build-and-push:
+    if: github.repository == 'FStarLang/pulse'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,6 +10,7 @@ defaults:
 
 jobs:
   linux:
+    if: github.repository == 'FStarLang/pulse'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@master
@@ -35,6 +36,7 @@ jobs:
           name: package-linux
 
   mac:
+    if: github.repository == 'FStarLang/pulse'
     runs-on: macos-14
     steps:
       - uses: actions/checkout@master
@@ -61,6 +63,7 @@ jobs:
           name: package-mac
 
   publish:
+    if: github.repository == 'FStarLang/pulse'
     runs-on: ubuntu-latest
     needs:
       - linux


### PR DESCRIPTION
This disables the nightly and devcontainer jobs on forks of this repo; they both end up failing because they try to push to fstarlang repositories/ghcr.

@mtzguido I don't know if you're using this for anything.