### PR TITLE
Add extraction rules for Pulse.Lib.Array.PtsTo array operators

### DIFF
--- a/src/extraction/ExtractPulse.fst
+++ b/src/extraction/ExtractPulse.fst
@@ -149,12 +149,20 @@ let pulse_translate_expr : translate_expr_t = fun env e ->
     when string_of_mlpath p = "Pulse.Lib.Vec.op_Array_Access" ->
     EBufRead (cb e, cb i)
 
+  | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ e; i; _p; _w ])
+    when string_of_mlpath p = "Pulse.Lib.Array.PtsTo.op_Array_Access" ->
+    EBufRead (cb e, cb i)
+
   | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ e; i; _p; _w; _m ])
     when string_of_mlpath p = "Pulse.Lib.Array.Core.mask_read" ->
     EBufRead (cb e, cb i)
 
   | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ e; i; v; _w ])
     when string_of_mlpath p = "Pulse.Lib.Vec.op_Array_Assignment" ->
+    EBufWrite (cb e, cb i, cb v)
+
+  | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ e; i; v; _s ])
+    when string_of_mlpath p = "Pulse.Lib.Array.PtsTo.op_Array_Assignment" ->
     EBufWrite (cb e, cb i, cb v)
 
   | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ e; i; v; _; _ ])

--- a/test/ArrayPtsTo.c.expected
+++ b/test/ArrayPtsTo.c.expected
@@ -1,0 +1,10 @@
+/* krml header omitted for test repeatability */
+
+
+#include "ArrayPtsTo.h"
+
+uint32_t ArrayPtsTo_test(uint32_t *a)
+{
+  a[(size_t)0U] = 42U;
+  return a[(size_t)1U];
+}

--- a/test/ArrayPtsTo.fst
+++ b/test/ArrayPtsTo.fst
@@ -1,0 +1,14 @@
+module ArrayPtsTo
+#lang-pulse
+open Pulse
+module A = Pulse.Lib.Array.PtsTo
+
+fn test (a: A.array UInt32.t) (#s: Ghost.erased (Seq.seq UInt32.t) { Seq.length s == 2 })
+  requires A.pts_to a s
+  returns r: UInt32.t
+  ensures exists* s'. A.pts_to a s' ** pure (s' `Seq.equal` Seq.upd s 0 42ul)
+  ensures rewrites_to r (Seq.index s 1)
+{
+  a.(0sz) <- 42ul;
+  a.(1sz)
+}


### PR DESCRIPTION
## Summary

Add Karamel extraction support for `Pulse.Lib.Array.PtsTo.op_Array_Access` and `Pulse.Lib.Array.PtsTo.op_Array_Assignment`.

These are the `pts_to`-based array indexing operators (`a.(i)` and `a.(i) <- v`) exposed by `Pulse.Lib.Array.PtsTo`. Without these extraction rules, code using this module for array access fails during Karamel extraction with an unrecognized primitive error.

## Example

The following Pulse code previously failed to extract:

```fstar
module ArrayPtsTo
#lang-pulse
open Pulse
module A = Pulse.Lib.Array.PtsTo

fn test (a: A.array UInt32.t) (#s: Ghost.erased (Seq.seq UInt32.t) { Seq.length s == 2 })
  requires A.pts_to a s
  returns r: UInt32.t
  ensures exists* s'. A.pts_to a s' ** pure (s' `Seq.equal` Seq.upd s 0 42ul)
  ensures rewrites_to r (Seq.index s 1)
{
  a.(0sz) <- 42ul;
  a.(1sz)
}
```

After this fix, it correctly extracts to:

```c
uint32_t ArrayPtsTo_test(uint32_t *a)
{
  a[(size_t)0U] = 42U;
  return a[(size_t)1U];
}
```

## Changes

- `src/extraction/ExtractPulse.fst`: Add two match cases mapping `PtsTo.op_Array_Access` → `EBufRead` and `PtsTo.op_Array_Assignment` → `EBufWrite`
- `test/ArrayPtsTo.fst` + `test/ArrayPtsTo.c.expected`: Minimal extraction test

> **Note:** The `.c.expected` was written by hand since I could not run extraction locally (F*/plugin version mismatch). If CI shows a diff, the expected file may need minor adjustment.