### PR TITLE
Fix missing elaboration of impure spec in ensures preceding a label

### DIFF
--- a/src/checker/Pulse.Checker.ForwardJumpLabel.fst
+++ b/src/checker/Pulse.Checker.ForwardJumpLabel.fst
@@ -24,6 +24,7 @@ open Pulse.Typing
 open Pulse.Checker.Pure
 open Pulse.Checker.Base
 open Pulse.Checker.Prover
+open Pulse.Checker.ImpureSpec
 module RU = Pulse.RuntimeUtils
 
 let starts_with (a b: string) : bool =
@@ -45,7 +46,8 @@ let check
   let has_explicit_post = not (T.term_eq (comp_post c) tm_emp) in
   let post : post_hint_t =
     if has_explicit_post then
-      intro_post_hint g EffectAnnotSTT None (comp_post c)
+      let post_slprop = purify_spec g { ctxt_now = pre; ctxt_old = None } (comp_post c) in
+      intro_post_hint g EffectAnnotSTT None post_slprop
     else
       match post_hint0 with
       | NoHint | TypeHint .. ->

--- a/test/Goto.c.expected
+++ b/test/Goto.c.expected
@@ -57,3 +57,21 @@ size_t Goto_find_zero(int32_t *a, size_t sz)
   return _return;
 }
 
+void Goto_test2_alt(int32_t *r)
+{
+  bool _return = false;
+  bool fail = false;
+  int32_t __anf0 = *r;
+  if (__anf0 == (int32_t)67)
+  {
+    *r = (int32_t)42;
+    _return = true;
+  }
+  bool _return1 = _return;
+  if (!_return1)
+    fail = true;
+  bool _return10 = _return;
+  if (!_return10)
+    *r = (int32_t)17;
+}
+

--- a/test/Goto.fst
+++ b/test/Goto.fst
@@ -38,3 +38,17 @@ fn find_zero (a: array Int32.t) (sz: SizeT.t)
   };
   !i
 }
+
+//labels with impure specs in ensures
+fn test2_alt (r: ref Int32.t)
+    preserves live r
+    ensures pure (!r == 17l \/ !r == 42l)
+{
+  {
+    if (!r = 67l) { r := 42l; return; };
+    goto fail;
+  }
+  ensures live r ** pure (!r <> 67l)
+  label fail:;
+  r := 17l;
+}


### PR DESCRIPTION
Fixes #560

The postcondition of a ForwardJumpLabel was passed directly to intro_post_hint without being purified first. This meant impure specs explicit existential quantification with points-to assertions, causing a typechecking failure.

Call purify_spec on the postcondition before intro_post_hint, matching what is done for function annotations in Pulse.Checker.Abs.